### PR TITLE
Fix release_all_locks not actually releasing locks

### DIFF
--- a/artemis/resource_lock.py
+++ b/artemis/resource_lock.py
@@ -50,8 +50,10 @@ class ResourceLock:
     @staticmethod
     def release_all_locks(logger: Logger) -> None:
         with LOCKS_TO_SUSTAIN_LOCK:
-            for lock in LOCKS_TO_SUSTAIN:
+            for lock in list(LOCKS_TO_SUSTAIN.keys()):
                 logger.info(f"Releasing lock: {lock} -> {LOCKS_TO_SUSTAIN[lock]}")
+                REDIS.delete(lock)
+            LOCKS_TO_SUSTAIN.clear()
 
     def acquire(self) -> None:
         """

--- a/test/unit/test_resource_lock.py
+++ b/test/unit/test_resource_lock.py
@@ -1,0 +1,178 @@
+import logging
+import threading
+import unittest
+from unittest.mock import MagicMock, patch
+
+from artemis.resource_lock import (
+    LOCKS_TO_SUSTAIN,
+    LOCKS_TO_SUSTAIN_LOCK,
+    FailedToAcquireLockException,
+    ResourceLock,
+)
+
+
+class TestReleaseAllLocks(unittest.TestCase):
+    """Tests for ResourceLock.release_all_locks — the safety-net method called
+    at the start of every worker iteration to clean up leaked locks."""
+
+    def setUp(self) -> None:
+        # Clean state before each test
+        with LOCKS_TO_SUSTAIN_LOCK:
+            LOCKS_TO_SUSTAIN.clear()
+        self.logger = logging.getLogger("test_resource_lock")
+
+    def tearDown(self) -> None:
+        with LOCKS_TO_SUSTAIN_LOCK:
+            LOCKS_TO_SUSTAIN.clear()
+
+    @patch("artemis.resource_lock.REDIS")
+    def test_release_all_locks_deletes_redis_keys(self, mock_redis: MagicMock) -> None:
+        """release_all_locks must call REDIS.delete for every held lock."""
+        with LOCKS_TO_SUSTAIN_LOCK:
+            LOCKS_TO_SUSTAIN["lock-1.2.3.4"] = "uuid-1"
+            LOCKS_TO_SUSTAIN["lock-5.6.7.8"] = "uuid-2"
+
+        ResourceLock.release_all_locks(self.logger)
+
+        mock_redis.delete.assert_any_call("lock-1.2.3.4")
+        mock_redis.delete.assert_any_call("lock-5.6.7.8")
+        self.assertEqual(mock_redis.delete.call_count, 2)
+
+    @patch("artemis.resource_lock.REDIS")
+    def test_release_all_locks_clears_sustain_dict(self, mock_redis: MagicMock) -> None:
+        """After release_all_locks, LOCKS_TO_SUSTAIN must be empty so the
+        heartbeat thread stops refreshing the deleted keys."""
+        with LOCKS_TO_SUSTAIN_LOCK:
+            LOCKS_TO_SUSTAIN["lock-target-a"] = "uuid-a"
+            LOCKS_TO_SUSTAIN["lock-target-b"] = "uuid-b"
+
+        ResourceLock.release_all_locks(self.logger)
+
+        with LOCKS_TO_SUSTAIN_LOCK:
+            self.assertEqual(len(LOCKS_TO_SUSTAIN), 0)
+
+    @patch("artemis.resource_lock.REDIS")
+    def test_release_all_locks_noop_when_empty(self, mock_redis: MagicMock) -> None:
+        """Calling release_all_locks with no held locks must not raise."""
+        ResourceLock.release_all_locks(self.logger)
+
+        mock_redis.delete.assert_not_called()
+        with LOCKS_TO_SUSTAIN_LOCK:
+            self.assertEqual(len(LOCKS_TO_SUSTAIN), 0)
+
+    @patch("artemis.resource_lock.REDIS")
+    def test_acquire_then_release_all_cleans_up(self, mock_redis: MagicMock) -> None:
+        """Simulates a lock leak: acquire a lock, then call release_all_locks
+        instead of the normal release path. The lock must be fully cleaned up."""
+        mock_redis.set.return_value = True  # simulate successful SET NX
+
+        lock = ResourceLock("lock-leaked-target", max_tries=1)
+        lock.acquire()
+
+        # Verify the lock is tracked
+        with LOCKS_TO_SUSTAIN_LOCK:
+            self.assertIn("lock-leaked-target", LOCKS_TO_SUSTAIN)
+
+        # Simulate the safety-net cleanup
+        ResourceLock.release_all_locks(self.logger)
+
+        mock_redis.delete.assert_any_call("lock-leaked-target")
+        with LOCKS_TO_SUSTAIN_LOCK:
+            self.assertNotIn("lock-leaked-target", LOCKS_TO_SUSTAIN)
+
+    @patch("artemis.resource_lock.REDIS")
+    def test_release_all_locks_is_thread_safe(self, mock_redis: MagicMock) -> None:
+        """release_all_locks must not corrupt state when called concurrently
+        with lock acquire/release on other threads."""
+        mock_redis.set.return_value = True
+        errors = []
+
+        def acquire_and_release() -> None:
+            try:
+                for i in range(20):
+                    lock = ResourceLock(f"lock-thread-{threading.current_thread().name}-{i}", max_tries=1)
+                    lock.acquire()
+                    lock.release()
+            except Exception as e:
+                errors.append(e)
+
+        def release_all_repeatedly() -> None:
+            try:
+                for _ in range(20):
+                    ResourceLock.release_all_locks(self.logger)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=acquire_and_release),
+            threading.Thread(target=acquire_and_release),
+            threading.Thread(target=release_all_repeatedly),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        self.assertEqual(errors, [], f"Thread safety errors: {errors}")
+
+
+class TestResourceLockBasics(unittest.TestCase):
+    """Verify that normal acquire/release still works correctly after the fix."""
+
+    def setUp(self) -> None:
+        with LOCKS_TO_SUSTAIN_LOCK:
+            LOCKS_TO_SUSTAIN.clear()
+
+    def tearDown(self) -> None:
+        with LOCKS_TO_SUSTAIN_LOCK:
+            LOCKS_TO_SUSTAIN.clear()
+
+    @patch("artemis.resource_lock.REDIS")
+    def test_acquire_adds_to_sustain_dict(self, mock_redis: MagicMock) -> None:
+        mock_redis.set.return_value = True
+
+        lock = ResourceLock("lock-test-target", max_tries=1)
+        lock.acquire()
+
+        with LOCKS_TO_SUSTAIN_LOCK:
+            self.assertIn("lock-test-target", LOCKS_TO_SUSTAIN)
+
+    @patch("artemis.resource_lock.REDIS")
+    def test_release_removes_from_sustain_dict_and_redis(self, mock_redis: MagicMock) -> None:
+        mock_redis.set.return_value = True
+
+        lock = ResourceLock("lock-test-target", max_tries=1)
+        lock.acquire()
+        lock.release()
+
+        with LOCKS_TO_SUSTAIN_LOCK:
+            self.assertNotIn("lock-test-target", LOCKS_TO_SUSTAIN)
+        mock_redis.delete.assert_called_with("lock-test-target")
+
+    @patch("artemis.resource_lock.REDIS")
+    def test_failed_acquire_raises(self, mock_redis: MagicMock) -> None:
+        mock_redis.set.return_value = False  # NX fails — lock already held
+
+        lock = ResourceLock("lock-contended", max_tries=1)
+
+        with self.assertRaises(FailedToAcquireLockException):
+            lock.acquire()
+
+        with LOCKS_TO_SUSTAIN_LOCK:
+            self.assertNotIn("lock-contended", LOCKS_TO_SUSTAIN)
+
+    @patch("artemis.resource_lock.REDIS")
+    def test_context_manager_releases_on_exit(self, mock_redis: MagicMock) -> None:
+        mock_redis.set.return_value = True
+
+        with ResourceLock("lock-ctx", max_tries=1):
+            with LOCKS_TO_SUSTAIN_LOCK:
+                self.assertIn("lock-ctx", LOCKS_TO_SUSTAIN)
+
+        with LOCKS_TO_SUSTAIN_LOCK:
+            self.assertNotIn("lock-ctx", LOCKS_TO_SUSTAIN)
+        mock_redis.delete.assert_called_with("lock-ctx")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Fix: release_all_locks() Did Not Actually Release Redis Locks

### Summary

`ResourceLock.release_all_locks()` was intended to act as a safety net at the start of each worker iteration. However, it only logged held locks without actually releasing them.

Because the heartbeat thread continuously refreshes entries in `LOCKS_TO_SUSTAIN`, any leaked lock would remain sustained in Redis for the lifetime of the worker process.

This could lead to permanent target lock-out after transient failures.

---

### Root Cause

The method:
- Logged lock names
- Did **not** call `REDIS.delete(lock)`
- Did **not** clear `LOCKS_TO_SUSTAIN`

As a result, leaked locks were indefinitely refreshed by the heartbeat thread.

---

### Fix

- Iterate over a safe copy of `LOCKS_TO_SUSTAIN.keys()`
- Call `REDIS.delete(lock)` for each lock
- Clear `LOCKS_TO_SUSTAIN` after deletion

This preserves the existing locking model while ensuring proper cleanup.

---

### Tests Added

- Verifies Redis keys are deleted
- Verifies sustain dict is cleared
- Ensures no-op behavior when empty
- Simulates acquire → forced cleanup scenario
- Thread-safety validation

---

### Impact

- Prevents permanent lock leaks
- Restores expected self-healing behavior
- Eliminates silent scan starvation in long-running workers