### PR TITLE
fix issue: #1977 (shorten PoC URLs length)

### DIFF
--- a/artemis/config.py
+++ b/artemis/config.py
@@ -899,6 +899,11 @@ class Config:
                 "NUCLEI_CHUNK_SIZE is 200, three calls will be made with 200 templates each.",
             ] = get_config("NUCLEI_CHUNK_SIZE", default=200, cast=int)
 
+            NUCLEI_POC_MAX_LENGTH: Annotated[
+                int,
+                "Maximum length (in characters) of PoC URL/command stored in reports. Set to 0 to keep full content.",
+            ] = get_config("NUCLEI_POC_MAX_LENGTH", default=200, cast=int)
+
         class PlaceholderPageContent:
             ENABLE_PLACEHOLDER_PAGE_DETECTOR: Annotated[
                 bool,


### PR DESCRIPTION
## Changes
- Added `NUCLEI_POC_MAX_LENGTH` config (default: 200)
- Truncation helper in `reporter.py` for `curl-command`/`path_query_fragment`
- Set to `0` for full PoCs

## Before/After
**Before**: ```GET /vulnerabilities/sqli.php?dest=http%3A%2F%2F127.0.0.1%2Fabc.html'&redirect=...[continues 800+ chars with 50+ parameters]```
**After**: `https://target...?param...[truncated]` (200 chars max)


## Test
```bash
$ pytest -q test/test_nuclei_poc_truncation.py
.                                                                    [100%]
1 passed in 0.67s
```