### PR TITLE
Added Web Techonology Identifier Module

### DIFF
--- a/artemis/modules/data/web_tech_identifier_data.json
+++ b/artemis/modules/data/web_tech_identifier_data.json
@@ -1,0 +1,21 @@
+{
+    "PHP": {
+        "cookies": {
+            "PHPSESSID": ""
+        },
+        "description": "PHP is a general-purpose scripting language used for web development.",
+        "headers": {
+            "Server": "(?i)php/([\\d.\\-+a-z]+)",
+            "X-Powered-By": "(?i)php/([\\d.\\-+a-z]+)"
+        },
+        "url": "\\.php(?:$|\\?)",
+        "website": "http://php.net"
+    },
+    "Apache HTTP Server": {
+        "description": "Apache is a free and open-source cross-platform web server software.",
+        "headers": {
+            "Server": "(?:Apache(?:/([\\d.]+))?|(?:^|\b)HTTPD)"
+        },
+        "website": "https://httpd.apache.org/"
+    }
+}

--- a/artemis/modules/web_tech_identifier.py
+++ b/artemis/modules/web_tech_identifier.py
@@ -1,0 +1,94 @@
+from karton.core import Task
+
+from artemis import load_risk_class
+from artemis.binds import Service, TaskStatus, TaskType
+from artemis.module_base import ArtemisBase
+from artemis.task_utils import get_target_url
+
+import re
+import json
+from typing import Generator, Dict, Any
+
+@load_risk_class.load_risk_class(load_risk_class.LoadRiskClass.LOW)
+class WebtechIdentifier(ArtemisBase):
+    """Identify web technologies and their versions from a given URL response."""
+
+    identity = "webtech_identifier"
+    filters = [
+        {"type": TaskType.SERVICE.value, "service": Service.HTTP.value},
+    ]
+    
+    def __init__(self, json_path: str):
+        self.json_path = json_path
+        self.params = self.load_params()
+    
+    def load_params(self) -> Dict[str, Any]:
+        """Load technology detection parameters from a JSON file."""
+        with open(self.json_path, "r") as f:
+            return json.load(f)
+        
+    def get_services(self) -> Generator[Dict[str, Any], None, None]:
+        """Yield detection parameters for each service."""
+        for service, details in self.params.items():
+            yield {
+                "name": service,
+                "headers": details.get("headers", {}),
+                "cookies": details.get("cookies", {}),
+                "url": details.get("url", None)
+            }
+
+    def process(self, response) -> Dict[str, Any]:
+        """Check response headers, cookies, and URL for known technologies."""
+        detected_tech = {}
+        headers = response.headers
+        cookies = response.cookies
+        response_url = response.url
+        meta_tags = re.findall(r'<meta[^>]+>', response.text, re.IGNORECASE)
+
+        for service in self.get_services():
+            service_name = service["name"]
+            detected = False
+            version = None
+            
+            # Check headers
+            for header, pattern in service["headers"].items():#the stored patterns and headers
+                """Check regex against the response headers"""
+                if header in headers:#match against fetched reponse headers
+                    match = re.search(pattern, headers[header], re.IGNORECASE)
+                    if match:
+                        detected, version = True, match.group(1) or "Unknown"
+            
+            # Check cookies
+            if any(cookie.name in service["cookies"] for cookie in cookies):
+                detected = True
+            
+            # Check URL structure
+            if service["url"] and re.search(service["url"], response_url, re.IGNORECASE):
+                detected = True
+
+            # Scan meta tags for PHP mentions
+            service_meta_tags = [meta for meta in meta_tags if re.search(service_name, str(meta), re.IGNORECASE)]
+            if service_meta_tags:
+                detected = True
+            
+            if detected:
+                detected_tech[service_name] = version or "Detected"
+        
+        return detected_tech
+
+        
+    def run(self,current_task:Task) -> None:
+        url = get_target_url(current_task)
+        self.log.info(f"webtech identifier scanning {url}")
+
+        response = self.http_get(url)
+        detected_tech = self.process(response)
+
+        self.db.save_task_result(
+            task=current_task,
+            data={"detected_tech": detected_tech},
+        )
+
+if __name__ == "__main__":
+    WebtechIdentifier().loop()
+

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -179,6 +179,13 @@ services:
     restart: always
     volumes: ["./docker/karton.ini:/etc/karton/karton.ini", "${DOCKER_COMPOSE_ADDITIONAL_SHARED_DIRECTORY:-./shared}:/shared/"]
 
+  karton-web_tech_identifier:
+    <<: *artemis-build-or-image
+    command: "python3 -m artemis.modules.web_tech_identifier"
+    env_file: .env
+    restart: always
+    volumes: ["./docker/karton.ini:/etc/karton/karton.ini", "${DOCKER_COMPOSE_ADDITIONAL_SHARED_DIRECTORY:-./shared}:/shared/"]
+
   karton-ip_lookup:
     <<: *artemis-build-or-image
     command: "python3 -m artemis.modules.ip_lookup"

--- a/test/modules/test_web_tech_identifier.py
+++ b/test/modules/test_web_tech_identifier.py
@@ -1,0 +1,35 @@
+import unittest
+from unittest.mock import patch, Mock
+from artemis.modules.web_tech_identifier import WebtechIdentifier
+
+class TestWebTechIdentifier(unittest.TestCase):
+    def setUp(self):
+        """Initialize the WebT\techIdentifier with test JSON data."""
+        self.identifier = WebtechIdentifier("artemis/modules/data/web_tech_identifier_data.json")
+
+    @patch("requests.get")
+    def test_process(self, mock_get):
+        """Test the process method with mocked HTTP response."""
+        mock_response = Mock()
+        mock_response.headers = {
+            "Server": "Apache/2.4.25 (Debian)",
+            "X-Powered-By": "PHP/5.6.40"
+        }
+        mock_response.cookies = [Mock(name="PHPSESSID")]
+        mock_response.url = "http://example.com"
+        mock_response.text = '<meta name="php" content="PHP 5.8">'
+        
+        mock_get.return_value = mock_response
+        
+        result = self.identifier.process(mock_response)
+        
+        expected_result = {
+            "Apache HTTP Server": "2.4.25",
+            "PHP": "5.6.40",
+            "PHP": "Detected"
+        }
+        
+        self.assertEqual(result, expected_result)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
In reference to issue #1541 

## Idea
- The idea to implement this was done was inspired by the famous browser extension `Wappalyzer`
- Using regex patterns for headers,cookies,meta tags,urls one can "guess" the service being used and possibly the version too.

## Changes made
- A new module `WebtechIdentifier` has been added,working with the help of regex patterns stored in `artemis/modules/data/web_tech_identifier_data.json`
- `docker-compose.yaml` has been updated

## Work Remaining
- Due to system limitations I am not able to run the tests as the process is very resource intensive when running all the containers and tests.If you could tell me how to just run a specific test. Here `test/modules/test_web_tech_identifier.py`
- Based upon your views I'll add a lot more services to `artemis/modules/data/web_tech_identifier_data.json`
-  There's a linting issue on my side, I am attaching the `pre-commit log` hereby
[pre-commit.log](https://github.com/user-attachments/files/19031541/pre-commit.log)

@kazet Looking forward to your insights !