### PR TITLE
Clean scheduledtask automatically

### DIFF
--- a/artemis/cleanup.py
+++ b/artemis/cleanup.py
@@ -5,14 +5,18 @@ import time
 from karton.core import Consumer
 from karton.core.backend import KartonBackend
 from karton.core.config import Config as KartonConfig
+from karton.core.inspect import KartonState
 
 from artemis import utils
+from artemis.db import DB
 
 logger = utils.build_logger(__name__)
 
 DONT_CLEANUP_TASKS_FRESHER_THAN__DAYS = 3
 DELAY_BETWEEN_CLEANUPS__SECONDS = 4 * 3600
 OLD_MODULES = ["dalfox"]
+
+db = DB()
 
 
 def _cleanup_tasks_not_in_queues() -> None:
@@ -67,9 +71,26 @@ def _cleanup_queues() -> None:
         logger.info("Queue for %s is cleaned up", old_module)
 
 
+def _cleanup_scheduled_tasks() -> None:
+    karton_state = KartonState(backend=KartonBackend(config=KartonConfig()))
+    finished_analysis_ids = []
+    for analysis in db.list_analysis():
+        if analysis["id"] not in karton_state.analyses or len(karton_state.analyses[analysis["id"]].pending_tasks) == 0:
+            finished_analysis_ids.append(analysis["id"])
+
+    if finished_analysis_ids:
+        # introducing batched to not overwhelm database
+        BATCH = 100
+        for i in range(0, len(finished_analysis_ids), BATCH):
+            analysis_ids = finished_analysis_ids[i : i + BATCH]
+            db.delete_analysis_scheduled_tasks(analysis_ids)
+            logger.info("Cleaned up ScheduledTask table for analysis: %s", ",".join(analysis_ids))
+
+
 def cleanup() -> None:
     _cleanup_tasks_not_in_queues()
     _cleanup_queues()
+    _cleanup_scheduled_tasks()
 
 
 if __name__ == "__main__":

--- a/artemis/config.py
+++ b/artemis/config.py
@@ -315,6 +315,10 @@ class Config:
             "Maximum number of URLs to scan per target for modules that crawl like lfi_detector, Nuclei, sq_injection_detector, etc.",
         ] = get_config("MAX_URLS_TO_SCAN", default=25, cast=int)
 
+        CLEANUP_RAISE_ERR_ON_NON_UNFINISHED_ANALYSES: Annotated[
+            bool, "Raise error in case cleanup task did not found unfinished analyses."
+        ] = get_config("CLEANUP_RAISE_ERR_ON_NON_UNFINISHED_ANALYSES", default=False, cast=bool)
+
     class Modules:
         class AdminPanelLoginBruter:
             ADMIN_PANEL_LOGIN_BRUTER_NUM_RECHECKS: Annotated[

--- a/artemis/config.py
+++ b/artemis/config.py
@@ -315,9 +315,9 @@ class Config:
             "Maximum number of URLs to scan per target for modules that crawl like lfi_detector, Nuclei, sq_injection_detector, etc.",
         ] = get_config("MAX_URLS_TO_SCAN", default=25, cast=int)
 
-        CLEANUP_RAISE_ERR_ON_NON_UNFINISHED_ANALYSES: Annotated[
+        CLEANUP_RAISE_ERROR_ON_NON_UNFINISHED_ANALYSES: Annotated[
             bool, "Raise error in case cleanup task did not found unfinished analyses."
-        ] = get_config("CLEANUP_RAISE_ERR_ON_NON_UNFINISHED_ANALYSES", default=False, cast=bool)
+        ] = get_config("CLEANUP_RAISE_ERROR_ON_NON_UNFINISHED_ANALYSES", default=False, cast=bool)
 
     class Modules:
         class AdminPanelLoginBruter:

--- a/artemis/db.py
+++ b/artemis/db.py
@@ -480,11 +480,12 @@ class DB:
             session.commit()
             return bool(result.rowcount)
 
-    def delete_analysis_scheduled_tasks(self, analysis_ids: list[str]) -> None:
+    def delete_scheduled_tasks_for_analyses(self, analysis_ids: list[str]) -> int:
         query = delete(ScheduledTask).where(ScheduledTask.analysis_id.in_(analysis_ids))  # type: ignore
         with self.session() as session:
-            session.execute(query)
+            result = session.execute(query)
             session.commit()
+            return int(result.rowcount)
 
     def get_task_results_since(
         self, time_from: datetime.datetime, tag: Optional[str] = None, batch_size: int = 100

--- a/artemis/db.py
+++ b/artemis/db.py
@@ -22,6 +22,7 @@ from sqlalchemy import (  # type: ignore
     Integer,
     String,
     create_engine,
+    delete,
 )
 from sqlalchemy.dialects.postgresql import TSVECTOR
 from sqlalchemy.dialects.postgresql import insert as postgres_insert
@@ -478,6 +479,12 @@ class DB:
             result = session.execute(statement)
             session.commit()
             return bool(result.rowcount)
+
+    def delete_analysis_scheduled_tasks(self, analysis_ids: list[str]) -> None:
+        query = delete(ScheduledTask).where(ScheduledTask.analysis_id.in_(analysis_ids))  # type: ignore
+        with self.session() as session:
+            session.execute(query)
+            session.commit()
 
     def get_task_results_since(
         self, time_from: datetime.datetime, tag: Optional[str] = None, batch_size: int = 100


### PR DESCRIPTION
Scheduletask table is only used for deduplication. Once the analysis is done we can safely remove records from the DB.