### PR TITLE
Add Retire.js-based vulnerable JS library detection module

### DIFF
--- a/artemis/modules/data/jsrepository.json
+++ b/artemis/modules/data/jsrepository.json
@@ -1,0 +1,337 @@
+{
+  "jquery": {
+    "bowername": [
+      "jquery"
+    ],
+    "extractors": {
+      "filename": [
+        "jquery[._-]([0-9]+(?:\\.[0-9]+)+)"
+      ],
+      "filecontent": [
+        "\\*!? jQuery JavaScript Library v?([0-9][0-9.a-zA-Z_\\-]*)",
+        "\\*!? jQuery v?([0-9][0-9.a-zA-Z_\\-]*)",
+        "jQuery\\s+v([0-9][0-9.a-zA-Z_\\-]*)"
+      ],
+      "uri": [
+        "jquery[._-]([0-9]+(?:\\.[0-9]+)+)"
+      ],
+      "hashes": {}
+    },
+    "vulnerabilities": [
+      {
+        "below": "1.9.0",
+        "severity": "medium",
+        "identifiers": {
+          "CVE": [
+            "CVE-2011-4969"
+          ]
+        },
+        "info": [
+          "https://nvd.nist.gov/vuln/detail/CVE-2011-4969"
+        ]
+      },
+      {
+        "below": "1.12.0",
+        "atOrAbove": "1.11.1",
+        "severity": "medium",
+        "identifiers": {
+          "CVE": [
+            "CVE-2015-9251"
+          ]
+        },
+        "info": [
+          "https://nvd.nist.gov/vuln/detail/CVE-2015-9251"
+        ]
+      },
+      {
+        "below": "3.4.0",
+        "atOrAbove": "1.0.3",
+        "severity": "medium",
+        "identifiers": {
+          "CVE": [
+            "CVE-2019-11358"
+          ]
+        },
+        "info": [
+          "https://nvd.nist.gov/vuln/detail/CVE-2019-11358"
+        ]
+      },
+      {
+        "below": "3.5.0",
+        "severity": "medium",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-11022",
+            "CVE-2020-11023"
+          ]
+        },
+        "info": [
+          "https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/"
+        ]
+      }
+    ]
+  },
+  "bootstrap": {
+    "bowername": [
+      "bootstrap"
+    ],
+    "extractors": {
+      "filename": [
+        "bootstrap[._-]([0-9]+(?:\\.[0-9]+)+)"
+      ],
+      "filecontent": [
+        "Bootstrap v([0-9][0-9.a-zA-Z_\\-]*)",
+        "\\* Bootstrap v([0-9][0-9.a-zA-Z_\\-]*)"
+      ],
+      "uri": [
+        "bootstrap[._-]([0-9]+(?:\\.[0-9]+)+)"
+      ],
+      "hashes": {}
+    },
+    "vulnerabilities": [
+      {
+        "below": "3.4.0",
+        "atOrAbove": "3.0.0",
+        "severity": "medium",
+        "identifiers": {
+          "CVE": [
+            "CVE-2018-14041",
+            "CVE-2018-14042"
+          ]
+        },
+        "info": [
+          "https://nvd.nist.gov/vuln/detail/CVE-2018-14041"
+        ]
+      },
+      {
+        "below": "4.3.1",
+        "atOrAbove": "4.0.0",
+        "severity": "medium",
+        "identifiers": {
+          "CVE": [
+            "CVE-2019-8331"
+          ]
+        },
+        "info": [
+          "https://nvd.nist.gov/vuln/detail/CVE-2019-8331"
+        ]
+      },
+      {
+        "below": "3.4.1",
+        "atOrAbove": "3.0.0",
+        "severity": "medium",
+        "identifiers": {
+          "CVE": [
+            "CVE-2019-8331"
+          ]
+        },
+        "info": [
+          "https://nvd.nist.gov/vuln/detail/CVE-2019-8331"
+        ]
+      }
+    ]
+  },
+  "lodash": {
+    "bowername": [
+      "lodash"
+    ],
+    "extractors": {
+      "filename": [
+        "lodash[._-]([0-9]+(?:\\.[0-9]+)+)"
+      ],
+      "filecontent": [
+        "lodash\\s+([0-9][0-9.a-zA-Z_\\-]*)",
+        "@license Lodash <https://lodash.com/>\\s+Copyright.*?\\s+<https://lodash.com/>\\s+Released under.*?\\s+([0-9][0-9.a-zA-Z_\\-]*)"
+      ],
+      "uri": [
+        "lodash[._-]([0-9]+(?:\\.[0-9]+)+)"
+      ],
+      "hashes": {}
+    },
+    "vulnerabilities": [
+      {
+        "below": "4.17.21",
+        "severity": "high",
+        "identifiers": {
+          "CVE": [
+            "CVE-2021-23337",
+            "CVE-2020-28500"
+          ]
+        },
+        "info": [
+          "https://nvd.nist.gov/vuln/detail/CVE-2021-23337"
+        ]
+      },
+      {
+        "below": "4.17.19",
+        "severity": "high",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-8203"
+          ]
+        },
+        "info": [
+          "https://nvd.nist.gov/vuln/detail/CVE-2020-8203"
+        ]
+      },
+      {
+        "below": "4.17.12",
+        "severity": "high",
+        "identifiers": {
+          "CVE": [
+            "CVE-2019-10744"
+          ]
+        },
+        "info": [
+          "https://nvd.nist.gov/vuln/detail/CVE-2019-10744"
+        ]
+      },
+      {
+        "below": "4.17.11",
+        "severity": "high",
+        "identifiers": {
+          "CVE": [
+            "CVE-2018-3721",
+            "CVE-2019-1010266"
+          ]
+        },
+        "info": [
+          "https://nvd.nist.gov/vuln/detail/CVE-2018-3721"
+        ]
+      }
+    ]
+  },
+  "angularjs": {
+    "bowername": [
+      "angularjs",
+      "angular"
+    ],
+    "extractors": {
+      "filename": [
+        "angular(?:js)?[._-]([0-9]+(?:\\.[0-9]+)+)"
+      ],
+      "filecontent": [
+        "@license AngularJS v([0-9][0-9.a-zA-Z_\\-]*)",
+        "AngularJS\\s+v([0-9][0-9.a-zA-Z_\\-]*)"
+      ],
+      "uri": [
+        "angular(?:js)?[._-]([0-9]+(?:\\.[0-9]+)+)"
+      ],
+      "hashes": {}
+    },
+    "vulnerabilities": [
+      {
+        "below": "1.6.0",
+        "severity": "high",
+        "identifiers": {
+          "CVE": [
+            "CVE-2016-9879"
+          ]
+        },
+        "info": [
+          "https://nvd.nist.gov/vuln/detail/CVE-2016-9879"
+        ]
+      },
+      {
+        "below": "1.8.0",
+        "severity": "medium",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-7676"
+          ]
+        },
+        "info": [
+          "https://nvd.nist.gov/vuln/detail/CVE-2020-7676"
+        ]
+      }
+    ]
+  },
+  "moment.js": {
+    "bowername": [
+      "moment"
+    ],
+    "extractors": {
+      "filename": [
+        "moment[._-]([0-9]+(?:\\.[0-9]+)+)"
+      ],
+      "filecontent": [
+        "moment\\.version\\s*=\\s*['\"]([0-9][0-9.a-zA-Z_\\-]*)['\"]",
+        "\\/\\*!\\s+moment\\.js\\s+version\\s*:\\s*([0-9][0-9.a-zA-Z_\\-]*)"
+      ],
+      "uri": [
+        "moment[._-]([0-9]+(?:\\.[0-9]+)+)"
+      ],
+      "hashes": {}
+    },
+    "vulnerabilities": [
+      {
+        "below": "2.29.2",
+        "severity": "high",
+        "identifiers": {
+          "CVE": [
+            "CVE-2022-24785"
+          ]
+        },
+        "info": [
+          "https://nvd.nist.gov/vuln/detail/CVE-2022-24785"
+        ]
+      },
+      {
+        "below": "2.29.4",
+        "severity": "high",
+        "identifiers": {
+          "CVE": [
+            "CVE-2022-31129"
+          ]
+        },
+        "info": [
+          "https://nvd.nist.gov/vuln/detail/CVE-2022-31129"
+        ]
+      },
+      {
+        "below": "2.19.3",
+        "severity": "high",
+        "identifiers": {
+          "CVE": [
+            "CVE-2017-18214"
+          ]
+        },
+        "info": [
+          "https://nvd.nist.gov/vuln/detail/CVE-2017-18214"
+        ]
+      }
+    ]
+  },
+  "underscore.js": {
+    "bowername": [
+      "underscore"
+    ],
+    "extractors": {
+      "filename": [
+        "underscore[._-]([0-9]+(?:\\.[0-9]+)+)"
+      ],
+      "filecontent": [
+        "\\/\\/ Underscore\\.js\\s+([0-9][0-9.a-zA-Z_\\-]*)"
+      ],
+      "uri": [
+        "underscore[._-]([0-9]+(?:\\.[0-9]+)+)"
+      ],
+      "hashes": {}
+    },
+    "vulnerabilities": [
+      {
+        "below": "1.12.1",
+        "atOrAbove": "1.3.2",
+        "severity": "high",
+        "identifiers": {
+          "CVE": [
+            "CVE-2021-23358"
+          ]
+        },
+        "info": [
+          "https://nvd.nist.gov/vuln/detail/CVE-2021-23358"
+        ]
+      }
+    ]
+  }
+}

