### PR TITLE
CVE-2025-68461 Nuclei Detection

### DIFF
--- a/artemis/modules/data/nuclei_templates_custom/CVE-2025-68461.yaml
+++ b/artemis/modules/data/nuclei_templates_custom/CVE-2025-68461.yaml
@@ -1,0 +1,75 @@
+id: CVE-2025-68461
+
+info:
+  name: CVE-2025-68461 - Roundcube Webmail SVG Animate Tag Cross-Site Scripting
+  author: rxerium
+  severity: high
+  description: |
+    Roundcube Webmail versions before 1.5.12 and 1.6 before 1.6.12 contain a Cross-Site Scripting (XSS) vulnerability via the animate tag in SVG documents. The vulnerability stems from improper neutralization of input during web page generation, allowing attackers to inject malicious JavaScript code that executes in the context of the victim's browser when viewing crafted SVG content within the webmail interface. This could enable attackers to steal session tokens, perform actions on behalf of the user, or exfiltrate sensitive information accessible through the webmail interface.
+  reference:
+    - https://nvd.nist.gov/vuln/detail/CVE-2025-68461
+    - https://roundcube.net/news/2025/12/13/security-updates-1.6.12-and-1.5.12
+    - https://github.com/roundcube/roundcubemail/commit/bfa032631c36b900e7444dfa278340b33cbf7cdb
+    - https://radar.offseq.com/threat/cve-2025-68461-cwe-79-improper-neutralization-of-i-1c741b3e
+  metadata:
+    vendor: Roundcube
+    product: Roundcube Webmail
+    cvss-score: 7.2
+    cwe-id: CWE-79
+    cisa-kev: false
+    verified: true
+    shodan-query: http.title:"Roundcube"
+  tags: cve,cve2025,roundcube,xss,svg
+
+http:
+  - method: GET
+    path:
+      - "{{BaseURL}}"
+
+    extractors:
+      - type: regex
+        name: major
+        group: 1
+        regex:
+          - '"rcversion":(\d)'
+        internal: true
+
+      - type: regex
+        name: minor
+        group: 1
+        regex:
+          - '"rcversion":\d\d(\d)'
+        internal: true
+
+      - type: regex
+        name: patch
+        group: 1
+        regex:
+          - '"rcversion":\d\d\d(\d+)'
+        internal: true
+
+      - type: dsl
+        name: version
+        dsl:
+          - major + "." + minor + "." + patch
+        internal: true
+
+      - type: dsl
+        dsl:
+          - '"Roundcube Version: "+ version'
+
+    matchers-condition: and
+    matchers:
+      - type: dsl
+        name: vulnerable
+        dsl:
+          - compare_versions(version, '< 1.5.12') || (compare_versions(version,'>= 1.6.0') && compare_versions(version, '< 1.6.12'))
+
+      - type: word
+        part: body
+        words:
+          - "Roundcube"
+
+      - type: status
+        status:
+          - 200


### PR DESCRIPTION
Hi there,

I saw the alert come in from [CERT Polska](https://moje.cert.pl/komunikaty/2025/66/powazna-podatnosc-w-oprogramowaniu-roundcube-webmail/#) a couple mins ago and figured I would add my Nuclei template to this project to detect vulnerable instances for CVE-2025-68461. Let me know if this will be useful to the project (and if I have added it to the correct folder).

Thanks,

Rishi