### PR TITLE
Fix premature raise skipping error saving for batch tasks

### DIFF
--- a/artemis/module_base.py
+++ b/artemis/module_base.py
@@ -713,7 +713,7 @@ class ArtemisBase(Karton):
                                 self.db.save_task_result(
                                     task=task, status=TaskStatus.ERROR, data=traceback.format_exc()
                                 )
-                                raise
+                            raise
             finally:
                 for task in task_group:
                     if Config.Data.SAVE_LOGS_IN_DATABASE:


### PR DESCRIPTION
## Fix: Prevent Partial Error Persistence for Failed Batch Tasks

### Problem
In `process_multiple()` (`artemis/module_base.py:716`), the `raise` statement was placed **inside** the `for task in task_group` loop.

When a batch failed after exhausting retries:
- Only the **first task** in the batch had its error details saved.
- Remaining tasks were marked as `CRASHED` by the outer handler,
- But without traceback information — causing silent debugging data loss.

This affects modules using `batch_tasks = True` (e.g., `nuclei`, `port_scanner`) with batch sizes > 1.

---

### Fix
Moved the `raise` statement **outside** the loop so that:
1. All tasks in the batch persist their error details.
2. The exception is re-raised only after error persistence completes.

---

### Result
- All failed batch tasks now correctly store traceback information.
- No silent loss of debugging data.
- Exception propagation behavior remains unchanged.