--- a/artemis/modules/js_vuln_detector.py
+++ b/artemis/modules/js_vuln_detector.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""
+JsVulnDetector – Artemis module that detects vulnerable client-side JavaScript
+libraries using the Retire.js vulnerability database.
+
+Scope: only external scripts referenced via ``<script src="...">``.  Inline
+scripts are intentionally excluded to keep the module fast and avoid false
+positives from minified/transpiled bundles.
+
+Per-page limits
+---------------
+* At most ``MAX_SCRIPTS_PER_PAGE`` script sources are inspected.
+* Script content is fetched (to attempt version extraction) only when the URL
+  itself does not reveal the version.  The fetched content is truncated to
+  ``MAX_SCRIPT_CONTENT_BYTES`` to protect against very large bundles.
+"""
+import json
+import re
+import urllib.parse
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import bs4
+from karton.core import Task
+from packaging.version import InvalidVersion, Version
+
+from artemis import load_risk_class
+from artemis.binds import Service, TaskStatus, TaskType
+from artemis.module_base import ArtemisBase
+from artemis.task_utils import get_target_url
+
+# --------------------------------------------------------------------------- #
+#  Tunables
+# --------------------------------------------------------------------------- #
+
+MAX_SCRIPTS_PER_PAGE = 25
+MAX_SCRIPT_CONTENT_BYTES = 256 * 1024  # 256 KB
+
+DB_PATH = Path(__file__).parent / "data" / "jsrepository.json"
+
+
+# --------------------------------------------------------------------------- #
+#  Database helpers
+# --------------------------------------------------------------------------- #
+
+
+def _load_db() -> Dict[str, Any]:
+    with open(DB_PATH, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _extract_version(text: str, patterns: List[str]) -> Optional[str]:
+    """Return the first capturing group matched by any pattern, or *None*."""
+    for raw_pattern in patterns:
+        try:
+            match = re.search(raw_pattern, text, re.IGNORECASE)
+        except re.error:
+            continue
+        if match:
+            groups = match.groups()
+            if groups and groups[0]:
+                return groups[0].strip()
+    return None
+
+
+def _version_is_vulnerable(version_str: str, vuln_entry: Dict[str, Any]) -> bool:
+    """
+    Return *True* when *version_str* falls within the affected range described
+    by *vuln_entry*, which may contain ``"atOrAbove"`` and/or ``"below"`` keys.
+    """
+    try:
+        version = Version(version_str)
+    except InvalidVersion:
+        # Non-PEP-440 version string – we cannot compare it safely.
+        return False
+
+    at_or_above = vuln_entry.get("atOrAbove")
+    below = vuln_entry.get("below")
+
+    if at_or_above:
+        try:
+            if version < Version(at_or_above):
+                return False
+        except InvalidVersion:
+            return False
+
+    if below:
+        try:
+            if version >= Version(below):
+                return False
+        except InvalidVersion:
+            return False
+
+    return True
+
+
+def _SEVERITY_RANK(s: str) -> int:
+    return {"critical": 4, "high": 3, "medium": 2, "low": 1}.get(s.lower(), 0)
+
+
+def check_library(
+    lib_name: str,
+    lib_info: Dict[str, Any],
+    script_url: str,
+    script_content: Optional[str],
+) -> Optional[Dict[str, Any]]:
+    """
+    Try to detect *lib_name* in the given script and, if a known-vulnerable
+    version is found, return a finding dictionary.  Returns *None* when no
+    vulnerability is detected.
+
+    The URL path (``script_url``) is always tried first so that fetching the
+    script content can be skipped for the common case where the version appears
+    in the file name.
+    """
+    extractors = lib_info.get("extractors", {})
+
+    # 1. Try URL / filename patterns (no extra HTTP request).
+    detected_version: Optional[str] = None
+    for key in ("filename", "uri"):
+        detected_version = _extract_version(script_url, extractors.get(key, []))
+        if detected_version:
+            break
+
+    # 2. Fall back to file-content patterns when needed.
+    if not detected_version and script_content is not None:
+        detected_version = _extract_version(script_content, extractors.get("filecontent", []))
+
+    if not detected_version:
+        return None
+
+    # 3. Check detected version against every vulnerability entry.
+    matching: List[Dict[str, Any]] = [
+        v for v in lib_info.get("vulnerabilities", []) if _version_is_vulnerable(detected_version, v)
+    ]
+    if not matching:
+        return None
+
+    cves: List[str] = []
+    severities: List[str] = []
+    info_urls: List[str] = []
+    for vuln in matching:
+        ids = vuln.get("identifiers", {})
+        cves.extend(ids.get("CVE", []))
+        severities.append(vuln.get("severity", "unknown"))
+        info_urls.extend(vuln.get("info", []))
+
+    worst_severity = max(severities, key=_SEVERITY_RANK) if severities else "unknown"
+
+    return {
+        "library": lib_name,
+        "detected_version": detected_version,
+        "script_url": script_url,
+        "cves": sorted(set(cves)),
+        "severity": worst_severity,
+        "info_urls": list(dict.fromkeys(info_urls)),  # deduplicated, preserving order
+    }
+
+
+# --------------------------------------------------------------------------- #
+#  Module class
+# --------------------------------------------------------------------------- #
+
+
+@load_risk_class.load_risk_class(load_risk_class.LoadRiskClass.LOW)
+class JsVulnDetector(ArtemisBase):
+    """
+    Detects vulnerable client-side JavaScript libraries (e.g. jQuery, Bootstrap,
+    Lodash) loaded via ``<script src="...">``, using the Retire.js vulnerability
+    database bundled at ``artemis/modules/data/jsrepository.json``.
+
+    For each detected library, the module reports the library name, the detected
+    version, associated CVE identifiers, the script URL, and remediation guidance
+    (upgrade to the latest stable release).
+    """
+
+    identity = "js_vuln_detector"
+    filters = [
+        {"type": TaskType.SERVICE.value, "service": Service.HTTP.value},
+    ]
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._db: Dict[str, Any] = _load_db()
+
+    # ---------------------------------------------------------------------- #
+    #  Internal helpers
+    # ---------------------------------------------------------------------- #
+
+    def _fetch_script(self, script_url: str) -> Optional[str]:
+        """
+        Fetch *script_url* and return its decoded text content, or *None* on
+        any error (connection failure, non-200 status, binary content, …).
+        Content larger than ``MAX_SCRIPT_CONTENT_BYTES`` is ignored.
+        """
+        try:
+            response = self.forgiving_http_get(script_url, max_size=MAX_SCRIPT_CONTENT_BYTES)
+            if response is None:
+                return None
+            if response.status_code != 200:
+                return None
+            content_type = response.headers.get("content-type", "")
+            # Accept application/javascript, text/javascript, text/plain, etc.
+            if "html" in content_type.lower():
+                return None
+            return response.content
+        except Exception as exc:
+            self.log.debug("Could not fetch script %s: %s", script_url, exc)
+            return None
+
+    # ---------------------------------------------------------------------- #
+    #  Karton task handler
+    # ---------------------------------------------------------------------- #
+
+    def run(self, current_task: Task) -> None:
+        url = get_target_url(current_task)
+
+        # Fetch the target page -------------------------------------------- #
+        try:
+            page_response = self.http_get(url)
+        except Exception as exc:
+            self.log.error("Failed to fetch %s: %s", url, exc)
+            self.db.save_task_result(
+                task=current_task,
+                status=TaskStatus.ERROR,
+                status_reason=str(exc),
+                data={"findings": [], "scripts_checked": 0},
+            )
+            return
+
+        if page_response.status_code != 200:
+            self.db.save_task_result(
+                task=current_task,
+                status=TaskStatus.OK,
+                status_reason=None,
+                data={"findings": [], "scripts_checked": 0},
+            )
+            return
+
+        content_type = page_response.headers.get("content-type", "")
+        if "html" not in content_type.lower():
+            # Not an HTML page – nothing to scan.
+            self.db.save_task_result(
+                task=current_task,
+                status=TaskStatus.OK,
+                status_reason=None,
+                data={"findings": [], "scripts_checked": 0},
+            )
+            return
+
+        # Parse HTML and extract <script src="…"> --------------------------- #
+        soup = bs4.BeautifulSoup(page_response.content_bytes, "html.parser")
+        script_tags = soup.find_all("script", src=True)
+
+        findings: List[Dict[str, Any]] = []
+        scripts_checked = 0
+
+        for tag in script_tags[:MAX_SCRIPTS_PER_PAGE]:
+            src: str = (tag.get("src") or "").strip()
+            if not src:
+                continue
+
+            script_url = urllib.parse.urljoin(url, src)
+            # Use only the URL path for pattern matching (avoids false positives
+            # from query-string parameters).
+            url_path = urllib.parse.urlparse(script_url).path.lower()
+
+            # Lazily fetched script content (at most once per script).
+            script_content: Optional[str] = None
+            content_fetched = False
+            scripts_checked += 1
+
+            for lib_name, lib_info in self._db.items():
+                # Quick pre-check: does the URL path look related to this lib?
+                # We try URL-only first to avoid an unnecessary HTTP request.
+                finding = check_library(lib_name, lib_info, url_path, script_content)
+
+                if finding is None and not content_fetched:
+                    # Fetch the script content and retry.
+                    script_content = self._fetch_script(script_url)
+                    content_fetched = True
+                    finding = check_library(lib_name, lib_info, url_path, script_content)
+
+                if finding is not None:
+                    # Record the full resolved URL for reporting.
+                    finding["script_url"] = script_url
+                    findings.append(finding)
+                    # One library per script is the common case; keep scanning
+                    # others in case multiple libs are bundled.
+
+        # Build result ------------------------------------------------------- #
+        if findings:
+            messages = []
+            for f in findings:
+                cve_str = ", ".join(f["cves"]) if f["cves"] else "no CVE listed"
+                messages.append(
+                    f"{f['library']} {f['detected_version']} "
+                    f"loaded from {f['script_url']} is vulnerable ({cve_str}). "
+                    f"Please upgrade to the latest stable version."
+                )
+            status = TaskStatus.INTERESTING
+            status_reason = "; ".join(messages)
+        else:
+            status = TaskStatus.OK
+            status_reason = None
+
+        self.db.save_task_result(
+            task=current_task,
+            status=status,
+            status_reason=status_reason,
+            data={"findings": findings, "scripts_checked": scripts_checked},
+        )
+
+
+if __name__ == "__main__":
+    JsVulnDetector().loop()

--- a/artemis/reporting/modules/js_vuln_detector/reporter.py
+++ b/artemis/reporting/modules/js_vuln_detector/reporter.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+from typing import Any, Callable, Dict, List
+
+from artemis.reporting.base.language import Language
+from artemis.reporting.base.normal_form import NormalForm, get_url_normal_form
+from artemis.reporting.base.report import Report
+from artemis.reporting.base.report_type import ReportType
+from artemis.reporting.base.reporter import Reporter
+from artemis.reporting.base.templating import ReportEmailTemplateFragment
+from artemis.reporting.utils import get_target_url, get_top_level_target
+
+
+class JsVulnDetectorReporter(Reporter):
+    VULNERABLE_JS_LIBRARY = ReportType("vulnerable_js_library")
+
+    @staticmethod
+    def create_reports(task_result: Dict[str, Any], language: Language) -> List[Report]:
+        if task_result["headers"]["receiver"] != "js_vuln_detector":
+            return []
+
+        if not isinstance(task_result.get("result"), dict):
+            return []
+
+        findings = task_result["result"].get("findings", [])
+        if not findings:
+            return []
+
+        return [
+            Report(
+                top_level_target=get_top_level_target(task_result),
+                target=get_target_url(task_result),
+                report_type=JsVulnDetectorReporter.VULNERABLE_JS_LIBRARY,
+                additional_data={"findings": findings},
+                timestamp=task_result["created_at"],
+            )
+        ]
+
+    @staticmethod
+    def get_email_template_fragments() -> List[ReportEmailTemplateFragment]:
+        return [
+            ReportEmailTemplateFragment.from_file(
+                str(Path(__file__).parents[0] / "template_vulnerable_js_library.jinja2"),
+                priority=3,
+            ),
+        ]
+
+    @staticmethod
+    def get_normal_form_rules() -> Dict[ReportType, Callable[[Report], NormalForm]]:
+        """Two reports for the same URL with the same set of vulnerable libraries share a normal form."""
+        return {
+            JsVulnDetectorReporter.VULNERABLE_JS_LIBRARY: lambda report: Reporter.dict_to_tuple(
+                {
+                    "type": report.report_type,
+                    "target": get_url_normal_form(report.target),
+                    "findings": tuple(
+                        Reporter.dict_to_tuple(
+                            {
+                                "library": f["library"],
+                                "detected_version": f["detected_version"],
+                                "cves": tuple(sorted(f.get("cves", []))),
+                            }
+                        )
+                        for f in sorted(
+                            report.additional_data["findings"],
+                            key=lambda x: (x["library"], x["detected_version"]),
+                        )
+                    ),
+                }
+            )
+        }

--- a/artemis/reporting/modules/js_vuln_detector/template_vulnerable_js_library.jinja2
+++ b/artemis/reporting/modules/js_vuln_detector/template_vulnerable_js_library.jinja2
@@ -1,0 +1,25 @@
+{% if "vulnerable_js_library" in data.contains_type %}
+    <li>{% trans %}We identified vulnerable JavaScript libraries loaded by the page:{% endtrans %}
+        <ul>
+            {% for report in data.reports %}
+                {% if report.report_type == "vulnerable_js_library" %}
+                    {% for finding in report.additional_data.findings %}
+                        <li>
+                            {{ report.target }}: {{ finding.library }} {{ finding.detected_version }}
+                            {% if finding.cves %}({{ ", ".join(finding.cves) }}){% endif %}
+                            — <a href="{{ finding.script_url }}">{{ finding.script_url }}</a>
+                        </li>
+                    {% endfor %}
+                    {{ report_meta(report) }}
+                {% endif %}
+            {% endfor %}
+        </ul>
+        <p>
+            {% trans trimmed %}
+                These JavaScript libraries have known security vulnerabilities (such as cross-site
+                scripting, prototype pollution, or denial-of-service). Please upgrade each affected
+                library to the latest stable release.
+            {% endtrans %}
+        </p>
+    </li>
+{% endif %}

--- a/artemis/reporting/modules/js_vuln_detector/translations/en_US/LC_MESSAGES/messages.po
+++ b/artemis/reporting/modules/js_vuln_detector/translations/en_US/LC_MESSAGES/messages.po
@@ -1,0 +1,10 @@
+#: artemis/reporting/modules/js_vuln_detector/template_vulnerable_js_library.jinja2:2
+msgid "We identified vulnerable JavaScript libraries loaded by the page:"
+msgstr ""
+
+#: artemis/reporting/modules/js_vuln_detector/template_vulnerable_js_library.jinja2:14
+msgid ""
+"These JavaScript libraries have known security vulnerabilities (such as "
+"cross-site scripting, prototype pollution, or denial-of-service). Please "
+"upgrade each affected library to the latest stable release."
+msgstr ""

--- a/artemis/reporting/modules/js_vuln_detector/translations/pl_PL/LC_MESSAGES/messages.po
+++ b/artemis/reporting/modules/js_vuln_detector/translations/pl_PL/LC_MESSAGES/messages.po
@@ -1,0 +1,13 @@
+#: artemis/reporting/modules/js_vuln_detector/template_vulnerable_js_library.jinja2:2
+msgid "We identified vulnerable JavaScript libraries loaded by the page:"
+msgstr "Wykryliśmy podatne biblioteki JavaScript ładowane przez stronę:"
+
+#: artemis/reporting/modules/js_vuln_detector/template_vulnerable_js_library.jinja2:14
+msgid ""
+"These JavaScript libraries have known security vulnerabilities (such as "
+"cross-site scripting, prototype pollution, or denial-of-service). Please "
+"upgrade each affected library to the latest stable release."
+msgstr ""
+"Te biblioteki JavaScript mają znane podatności bezpieczeństwa (np. "
+"cross-site scripting, prototype pollution lub ataki DoS). Prosimy o "
+"aktualizację każdej podatnej biblioteki do najnowszej stabilnej wersji."

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -209,6 +209,13 @@ services:
     restart: always
     volumes: ["${DOCKER_COMPOSE_ADDITIONAL_SHARED_DIRECTORY:-./shared}:/shared/"]
 
+  karton-js_vuln_detector:
+    <<: [*logging, *artemis-build-or-image]
+    command: "python3 -m artemis.modules.js_vuln_detector"
+    env_file: .env
+    restart: always
+    volumes: ["${DOCKER_COMPOSE_ADDITIONAL_SHARED_DIRECTORY:-./shared}:/shared/"]
+
   karton-ip_lookup:
     <<: [*logging, *artemis-build-or-image]
     command: "python3 -m artemis.modules.ip_lookup"

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -14,6 +14,7 @@ Artemis includes:
  - Wordpress/Joomla/Drupal/WordPress plugin version check,
  - a check for VCS folders (e.g. ``.git``),
  - a check for enabled directory index,
+ - detection of vulnerable client-side JavaScript libraries (e.g. jQuery, Bootstrap, Lodash) using the `Retire.js <https://retirejs.github.io/retire.js/>`_ vulnerability database,
  - port scanning,
  - metrics export for Prometheus (including data such as number of processed or crashed tasks): http://127.0.0.1:5000/metrics
  - easy extensibility via plug-and-play modules,

--- a/test/data/vulnerable_js.html
+++ b/test/data/vulnerable_js.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Test Page – Vulnerable JavaScript Libraries</title>
+    <!--
+        This fixture page is used by test/modules/test_js_vuln_detector.py.
+        It intentionally loads jQuery 1.12.0, which is known to be vulnerable
+        to CVE-2020-11022 / CVE-2020-11023.
+    -->
+    <script src="/js/jquery-1.12.0.min.js"></script>
+    <script src="/js/bootstrap-3.3.7.min.js"></script>
+    <script src="/js/app.js"></script>
+</head>
+<body>
+    <p>Test page for vulnerable JS library detection.</p>
+</body>
+</html>

--- a/test/modules/test_js_vuln_detector.py
+++ b/test/modules/test_js_vuln_detector.py
@@ -1,0 +1,186 @@
+import unittest
+from test.base import ArtemisModuleTestCase
+
+import requests_mock as requests_mock_module
+from karton.core import Task
+
+from artemis.binds import Service, TaskStatus, TaskType
+from artemis.modules.js_vuln_detector import (
+    JsVulnDetector,
+    _version_is_vulnerable,
+    check_library,
+)
+
+
+class TestVersionIsVulnerable(unittest.TestCase):
+    """Unit tests for the pure version-comparison helper."""
+
+    def test_below_only_inside_range(self) -> None:
+        self.assertTrue(_version_is_vulnerable("1.12.0", {"below": "3.5.0"}))
+
+    def test_below_only_at_boundary(self) -> None:
+        # 'below' is exclusive: exactly the boundary is *not* vulnerable.
+        self.assertFalse(_version_is_vulnerable("3.5.0", {"below": "3.5.0"}))
+
+    def test_below_only_above_range(self) -> None:
+        self.assertFalse(_version_is_vulnerable("3.6.0", {"below": "3.5.0"}))
+
+    def test_at_or_above_and_below_inside(self) -> None:
+        self.assertTrue(_version_is_vulnerable("1.12.0", {"atOrAbove": "1.0.3", "below": "3.4.0"}))
+
+    def test_at_or_above_and_below_below_range(self) -> None:
+        self.assertFalse(_version_is_vulnerable("1.0.2", {"atOrAbove": "1.0.3", "below": "3.4.0"}))
+
+    def test_at_or_above_inclusive(self) -> None:
+        self.assertTrue(_version_is_vulnerable("1.0.3", {"atOrAbove": "1.0.3", "below": "3.4.0"}))
+
+    def test_invalid_version_string(self) -> None:
+        self.assertFalse(_version_is_vulnerable("not-a-version", {"below": "3.5.0"}))
+
+
+class TestCheckLibrary(unittest.TestCase):
+    """Unit tests for the pure check_library() function."""
+
+    def _jquery_lib(self):  # type: ignore
+        import json
+        from pathlib import Path
+        db_path = Path(__file__).parents[1] / "artemis" / "modules" / "data" / "jsrepository.json"
+        return json.loads(db_path.read_text())["jquery"]
+
+    def test_vulnerable_jquery_from_url(self) -> None:
+        result = check_library("jquery", self._jquery_lib(), "/js/jquery-1.12.0.min.js", None)
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["library"], "jquery")
+        self.assertEqual(result["detected_version"], "1.12.0")
+        self.assertIn("CVE-2020-11022", result["cves"])
+        self.assertIn("CVE-2020-11023", result["cves"])
+
+    def test_safe_jquery_from_url(self) -> None:
+        # jQuery 3.7.0 has no known vulnerabilities in our DB.
+        result = check_library("jquery", self._jquery_lib(), "/js/jquery-3.7.0.min.js", None)
+        self.assertIsNone(result)
+
+    def test_version_extracted_from_content(self) -> None:
+        # URL does not reveal version; content does.
+        content = "/*! jQuery JavaScript Library v1.8.3 | ... */"
+        result = check_library("jquery", self._jquery_lib(), "/js/jquery.min.js", content)
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertEqual(result["detected_version"], "1.8.3")
+
+    def test_no_match_returns_none(self) -> None:
+        result = check_library("jquery", self._jquery_lib(), "/js/app.js", "var foo = 1;")
+        self.assertIsNone(result)
+
+
+class JsVulnDetectorTest(ArtemisModuleTestCase):
+    # The reason for ignoring mypy error is https://github.com/CERT-Polska/karton/issues/201
+    karton_class = JsVulnDetector  # type: ignore
+
+    def _make_task(self, host: str = "example.com", port: int = 80) -> Task:
+        return Task(
+            {"type": TaskType.SERVICE, "service": Service.HTTP},
+            payload={"host": host, "port": port},
+        )
+
+    def test_vulnerable_jquery_detected(self) -> None:
+        """A page loading jQuery 1.12.0 must be reported as INTERESTING."""
+        html = (
+            b"<!DOCTYPE html><html><head>"
+            b'<script src="/js/jquery-1.12.0.min.js"></script>'
+            b"</head><body></body></html>"
+        )
+        with requests_mock_module.Mocker() as m:
+            m.get("http://example.com:80", content_type="text/html", content=html)
+            m.get(
+                "http://example.com:80/js/jquery-1.12.0.min.js",
+                text="/*! jQuery JavaScript Library v1.12.0 */",
+                headers={"content-type": "application/javascript"},
+            )
+            self.mock_db.reset_mock()
+            self.run_task(self._make_task())
+
+        (call,) = self.mock_db.save_task_result.call_args_list
+        self.assertEqual(call.kwargs["status"], TaskStatus.INTERESTING)
+        findings = call.kwargs["data"]["findings"]
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["library"], "jquery")
+        self.assertEqual(findings[0]["detected_version"], "1.12.0")
+        self.assertIn("CVE-2020-11022", findings[0]["cves"])
+
+    def test_safe_jquery_not_reported(self) -> None:
+        """A page loading a safe jQuery version must be reported as OK."""
+        html = (
+            b"<!DOCTYPE html><html><head>"
+            b'<script src="/js/jquery-3.7.0.min.js"></script>'
+            b"</head><body></body></html>"
+        )
+        with requests_mock_module.Mocker() as m:
+            m.get("http://example.com:80", content_type="text/html", content=html)
+            m.get(
+                "http://example.com:80/js/jquery-3.7.0.min.js",
+                text="/*! jQuery v3.7.0 */",
+                headers={"content-type": "application/javascript"},
+            )
+            self.mock_db.reset_mock()
+            self.run_task(self._make_task())
+
+        (call,) = self.mock_db.save_task_result.call_args_list
+        self.assertEqual(call.kwargs["status"], TaskStatus.OK)
+        self.assertEqual(call.kwargs["data"]["findings"], [])
+
+    def test_no_scripts_ok(self) -> None:
+        """A page with no <script src> tags must be reported as OK."""
+        html = b"<!DOCTYPE html><html><head></head><body><p>Hello</p></body></html>"
+        with requests_mock_module.Mocker() as m:
+            m.get("http://example.com:80", content_type="text/html", content=html)
+            self.mock_db.reset_mock()
+            self.run_task(self._make_task())
+
+        (call,) = self.mock_db.save_task_result.call_args_list
+        self.assertEqual(call.kwargs["status"], TaskStatus.OK)
+        self.assertEqual(call.kwargs["data"]["findings"], [])
+
+    def test_non_html_response_ok(self) -> None:
+        """A non-HTML endpoint (e.g. a JSON API) must be reported as OK."""
+        with requests_mock_module.Mocker() as m:
+            m.get(
+                "http://example.com:80",
+                text='{"status": "ok"}',
+                headers={"content-type": "application/json"},
+            )
+            self.mock_db.reset_mock()
+            self.run_task(self._make_task())
+
+        (call,) = self.mock_db.save_task_result.call_args_list
+        self.assertEqual(call.kwargs["status"], TaskStatus.OK)
+
+    def test_multiple_vulnerable_libraries(self) -> None:
+        """Both vulnerable jQuery and Bootstrap on the same page must be detected."""
+        html = (
+            b"<!DOCTYPE html><html><head>"
+            b'<script src="/js/jquery-1.11.0.min.js"></script>'
+            b'<script src="/js/bootstrap-3.3.7.min.js"></script>'
+            b"</head><body></body></html>"
+        )
+        with requests_mock_module.Mocker() as m:
+            m.get("http://example.com:80", content_type="text/html", content=html)
+            m.get(
+                "http://example.com:80/js/jquery-1.11.0.min.js",
+                text="/*! jQuery JavaScript Library v1.11.0 */",
+                headers={"content-type": "application/javascript"},
+            )
+            m.get(
+                "http://example.com:80/js/bootstrap-3.3.7.min.js",
+                text="/*! * Bootstrap v3.3.7 */",
+                headers={"content-type": "application/javascript"},
+            )
+            self.mock_db.reset_mock()
+            self.run_task(self._make_task())
+
+        (call,) = self.mock_db.save_task_result.call_args_list
+        self.assertEqual(call.kwargs["status"], TaskStatus.INTERESTING)
+        libs = {f["library"] for f in call.kwargs["data"]["findings"]}
+        self.assertIn("jquery", libs)
+        self.assertIn("bootstrap", libs)


### PR DESCRIPTION
## Summary

Implements #2308.

Adds a new Karton module **`js_vuln_detector`** that detects vulnerable client-side JavaScript libraries loaded via `<script src="...">` tags, using a bundled subset of the [Retire.js](https://retirejs.github.io/retire.js/) vulnerability database.

## What's included

### New module: `artemis/modules/js_vuln_detector.py`
- Fetches HTTP/HTML pages and parses `<script src="...">` tags with BeautifulSoup.
- Matches library names and versions against a bundled vulnerability database (jQuery, Bootstrap, Lodash, AngularJS, Moment.js, Underscore.js).
- Extracts versions from **URL/filename first** (no extra HTTP request), falling back to fetching and scanning script file content (lazy-fetched, capped at 256 KB).
- Reports findings via `TaskStatus.INTERESTING` including library name, detected version, CVE identifiers, script URL, and upgrade guidance.
- Constants: `MAX_SCRIPTS_PER_PAGE = 25`, `MAX_SCRIPT_CONTENT_BYTES = 256 KB`.
- Inline scripts are intentionally excluded (documented in module docstring).

### Bundled DB: `artemis/modules/data/jsrepository.json`
- Retire.js-format vulnerability database covering the 6 most widely-deployed libraries.
- No network access required at runtime.

### Reporting: `artemis/reporting/modules/js_vuln_detector/`
- `reporter.py` — auto-discovered reporter with `VULNERABLE_JS_LIBRARY` ReportType.
- Jinja2 email template with per-finding details.
- English and Polish (`pl_PL`) translation files.

### Tests: `test/modules/test_js_vuln_detector.py`
- Pure unit tests for `_version_is_vulnerable()` and `check_library()` (no Karton/Redis required).
- Integration-style tests using `requests_mock` for the full module flow:
  - Vulnerable jQuery detected → `INTERESTING`
  - Safe jQuery → `OK`
  - Page with no scripts → `OK`
  - Non-HTML response → `OK`
  - Multiple vulnerable libraries on same page

### Fixture: `test/data/vulnerable_js.html`
- HTML page loading jQuery 1.12.0 and Bootstrap 3.3.7 (both vulnerable).

### docker-compose.yaml
- New `karton-js_vuln_detector` service entry.

### docs/features.rst
- Added bullet point describing the new module.

## Dependencies
No new dependencies — `beautifulsoup4` and `packaging` are already in `requirements.txt`.

Closes #2308