### PR TITLE
Fix key error in dangling dns module

### DIFF
--- a/artemis/module_base.py
+++ b/artemis/module_base.py
@@ -746,9 +746,18 @@ class ArtemisBase(Karton):
         result = None
         if task.headers["type"] == TaskType.NEW:
             result = task.payload["data"]
-        elif task.headers["type"] == TaskType.IP or task.headers["type"] == TaskType.SUSPECTED_DANGLING_IP:
+        elif task.headers["type"] == TaskType.IP:
             result = task.payload["ip"]
-        elif task.headers["type"] == TaskType.DOMAIN or task.headers["type"] == TaskType.DOMAIN_THAT_MAY_NOT_EXIST:
+        elif task.headers["type"] == TaskType.SUSPECTED_DANGLING_IP and "ip" in task.payload:
+            # Payload for suspected dangling ip has changed and now it should contain IP, but old tasks do not have it
+            # Get ip if possible, otherwise fallback to domain in next condition
+            # FIXME: to be removed in future
+            result = task.payload["ip"]
+        elif (
+            task.headers["type"] == TaskType.DOMAIN
+            or task.headers["type"] == TaskType.DOMAIN_THAT_MAY_NOT_EXIST
+            or task.headers["type"] == TaskType.SUSPECTED_DANGLING_IP
+        ):
             # This is an approximation. Sometimes, when we scan domain, we actually scan the IP the domain
             # resolves to (e.g. in port_scan karton), sometimes the domain itself (e.g. the DNS kartons) or
             # even the MX servers. Therefore this will not map 1:1 to the actual host being scanned.

--- a/test/modules/test_dangling_dns_detector.py
+++ b/test/modules/test_dangling_dns_detector.py
@@ -231,7 +231,10 @@ class TestDanglingDnsDetectorIntegration(ArtemisModuleTestCase):
         # given
         task = Task(
             {"type": TaskType.DOMAIN_THAT_MAY_NOT_EXIST.value},
-            payload={"domain": "dangling-cname.test.artemis.lab.cert.pl"},
+            payload={
+                "domain": "dangling-cname.test.artemis.lab.cert.pl",
+                "last_domain": "dangling-cname.test.artemis.lab.cert.pl",
+            },
         )
 
         # when
@@ -249,7 +252,10 @@ class TestDanglingDnsDetectorIntegration(ArtemisModuleTestCase):
         # given
         task = Task(
             {"type": TaskType.DOMAIN_THAT_MAY_NOT_EXIST.value},
-            payload={"domain": "dangling.test.artemis.lab.cert.pl"},
+            payload={
+                "domain": "dangling.test.artemis.lab.cert.pl",
+                "last_domain": "dangling.test.artemis.lab.cert.pl",
+            },
         )
 
         # when


### PR DESCRIPTION
After: https://github.com/CERT-Polska/Artemis/pull/2223 payload changed for retry tasks.
Adds fallback to prevent keyerror.