### PR TITLE
Update Pydantic model serialization for v2 compatibility

### DIFF
--- a/artemis/modules/admin_panel_login_bruter.py
+++ b/artemis/modules/admin_panel_login_bruter.py
@@ -251,7 +251,7 @@ class AdminPanelLoginBruter(ArtemisBase):
             task=current_task,
             status=status,
             status_reason=status_reason,
-            data={"results": [result.dict() for result in results]},
+            data={"results": [result.model_dump() for result in results]},
         )
 
 


### PR DESCRIPTION
## PR Summary
The current code in `modules/admin_panel_login_bruter.py` uses the deprecated `dict()` method on Pydantic models, resulting in `PydanticDeprecatedSince20` warnings during execution. This usage is incompatible with Pydantic V2+ and will be removed in V3.0. Relevant [CI log](https://github.com/CERT-Polska/Artemis/actions/runs/15997168764/job/45128673015#step:4:8924) warning:
```python
/opt/artemis/modules/admin_panel_login_bruter.py:254: PydanticDeprecatedSince20: The `dict` method is deprecated; use `model_dump` instead. Deprecated in Pydantic V2.0 to be removed in V3.0. See Pydantic V2 Migration Guide at https://errors.pydantic.dev/2.10/migration/
```
This small PR updates the `AdminPanelLoginBruter` module to replace `dict()` with `model_dump()`, resolving the deprecation warning and ensuring compatibility with Pydantic.
