### PR TITLE
Fix rogue lock release in check_connection_to_base_url_and_save_error

### DIFF
--- a/artemis/module_base.py
+++ b/artemis/module_base.py
@@ -817,8 +817,6 @@ class ArtemisBase(Karton):
 
     def check_connection_to_base_url_and_save_error(self, task: Task) -> bool:
         base_url = get_target_url(task)
-        scan_destination = self._get_scan_destination(task)
-        lock = ResourceLock(f"lock-{scan_destination}", max_tries=Config.Locking.SCAN_DESTINATION_LOCK_MAX_TRIES)
 
         try:
             response = self.http_get(base_url)
@@ -844,9 +842,8 @@ class ArtemisBase(Karton):
                     data={"waf_detected": True},
                 )
                 self.log.info(
-                    f"Unable to connect to base URL: {base_url}: WAF detected, task skipped, releasing lock for {scan_destination}"
+                    f"Unable to connect to base URL: {base_url}: WAF detected, task skipped"
                 )
-                lock.release()
                 return False
 
             return True
@@ -857,9 +854,8 @@ class ArtemisBase(Karton):
                 status_reason=f"Unable to connect to base URL {base_url}: {repr(e)}, task skipped",
             )
             self.log.info(
-                f"Unable to connect to base URL: {base_url}: {repr(e)}, task skipped, releasing lock for {scan_destination}"
+                f"Unable to connect to base URL: {base_url}: {repr(e)}, task skipped"
             )
-            lock.release()
             return False
 
     def http_get(self, *args, **kwargs) -> http_requests.HTTPResponse:  # type: ignore


### PR DESCRIPTION
## Fix: Remove Unauthorized Lock Release in `check_connection_to_base_url_and_save_error`

### Summary

`check_connection_to_base_url_and_save_error()` was creating a new `ResourceLock`
instance and calling `.release()` on it, even though the actual lock was
acquired earlier in `_single_iteration`.

This violated lock ownership and could:

- Prematurely release a legitimately held lock
- Create a race window allowing concurrent scanning of the same target
- Cause double-release that deletes another process's lock
- Break rate limiting and enable cross-process lock corruption

### Root Cause

Lock lifecycle is owned by `_single_iteration`:

- Acquire → `_take_and_lock_tasks`
- Release → `_single_iteration` cleanup loop

`check_connection_to_base_url_and_save_error()` incorrectly interfered
with this lifecycle by releasing a lock it did not acquire.

### Changes

- Removed creation of a new `ResourceLock` inside
  `check_connection_to_base_url_and_save_error`
- Removed both `lock.release()` calls
- Updated log messages accordingly

### Result

- Lock lifecycle is now consistently managed by `_single_iteration`
- No premature release
- No double-release
- Distributed locking and rate limiting work correctly across modules