### PR TITLE
Fix formatting in README for environment setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To start a locally modified version of Artemis, run:
 ```commandline
  ./scripts/start_dev
 ```
-This script automatically copies the example environment file (env.example) to .env if it doesn't exist. You can then configure the settings in the .env file according to your needs. This includes customizing the user-agent by setting the CUSTOM_USER_AGENT variable, as well as other relevant parameters. For a complete list of configuration variables and their descriptions, please refer to the [Configuration section in the documentation](https://artemis-scanner.readthedocs.io/en/latest/user-guide/configuration.html).
+This script automatically copies the example environment file (`env.example`) to `.env` if it doesn't exist. You can then configure the settings in the .env file according to your needs. This includes customizing the user-agent by setting the CUSTOM_USER_AGENT variable, as well as other relevant parameters. For a complete list of configuration variables and their descriptions, please refer to the [Configuration section in the documentation](https://artemis-scanner.readthedocs.io/en/latest/user-guide/configuration.html).
 
 The Artemis image is then built locally (from the code you are developing) not downloaded from Docker Hub.
 For `web`, you will also be able to see the results of code modifications on the page without reloading the entire container.


### PR DESCRIPTION
This pull request makes a minor update to the `README.md` file, improving the formatting of file names in the documentation for clarity.