### PR TITLE
Resolve warnings of bs4 library

### DIFF
--- a/artemis/modules/drupal_scanner.py
+++ b/artemis/modules/drupal_scanner.py
@@ -36,7 +36,7 @@ class DrupalScanner(BaseNewerVersionComparerModule):
         soup = bs4.BeautifulSoup(response.content)
 
         version: Optional[str] = None
-        for script in soup.findAll("script"):
+        for script in soup.find_all("script"):
             if "/core/misc/drupal.js?v=" in script.get("src", ""):
                 version = script["src"].split("=")[1]
 


### PR DESCRIPTION
# PR Summary
This small PR resolves the `bs4` deprecation warnings:
```python
DeprecationWarning: Call to deprecated method findAll. (Replaced by find_all) -- Deprecated since version 4.0.0.
```