### PR TITLE
Revert "Bump karton-core from 4.2.0 to 5.0.0 (#7)"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ authorized_licenses = [
 
 [tool.liccheck.authorized_packages]
 # BSD, not properly provided in package metadata
-karton-core = "5.0.0"
+karton-core = "4.2.0"
 
 # Apache 2, not properly provided in package metadata
 aiofiles = "0.7.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ fastapi==0.88.0
 h11==0.14.0
 idna==3.2
 Jinja2==3.1.2
-karton-core==5.0.0
+karton-core==4.2.0
 liccheck==0.7.3
 MarkupSafe==2.1.1
 minio==7.1.12

--- a/test/base.py
+++ b/test/base.py
@@ -1,11 +1,11 @@
 import os
 from unittest.mock import MagicMock
 
-from karton.core.test import BackendMock, ConfigMock, KartonTestCase
+from karton.core.test import ConfigMock, KartonBackendMock, KartonTestCase
 from redis import StrictRedis
 
 
-class KartonBackendMockWithRedis(BackendMock):
+class KartonBackendMockWithRedis(KartonBackendMock):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
This reverts commit 2defca6e131f88ffd8b9922aeb4b5103a4b5d8fe.