### PR TITLE
Build docker images for linux/arm64

### DIFF
--- a/.github/workflows/docker_nightly.yml
+++ b/.github/workflows/docker_nightly.yml
@@ -8,7 +8,10 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        arch: ["linux/arm64", "linux/amd64"]
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -41,7 +44,7 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile
-          platforms: linux/amd64
+          platforms: ${{ matrix.arch }}
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -8,6 +8,9 @@ jobs:
   main:
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    strategy:
+      matrix:
+        arch: ["linux/arm64", "linux/amd64"]
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -40,7 +43,7 @@ jobs:
         with:
           context: .
           file: ./docker/Dockerfile
-          platforms: linux/amd64
+          platforms: ${{ matrix.arch }}
           push: true
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
I added support for linux/arm64 architecture used on Apple Silicon.
This image is used by Dockerfiles in https://github.com/CERT-Polska/Artemis-modules-extra that fails on Mac and requires manual, local build.