### PR TITLE
bump aiohttp dependency in pre-commit 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
   - id: mypy
     args: [--strict]
     additional_dependencies:
-    - aiohttp==3.8.5
+    - aiohttp==3.12.15
     - alembic==1.13.2
     - dnspython==2.4.2
     - fastapi==0.103.0


### PR DESCRIPTION
I run into problem with wheel build on python 3.13.
This fixes it.