### PR TITLE
feat: Add task ID returns to create_tasks and API

### DIFF
--- a/artemis/api.py
+++ b/artemis/api.py
@@ -119,7 +119,7 @@ def add(
     else:
         module_runtime_configurations = {}
 
-    create_tasks(
+    task_ids = create_tasks(
         targets,
         tag,
         disabled_modules=disabled_modules,
@@ -128,7 +128,7 @@ def add(
         module_runtime_configurations=module_runtime_configurations,
     )
 
-    return {"ok": True}
+    return {"ok": True, "ids": task_ids}
 
 
 @router.get("/analyses", dependencies=[Depends(verify_api_token)])

--- a/artemis/producer.py
+++ b/artemis/producer.py
@@ -19,7 +19,9 @@ def create_tasks(
     priority: Optional[TaskPriority] = None,
     requests_per_second_override: Optional[float] = None,
     module_runtime_configurations: Optional[Dict[str, Dict[str, Any]]] = None,
-) -> None:
+) -> List[str]:
+    """Create tasks for given URIs and return their IDs."""
+    task_ids = []
     for uri in {uri.lower() for uri in uris}:
         task = Task({"type": TaskType.NEW})
         task.add_payload("data", uri)
@@ -42,3 +44,6 @@ def create_tasks(
         db.save_scheduled_task(task)
         db.save_tag(tag)
         producer.send_task(task)
+        task_ids.append(task.uid)
+
+    return task_ids


### PR DESCRIPTION
- Modified create_tasks() to return List[str] of task IDs
- Updated /add endpoint to return {"ok": true, "ids": [...]} response
- Task UIDs are now accessible to clients after creation