### PR TITLE
Use lxml instead of default parser

### DIFF
--- a/artemis/crawling.py
+++ b/artemis/crawling.py
@@ -17,7 +17,7 @@ def get_links_and_resources_on_same_domain(url: str) -> List[str]:
     except requests.exceptions.RequestException:
         return []
 
-    soup = BeautifulSoup(response.text)
+    soup = BeautifulSoup(response.text, "lxml")
     links = []
     for tag in soup.find_all():
         new_url = None
@@ -48,7 +48,7 @@ def get_injectable_parameters(url: str) -> List[str]:
 
     result = set()
     try:
-        soup = BeautifulSoup(content, "html.parser")
+        soup = BeautifulSoup(content, "lxml")
     except ParserRejectedMarkup:
         return []
 

--- a/artemis/modules/admin_panel_login_bruter.py
+++ b/artemis/modules/admin_panel_login_bruter.py
@@ -96,7 +96,7 @@ class AdminPanelLoginBruter(ArtemisBase):
                 return (False, None)
 
             original_cookies = session.cookies.get_dict()  # type: ignore
-            soup = BeautifulSoup(response.text, "html.parser")
+            soup = BeautifulSoup(response.text, "lxml")
             forms = soup.find_all("form")
 
             for form in forms:

--- a/artemis/modules/directory_index.py
+++ b/artemis/modules/directory_index.py
@@ -34,7 +34,7 @@ class DirectoryIndex(ArtemisBase):
 
     def scan(self, base_url: str) -> List[FoundURL]:
         response = self.http_get(base_url)
-        soup = BeautifulSoup(response.content, "html.parser")
+        soup = BeautifulSoup(response.content, "lxml")
         original_base_url_parsed = urllib.parse.urlparse(base_url)
 
         path_candidates = set()

--- a/artemis/modules/drupal_scanner.py
+++ b/artemis/modules/drupal_scanner.py
@@ -33,7 +33,7 @@ class DrupalScanner(BaseNewerVersionComparerModule):
     def run(self, current_task: Task) -> None:
         url = current_task.get_payload("url")
         response = self.http_get(url, max_size=DrupalScanner.DOWNLOADED_CONTENT_PREFIX_SIZE)
-        soup = bs4.BeautifulSoup(response.content)
+        soup = bs4.BeautifulSoup(response.content, "lxml")
 
         version: Optional[str] = None
         for script in soup.find_all("script"):

--- a/artemis/modules/scripts_unregistered_domains.py
+++ b/artemis/modules/scripts_unregistered_domains.py
@@ -71,7 +71,7 @@ class ScriptsUnregisteredDomains(ArtemisBase):
 
         content = self.http_get(url).content
 
-        soup = bs4.BeautifulSoup(content, "html.parser")
+        soup = bs4.BeautifulSoup(content, "lxml")
         scripts = soup.find_all("script", src=True)
         scripts_from_unregistered_domains = []
         messages = []

--- a/artemis/reporting/export/main.py
+++ b/artemis/reporting/export/main.py
@@ -68,13 +68,13 @@ environment.filters["nl2br"] = nl2br
 def unwrap(html: str) -> str:
     """Uwraps html if it's wrapped in a single tag (e.g. <div>)."""
     html = html.strip()
-    soup = bs4.BeautifulSoup(html)
+    soup = bs4.BeautifulSoup(html, "lxml")
     while len(list(soup.children)) == 1:
         only_child = list(soup.children)[0]
 
         if only_child.name:  # type: ignore
             only_child.unwrap()
-            soup = bs4.BeautifulSoup(soup.renderContents().strip())
+            soup = bs4.BeautifulSoup(soup.renderContents().strip(), "lxml")
         else:
             break
 

--- a/artemis/reporting/modules/bruter/classifier.py
+++ b/artemis/reporting/modules/bruter/classifier.py
@@ -44,7 +44,7 @@ def is_log_file(found_url: FoundURL) -> bool:
         return False
 
     if found_url.has_directory_index:
-        soup = bs4.BeautifulSoup(found_url.content_prefix)
+        soup = bs4.BeautifulSoup(found_url.content_prefix, "lxml")
         for link in soup.find_all("a"):
             href = link.get("href")
             if (

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ Jinja2==3.1.6
 karton-core==5.9.0
 git+https://github.com/CERT-Polska/mailgoose@v1.3.15#egg=libmailgoose&subdirectory=scan
 liccheck==0.9.2
+lxml==6.0.2
 Markdown==3.10
 MarkupSafe==3.0.3
 minio==7.2.19

--- a/test/e2e/base.py
+++ b/test/e2e/base.py
@@ -50,7 +50,7 @@ class BaseE2ETestCase(TestCase):
         with requests.Session() as s:
             response = s.get(BACKEND_URL + "add")
             data = response.content
-            soup = BeautifulSoup(data, "html.parser")
+            soup = BeautifulSoup(data, "lxml")
             csrf_token = soup.find("input", {"name": "csrf_token"})["value"]  # type: ignore
             response = s.post(
                 BACKEND_URL + "add",
@@ -66,7 +66,7 @@ class BaseE2ETestCase(TestCase):
     def submit_tasks_with_modules_enabled(self, tasks: List[str], tag: str, modules_enabled: List[str]) -> None:
         with requests.Session() as s:
             data = s.get(BACKEND_URL + "add").content
-            soup = BeautifulSoup(data, "html.parser")
+            soup = BeautifulSoup(data, "lxml")
             csrf_token = soup.find("input", {"name": "csrf_token"})["value"]  # type: ignore
 
             response = s.post(

--- a/test/e2e/test_exporting.py
+++ b/test/e2e/test_exporting.py
@@ -32,7 +32,7 @@ class ExportingTestCase(BaseE2ETestCase):
 
         with requests.Session() as s:
             data = s.get(BACKEND_URL + "export").content
-            soup = BeautifulSoup(data, "html.parser")
+            soup = BeautifulSoup(data, "lxml")
             csrf_token = soup.find("input", {"name": "csrf_token"})["value"]  # type: ignore
 
             response = s.post(
@@ -444,7 +444,7 @@ class ExportingTestCase(BaseE2ETestCase):
 
         with requests.Session() as s:
             data = s.get(BACKEND_URL + "export").content
-            soup = BeautifulSoup(data, "html.parser")
+            soup = BeautifulSoup(data, "lxml")
 
             option_values = [option.text for option in soup.select("select option")]
 
@@ -456,7 +456,7 @@ class ExportingTestCase(BaseE2ETestCase):
 
         with requests.Session() as s:
             data = s.get(BACKEND_URL + "export").content
-            soup = BeautifulSoup(data, "html.parser")
+            soup = BeautifulSoup(data, "lxml")
             csrf_token = soup.find("input", {"name": "csrf_token"})["value"]  # type: ignore
 
             s.post(
@@ -472,7 +472,7 @@ class ExportingTestCase(BaseE2ETestCase):
 
         with requests.Session() as s:
             data = s.get(BACKEND_URL + "exports").content
-            soup = BeautifulSoup(data, "html.parser")
+            soup = BeautifulSoup(data, "lxml")
             t_body = soup.find_all(id="task_list")[0].tbody
 
             for tr in t_body.find_all("tr"):


### PR DESCRIPTION
During investigating fails/timeouts of tests I've discovered that we do not always precise parser, or use html.parser for xml which is not recommended.
The branch is to test if lxml will speed up the parsing and can replace default parser in BeautifulSoup 