### PR TITLE
log file is medium-severity, 

### DIFF
--- a/artemis/reporting/severity.py
+++ b/artemis/reporting/severity.py
@@ -25,7 +25,7 @@ SEVERITY_MAP = {
     ReportType("exposed_archive"): Severity.HIGH,
     ReportType("exposed_configuration_file"): Severity.HIGH,
     ReportType("exposed_sql_dump"): Severity.HIGH,
-    ReportType("exposed_log_file"): Severity.HIGH,
+    ReportType("exposed_log_file"): Severity.MEDIUM,
     ReportType("wordpress_outdated_plugin_theme"): Severity.MEDIUM,
     ReportType("misconfigured_email"): Severity.MEDIUM,
     ReportType("old_joomla"): Severity.MEDIUM,


### PR DESCRIPTION
they are divided into two groups: (few) interesting and (many) boring information leaks - and the same reasoning made us set wordpress_outdated_plugin_theme severity to medium