### PR TITLE
docs: add REST scan API guidance to docs/api/rest-scan-example.rst

### DIFF
--- a/docs/api/rest-scan-example.rst
+++ b/docs/api/rest-scan-example.rst
@@ -1,0 +1,22 @@
+REST Scan API Example
+=====================
+
+To use Artemis REST API:
+
+1. Start Artemis: `docker compose up -d`
+2. Access Swagger UI: http://localhost:5000/docs
+3. Key endpoints:
+
+**Create scan:**
+.. code-block:: bash
+
+   curl -X POST http://localhost:5000/api/scans \\
+     -H "Content-Type: application/json" \\
+     -d '{"target": "example.com"}'
+
+**List scans:**
+.. code-block:: bash
+
+   curl http://localhost:5000/api/scans
+
+**Swagger docs:** http://localhost:5000/docs (full API)


### PR DESCRIPTION
@kadewu  FIXED - Added docs guidance EXACTLY as PR#2324 requested!

**Created:** docs/api/rest-scan-example.rst
- REST API curl examples from localhost:5000/docs
- Swagger UI link (localhost:5000/docs)
- Usage guidance only

**No tests, no extras - pure documentation as originally intended.**

Ready for review! 