### PR TITLE
Add periodic scanning support

### DIFF
--- a/artemis/api.py
+++ b/artemis/api.py
@@ -280,6 +280,69 @@ async def post_export(
     }
 
 
+@router.post("/periodic-scans", dependencies=[Depends(verify_api_token)])
+def create_periodic_scan(
+    targets: List[str],
+    interval_hours: int = Body(),
+    tag: Optional[str] = Body(default=None),
+    disabled_modules: Optional[List[str]] = Body(default=None),
+    enabled_modules: Optional[List[str]] = Body(default=None),
+    priority: str = Body(default="normal"),
+) -> Dict[str, Any]:
+    """Create a periodic scan schedule. Targets will be re-scanned automatically at the given interval."""
+    if disabled_modules and enabled_modules:
+        raise HTTPException(
+            status_code=400, detail="It's not possible to set both disabled_modules and enabled_modules."
+        )
+
+    for task in targets:
+        if not Classifier.is_supported(task):
+            raise HTTPException(status_code=400, detail=f"Invalid target: {task}")
+
+    if interval_hours < 1:
+        raise HTTPException(status_code=400, detail="interval_hours must be at least 1.")
+
+    identities_that_can_be_disabled = set([bind.identity for bind in get_binds_that_can_be_disabled()])
+
+    if enabled_modules:
+        disabled_modules = list(identities_that_can_be_disabled - set(enabled_modules))
+    elif not disabled_modules:
+        disabled_modules = Config.Miscellaneous.MODULES_DISABLED_BY_DEFAULT
+
+    scan_id = db.create_periodic_scan(
+        targets="\n".join(targets),
+        interval_hours=interval_hours,
+        tag=tag,
+        disabled_modules=",".join(disabled_modules),
+        priority=priority,
+    )
+    return {"ok": True, "id": scan_id}
+
+
+@router.get("/periodic-scans", dependencies=[Depends(verify_api_token)])
+def list_periodic_scans() -> List[Dict[str, Any]]:
+    """List all periodic scan schedules."""
+    return db.list_periodic_scans()
+
+
+@router.delete("/periodic-scans/{scan_id}", dependencies=[Depends(verify_api_token)])
+def delete_periodic_scan(scan_id: int) -> Dict[str, bool]:
+    """Delete a periodic scan schedule."""
+    if not db.get_periodic_scan(scan_id):
+        raise HTTPException(status_code=404, detail="Periodic scan not found")
+    db.delete_periodic_scan(scan_id)
+    return {"ok": True}
+
+
+@router.patch("/periodic-scans/{scan_id}", dependencies=[Depends(verify_api_token)])
+def update_periodic_scan(scan_id: int, enabled: bool = Body()) -> Dict[str, bool]:
+    """Enable or disable a periodic scan schedule."""
+    if not db.get_periodic_scan(scan_id):
+        raise HTTPException(status_code=404, detail="Periodic scan not found")
+    db.update_periodic_scan_enabled(scan_id, enabled)
+    return {"ok": True}
+
+
 @router.get("/analyses-table", include_in_schema=False)
 def get_analyses_table(
     request: Request,

--- a/artemis/db.py
+++ b/artemis/db.py
@@ -229,6 +229,36 @@ class PaginatedResults:
     data: List[Dict[str, Any]]
 
 
+class PeriodicScan(Base):  # type: ignore
+    """
+    Represents a periodic (recurring) scan schedule.
+    When enabled, the scheduler service will automatically create scan tasks at the configured interval.
+
+    :ivar id: Unique identifier for the periodic scan.
+    :ivar targets: Newline-separated list of targets to scan.
+    :ivar tag: Optional tag to group analyses.
+    :ivar disabled_modules: Comma-separated list of disabled modules.
+    :ivar interval_hours: How often (in hours) to re-scan.
+    :ivar priority: Task priority (normal, high, low).
+    :ivar enabled: Whether this periodic scan is active.
+    :ivar last_run_at: When the scan was last triggered.
+    :ivar next_run_at: When the scan should next be triggered.
+    :ivar created_at: When this periodic scan was created.
+    """
+
+    __tablename__ = "periodic_scan"
+    id = Column(Integer, primary_key=True)
+    targets = Column(String, nullable=False)
+    tag = Column(String, index=True, nullable=True)
+    disabled_modules = Column(String, nullable=True)
+    interval_hours = Column(Integer, nullable=False)
+    priority = Column(String, nullable=False, server_default="normal")
+    enabled = Column(Boolean, nullable=False, server_default="true", index=True)
+    last_run_at = Column(DateTime, nullable=True)
+    next_run_at = Column(DateTime, nullable=False)
+    created_at = Column(DateTime, server_default=text("NOW()"))
+
+
 class TagArchiveRequest(Base):  # type: ignore
     __tablename__ = "tag_archive_request"
     id = Column(Integer, primary_key=True)
@@ -718,6 +748,77 @@ class DB:
             tag_archive_requests = session.query(TagArchiveRequest).filter(TagArchiveRequest.tag == tag)
             for tag_archive_request in tag_archive_requests:
                 session.delete(tag_archive_request)
+                session.commit()
+
+    def create_periodic_scan(
+        self,
+        targets: str,
+        interval_hours: int,
+        tag: Optional[str] = None,
+        disabled_modules: Optional[str] = None,
+        priority: str = "normal",
+    ) -> int:
+        next_run_at = datetime.datetime.utcnow()
+        periodic_scan = PeriodicScan(
+            targets=targets,
+            tag=tag,
+            disabled_modules=disabled_modules or "",
+            interval_hours=interval_hours,
+            priority=priority,
+            enabled=True,
+            next_run_at=next_run_at,
+        )
+        with self.session() as session:
+            session.add(periodic_scan)
+            session.commit()
+            return periodic_scan.id  # type: ignore
+
+    def list_periodic_scans(self) -> List[Dict[str, Any]]:
+        with self.session() as session:
+            return [self._strip_internal_db_info(item.__dict__) for item in session.query(PeriodicScan).order_by(PeriodicScan.created_at.desc())]
+
+    def get_periodic_scan(self, scan_id: int) -> Optional[Dict[str, Any]]:
+        with self.session() as session:
+            item = session.query(PeriodicScan).get(scan_id)
+            if item:
+                return self._strip_internal_db_info(item.__dict__)
+            return None
+
+    def update_periodic_scan_enabled(self, scan_id: int, enabled: bool) -> None:
+        with self.session() as session:
+            scan = session.query(PeriodicScan).get(scan_id)
+            if scan:
+                scan.enabled = enabled
+                session.add(scan)
+                session.commit()
+
+    def delete_periodic_scan(self, scan_id: int) -> None:
+        with self.session() as session:
+            scan = session.query(PeriodicScan).get(scan_id)
+            if scan:
+                session.delete(scan)
+                session.commit()
+
+    def get_due_periodic_scans(self) -> List[Dict[str, Any]]:
+        """Return periodic scans that are enabled and due (next_run_at <= now)."""
+        now = datetime.datetime.utcnow()
+        with self.session() as session:
+            return [
+                self._strip_internal_db_info(item.__dict__)
+                for item in session.query(PeriodicScan).filter(
+                    PeriodicScan.enabled == True,  # noqa: E712
+                    PeriodicScan.next_run_at <= now,
+                )
+            ]
+
+    def mark_periodic_scan_as_run(self, scan_id: int) -> None:
+        now = datetime.datetime.utcnow()
+        with self.session() as session:
+            scan = session.query(PeriodicScan).get(scan_id)
+            if scan:
+                scan.last_run_at = now
+                scan.next_run_at = now + datetime.timedelta(hours=scan.interval_hours)
+                session.add(scan)
                 session.commit()
 
 

--- a/artemis/frontend.py
+++ b/artemis/frontend.py
@@ -190,6 +190,130 @@ async def post_add(
         )
 
 
+@router.get("/periodic-scans", include_in_schema=False)
+def get_periodic_scans(request: Request, csrf_protect: CsrfProtect = Depends()) -> Response:
+    return csrf.csrf_form_template_response(
+        "periodic_scans.jinja2",
+        {
+            "request": request,
+            "periodic_scans": db.list_periodic_scans(),
+        },
+        csrf_protect,
+    )
+
+
+@router.get("/periodic-scans/add", include_in_schema=False)
+def get_add_periodic_scan_form(request: Request, csrf_protect: CsrfProtect = Depends()) -> Response:
+    binds = sorted(get_binds_that_can_be_disabled(), key=lambda bind: bind.identity.lower())
+
+    return csrf.csrf_form_template_response(
+        "add_periodic_scan.jinja2",
+        {
+            "request": request,
+            "binds": binds,
+            "priority": TaskPriority.NORMAL.value,
+            "priorities": list(TaskPriority),
+            "modules_disabled_by_default": Config.Miscellaneous.MODULES_DISABLED_BY_DEFAULT,
+        },
+        csrf_protect,
+    )
+
+
+@router.post("/periodic-scans/add", include_in_schema=False)
+@csrf.validate_csrf
+async def post_add_periodic_scan(
+    request: Request,
+    targets: str = Form(),
+    interval_hours: int = Form(),
+    tag: Optional[str] = Form(None),
+    priority: Optional[str] = Form(None),
+    choose_modules_to_enable: Optional[bool] = Form(None),
+    csrf_protect: CsrfProtect = Depends(),
+) -> Response:
+    disabled_modules: list[str] = []
+
+    if choose_modules_to_enable:
+        async with request.form() as form:
+            for bind in get_binds_that_can_be_disabled():
+                if f"module_enabled_{bind.identity}" not in form:
+                    disabled_modules.append(bind.identity)
+
+    total_list: list[str] = []
+    if targets:
+        targets = targets.strip()
+        total_list += (x.strip() for x in targets.split("\n"))
+
+    validation_messages = []
+    for task in total_list:
+        if not Classifier.is_supported(task):
+            validation_messages.append(
+                f"{task} is not supported - Artemis supports domains, IPs or IPv4 ranges."
+            )
+
+    if interval_hours < 1:
+        validation_messages.append("Interval must be at least 1 hour.")
+
+    if validation_messages:
+        binds = sorted(get_binds_that_can_be_disabled(), key=lambda bind: bind.identity.lower())
+        return csrf.csrf_form_template_response(
+            "add_periodic_scan.jinja2",
+            {
+                "validation_message": ", ".join(validation_messages),
+                "request": request,
+                "binds": binds,
+                "priority": priority,
+                "priorities": list(TaskPriority),
+                "tasks": total_list,
+                "tag": tag or "",
+                "interval_hours": interval_hours,
+                "disabled_modules": disabled_modules,
+                "modules_disabled_by_default": Config.Miscellaneous.MODULES_DISABLED_BY_DEFAULT,
+            },
+            csrf_protect,
+        )
+
+    db.create_periodic_scan(
+        targets="\n".join(total_list),
+        interval_hours=interval_hours,
+        tag=tag,
+        disabled_modules=",".join(disabled_modules),
+        priority=priority or "normal",
+    )
+    return RedirectResponse("/periodic-scans", status_code=303)
+
+
+@router.get("/periodic-scans/delete/{scan_id}", include_in_schema=False)
+def get_delete_periodic_scan(request: Request, scan_id: int, csrf_protect: CsrfProtect = Depends()) -> Response:
+    scan = db.get_periodic_scan(scan_id)
+    if not scan:
+        raise HTTPException(status_code=404, detail="Periodic scan not found")
+    return csrf.csrf_form_template_response(
+        "delete_periodic_scan.jinja2",
+        {
+            "request": request,
+            "scan": scan,
+        },
+        csrf_protect,
+    )
+
+
+@router.post("/periodic-scans/delete/{scan_id}", include_in_schema=False)
+@csrf.validate_csrf
+async def post_delete_periodic_scan(request: Request, scan_id: int, csrf_protect: CsrfProtect = Depends()) -> Response:
+    db.delete_periodic_scan(scan_id)
+    return RedirectResponse("/periodic-scans", status_code=303)
+
+
+@router.post("/periodic-scans/toggle/{scan_id}", include_in_schema=False)
+@csrf.validate_csrf
+async def post_toggle_periodic_scan(request: Request, scan_id: int, csrf_protect: CsrfProtect = Depends()) -> Response:
+    scan = db.get_periodic_scan(scan_id)
+    if not scan:
+        raise HTTPException(status_code=404, detail="Periodic scan not found")
+    db.update_periodic_scan_enabled(scan_id, not scan["enabled"])
+    return RedirectResponse("/periodic-scans", status_code=303)
+
+
 @router.get("/exports", include_in_schema=False)
 def get_exports(request: Request) -> Response:
     return templates.TemplateResponse(

--- a/artemis/periodic_scan_scheduler.py
+++ b/artemis/periodic_scan_scheduler.py
@@ -1,0 +1,57 @@
+import time
+
+from karton.core.task import TaskPriority
+
+from artemis import utils
+from artemis.db import DB
+from artemis.producer import create_tasks
+
+logger = utils.build_logger(__name__)
+
+SCHEDULER_CHECK_INTERVAL_SECONDS = 60
+
+db = DB()
+
+
+def run_due_periodic_scans() -> None:
+    due_scans = db.get_due_periodic_scans()
+    logger.info("Found %d due periodic scan(s)", len(due_scans))
+
+    for scan in due_scans:
+        scan_id = scan["id"]
+        targets = [t.strip() for t in scan["targets"].split("\n") if t.strip()]
+        tag = scan.get("tag")
+        disabled_modules_str = scan.get("disabled_modules", "")
+        disabled_modules = [m for m in disabled_modules_str.split(",") if m] if disabled_modules_str else []
+        priority = TaskPriority(scan.get("priority", "normal"))
+
+        logger.info(
+            "Running periodic scan %d: %d target(s), tag=%s, interval=%dh",
+            scan_id,
+            len(targets),
+            tag,
+            scan["interval_hours"],
+        )
+
+        try:
+            task_ids = create_tasks(
+                targets,
+                tag,
+                disabled_modules=disabled_modules,
+                priority=priority,
+            )
+            logger.info("Periodic scan %d: created %d task(s): %s", scan_id, len(task_ids), task_ids)
+        except Exception:
+            logger.exception("Error running periodic scan %d", scan_id)
+
+        db.mark_periodic_scan_as_run(scan_id)
+
+
+if __name__ == "__main__":
+    logger.info("Periodic scan scheduler started (check interval: %ds)", SCHEDULER_CHECK_INTERVAL_SECONDS)
+    while True:
+        try:
+            run_due_periodic_scans()
+        except Exception:
+            logger.exception("Error in periodic scan scheduler loop")
+        time.sleep(SCHEDULER_CHECK_INTERVAL_SECONDS)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -74,6 +74,12 @@ services:
     env_file: .env
     restart: always
 
+  periodic-scan-scheduler:
+    <<: [*logging, *artemis-build-or-image]
+    command: "bash -c 'alembic upgrade head && python3 -m artemis.periodic_scan_scheduler'"
+    env_file: .env
+    restart: always
+
   metrics:
     <<: [*logging, *artemis-build-or-image]
     env_file: .env

--- a/migrations/versions/a1b2c3d4e5f6_add_periodic_scan_table.py
+++ b/migrations/versions/a1b2c3d4e5f6_add_periodic_scan_table.py
@@ -1,0 +1,41 @@
+"""Add periodic_scan table
+
+Revision ID: a1b2c3d4e5f6
+Revises: 3d5b256854bb
+Create Date: 2026-03-03 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "3d5b256854bb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "periodic_scan",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("targets", sa.String(), nullable=False),
+        sa.Column("tag", sa.String(), nullable=True),
+        sa.Column("disabled_modules", sa.String(), nullable=True),
+        sa.Column("interval_hours", sa.Integer(), nullable=False),
+        sa.Column("priority", sa.String(), nullable=False, server_default="normal"),
+        sa.Column("enabled", sa.Boolean(), nullable=False, server_default="true"),
+        sa.Column("last_run_at", sa.DateTime(), nullable=True),
+        sa.Column("next_run_at", sa.DateTime(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.text("NOW()"), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_periodic_scan_tag"), "periodic_scan", ["tag"], unique=False)
+    op.create_index(op.f("ix_periodic_scan_enabled"), "periodic_scan", ["enabled"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f("ix_periodic_scan_enabled"), table_name="periodic_scan")
+    op.drop_index(op.f("ix_periodic_scan_tag"), table_name="periodic_scan")
+    op.drop_table("periodic_scan")

--- a/templates/add_periodic_scan.jinja2
+++ b/templates/add_periodic_scan.jinja2
@@ -1,0 +1,110 @@
+{% extends "components/base.jinja2" %}
+{% block main %}
+    <script>
+        function setSelectionForAllModules(value) {
+            document.querySelectorAll(".enabled-modules input[type='checkbox']").forEach(
+                function(item) {
+                    if (item.getAttribute("name") != "module_enabled_example") {
+                        item.checked = value;
+                    }
+                }
+            );
+        }
+    </script>
+
+    <h1>Add periodic scan</h1>
+    <p class="text-muted">
+        Configure a recurring scan that will automatically re-scan targets at the specified interval.
+    </p>
+
+    <form action="/periodic-scans/add" method="post" class="w-100">
+        {% if validation_message %}
+            <div class="alert alert-danger" role="alert">
+                {{ validation_message }}
+            </div>
+        {% endif %}
+
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
+
+        <div class="form-group mb-3">
+            <label class="form-label">Targets (separated with newlines)</label>
+            <textarea class="form-control" name="targets" rows="10" required>{% for task in tasks %}{{ task }}
+{% endfor %}</textarea>
+        </div>
+        <div class="form-group mb-3">
+            <label class="form-label">Enter your tag{% if tag_names %} or select existing one{% endif %}</label>
+            <input list="object-list" class="form-control" name="tag" autocomplete="off" {% if tag %}value="{{ tag }}"{% endif %}>
+            <datalist id="object-list">
+                 {% for tag in tag_names %}
+                    <option>{{ tag.tag_name }}</option>
+                 {% endfor %}
+            </datalist>
+            <small class="form-text text-muted">
+                Tags can be used to group scanned targets.
+            </small>
+        </div>
+        <div class="form-group mb-3">
+            <label class="form-label">Scan interval (hours)</label>
+            <input type="number" class="form-control" name="interval_hours" min="1" value="{{ interval_hours|default(24) }}" required>
+            <small class="form-text text-muted">
+                How often the targets should be re-scanned. For example, 24 means daily, 168 means weekly.
+            </small>
+        </div>
+        <input type="submit" class="btn btn-primary" value="Create periodic scan">
+
+        <h2 class="mt-4">Advanced settings</h2>
+        <div class="form-group mb-3">
+            <label class="form-label">Priority</label>
+            <select name="priority" class="form-control">
+                {% for possible_priority in priorities %}
+                    <option name="{{ possible_priority.value }}" {% if priority == possible_priority.value %}selected{% endif %}>{{ possible_priority.value }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="form-group mb-3">
+            <small class="form-text text-muted">
+                The priority defines how fast the scanning will be performed - tasks with higher priority will be done earlier.
+            </small>
+        </div>
+        <div class="form-group mb-3 enabled-modules">
+            <label class="form-label">Enabled modules</label>
+            (<a href="" onclick="setSelectionForAllModules(true); return false;">select all except example</a> |
+            <a href="" onclick="setSelectionForAllModules(false); return false;">unselect all</a>)
+
+            {% if modules_disabled_by_default %}
+                <div class="alert alert-info">
+                    The following modules are disabled by default: {{ ", ".join(modules_disabled_by_default) }} - select the checkbox to start them.
+                    To change this, update the <tt>MODULES_DISABLED_BY_DEFAULT</tt> setting.
+                </div>
+            {% endif %}
+
+            <input type="hidden" name="choose_modules_to_enable" value="1">
+
+            <div class="row m-0">
+                {% for bind in binds %}
+                    <div class="form-check col-md-4">
+                        <label class="form-check-label">
+                            <input class="form-check-input" type="checkbox" value="" name="module_enabled_{{ bind.identity }}"
+                                {% if disabled_modules %}
+                                    {% if bind.identity not in disabled_modules %}checked{% endif %}
+                                {% else %}
+                                    {% if bind.identity not in modules_disabled_by_default %}checked{% endif %}
+                                {% endif %}>
+                            {{ bind.identity }}<br/>
+                            <span class="small text-muted">{{ bind.info|dedent|render_markdown|safe }}</span>
+                        </label>
+                    </div>
+
+                    {% if loop.index % 3 == 0 %}
+                        </div><div class="row m-0">
+                    {% endif %}
+                {% endfor %}
+            </div>
+
+            <p class="text-muted pb-4">
+                Even if the modules above are disabled, Artemis internal logic or core modules (that are always enabled) may
+                perform domain queries or HTTP requests.
+            </p>
+        </div>
+    </form>
+{% endblock %}

--- a/templates/components/navbar.jinja2
+++ b/templates/components/navbar.jinja2
@@ -14,6 +14,9 @@
                         <a class="nav-link {{ 'active' if request.path == '/add' }}" href="/add">Add targets</a>
                     </li>
                     <li class="nav-item">
+                        <a class="nav-link {{ 'active' if request.path.startswith('/periodic-scans') }}" href="/periodic-scans">Periodic scans</a>
+                    </li>
+                    <li class="nav-item">
                         <a class="nav-link {{ 'active' if request.path == '/' }}" href="/">View targets</a>
                     </li>
                     <li class="nav-item">

--- a/templates/delete_periodic_scan.jinja2
+++ b/templates/delete_periodic_scan.jinja2
@@ -1,0 +1,16 @@
+{% extends "components/base.jinja2" %}
+{% block main %}
+    <h1>Delete periodic scan</h1>
+    <p>
+        Are you sure you want to delete the periodic scan for
+        <strong>{{ scan.targets.split('\n')[0] }}{% if scan.targets.split('\n')|length > 1 %} (+{{ scan.targets.split('\n')|length - 1 }} more targets){% endif %}</strong>{% if scan.tag %} (tag: {{ scan.tag }}){% endif %}?
+    </p>
+    <p>
+        This action cannot be undone. Already-running scans will not be affected.
+    </p>
+    <form action="/periodic-scans/delete/{{ scan.id }}" method="post">
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
+        <input type="submit" class="btn btn-danger" value="Delete">
+        <a class="btn btn-secondary" href="/periodic-scans">Cancel</a>
+    </form>
+{% endblock %}

--- a/templates/periodic_scans.jinja2
+++ b/templates/periodic_scans.jinja2
@@ -1,0 +1,70 @@
+{% extends "components/base.jinja2" %}
+{% block main %}
+    <h1>Periodic scans</h1>
+    <p>
+        Periodic scans automatically re-scan your targets at a configured interval.
+    </p>
+
+    <a class="btn btn-primary mb-3" href="/periodic-scans/add">Add periodic scan</a>
+
+    {% if periodic_scans %}
+        <table class="table table-hover">
+            <thead>
+                <tr>
+                    <th scope="col">Created at</th>
+                    <th scope="col">Targets</th>
+                    <th scope="col">Tag</th>
+                    <th scope="col">Interval</th>
+                    <th scope="col">Priority</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Last run</th>
+                    <th scope="col">Next run</th>
+                    <th scope="col">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for scan in periodic_scans %}
+                    <tr>
+                        <td>{{ scan.created_at.strftime('%Y-%m-%d %H:%M') if scan.created_at else 'N/A' }}</td>
+                        <td>
+                            <span data-bs-toggle="tooltip" title="{{ scan.targets }}">
+                                {{ scan.targets.split('\n')[0] }}{% if scan.targets.split('\n')|length > 1 %} (+{{ scan.targets.split('\n')|length - 1 }} more){% endif %}
+                            </span>
+                        </td>
+                        <td>{{ scan.tag or '' }}</td>
+                        <td>Every {{ scan.interval_hours }}h</td>
+                        <td>{{ scan.priority }}</td>
+                        <td>
+                            {% if scan.enabled %}
+                                <span class="badge bg-success">Enabled</span>
+                            {% else %}
+                                <span class="badge bg-secondary">Disabled</span>
+                            {% endif %}
+                        </td>
+                        <td>{{ scan.last_run_at.strftime('%Y-%m-%d %H:%M') if scan.last_run_at else 'Never' }}</td>
+                        <td>{{ scan.next_run_at.strftime('%Y-%m-%d %H:%M') if scan.next_run_at else 'N/A' }}</td>
+                        <td>
+                            <form action="/periodic-scans/toggle/{{ scan.id }}" method="post" style="display:inline;">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
+                                <button type="submit" class="btn btn-sm {% if scan.enabled %}btn-warning{% else %}btn-success{% endif %}">
+                                    {% if scan.enabled %}Disable{% else %}Enable{% endif %}
+                                </button>
+                            </form>
+                            <a class="btn btn-sm btn-danger" href="/periodic-scans/delete/{{ scan.id }}">Delete</a>
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    {% else %}
+        <p class="text-muted">No periodic scans configured yet.</p>
+    {% endif %}
+{% endblock %}
+
+{% block scripts %}
+    <script>
+        $(document).ready(function() {
+            $('[data-bs-toggle="tooltip"]').tooltip();
+        });
+    </script>
+{% endblock %}

--- a/test/unit/test_periodic_scan.py
+++ b/test/unit/test_periodic_scan.py
@@ -1,0 +1,241 @@
+import datetime
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+
+from artemis.db import PeriodicScan
+
+
+class TestPeriodicScanModel(unittest.TestCase):
+    def test_periodic_scan_table_name(self) -> None:
+        self.assertEqual(PeriodicScan.__tablename__, "periodic_scan")
+
+    def test_periodic_scan_columns(self) -> None:
+        column_names = {col.name for col in PeriodicScan.__table__.columns}
+        expected = {
+            "id",
+            "targets",
+            "tag",
+            "disabled_modules",
+            "interval_hours",
+            "priority",
+            "enabled",
+            "last_run_at",
+            "next_run_at",
+            "created_at",
+        }
+        self.assertEqual(column_names, expected)
+
+    def test_periodic_scan_id_is_primary_key(self) -> None:
+        self.assertTrue(PeriodicScan.__table__.columns["id"].primary_key)
+
+    def test_periodic_scan_targets_not_nullable(self) -> None:
+        self.assertFalse(PeriodicScan.__table__.columns["targets"].nullable)
+
+    def test_periodic_scan_interval_not_nullable(self) -> None:
+        self.assertFalse(PeriodicScan.__table__.columns["interval_hours"].nullable)
+
+    def test_periodic_scan_enabled_not_nullable(self) -> None:
+        self.assertFalse(PeriodicScan.__table__.columns["enabled"].nullable)
+
+    def test_periodic_scan_tag_nullable(self) -> None:
+        self.assertTrue(PeriodicScan.__table__.columns["tag"].nullable)
+
+    def test_periodic_scan_last_run_at_nullable(self) -> None:
+        self.assertTrue(PeriodicScan.__table__.columns["last_run_at"].nullable)
+
+
+class TestPeriodicScanScheduler(unittest.TestCase):
+    """Tests for the periodic scan scheduler logic.
+
+    artemis.producer creates a Karton Producer at module level, which requires
+    S3/Redis infrastructure. We mock it at sys.modules level before importing
+    the scheduler module.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._mock_producer_module = MagicMock()
+        cls._mock_producer_module.create_tasks = MagicMock(return_value=[])
+        sys.modules.setdefault("artemis.producer", cls._mock_producer_module)
+
+        if "artemis.periodic_scan_scheduler" in sys.modules:
+            del sys.modules["artemis.periodic_scan_scheduler"]
+
+    def setUp(self) -> None:
+        self._mock_producer_module.create_tasks.reset_mock()
+
+    def _get_scheduler_module(self) -> MagicMock:
+        import artemis.periodic_scan_scheduler as scheduler_mod
+
+        return scheduler_mod  # type: ignore
+
+    def test_run_due_periodic_scans_no_due_scans(self) -> None:
+        scheduler = self._get_scheduler_module()
+        scheduler.db = MagicMock()
+        scheduler.db.get_due_periodic_scans.return_value = []
+
+        scheduler.run_due_periodic_scans()
+
+        self._mock_producer_module.create_tasks.assert_not_called()
+        scheduler.db.mark_periodic_scan_as_run.assert_not_called()
+
+    def test_run_due_periodic_scans_with_due_scan(self) -> None:
+        scheduler = self._get_scheduler_module()
+        scheduler.db = MagicMock()
+        scheduler.db.get_due_periodic_scans.return_value = [
+            {
+                "id": 1,
+                "targets": "example.com\nexample.org",
+                "tag": "test-tag",
+                "disabled_modules": "bruter,nuclei",
+                "interval_hours": 24,
+                "priority": "normal",
+                "enabled": True,
+                "last_run_at": None,
+                "next_run_at": datetime.datetime(2026, 1, 1),
+            }
+        ]
+        self._mock_producer_module.create_tasks.return_value = ["task-id-1", "task-id-2"]
+
+        scheduler.run_due_periodic_scans()
+
+        self._mock_producer_module.create_tasks.assert_called_once()
+        call_args = self._mock_producer_module.create_tasks.call_args
+        self.assertEqual(sorted(call_args[0][0]), ["example.com", "example.org"])
+        self.assertEqual(call_args[0][1], "test-tag")
+        self.assertEqual(sorted(call_args[1]["disabled_modules"]), ["bruter", "nuclei"])
+        scheduler.db.mark_periodic_scan_as_run.assert_called_once_with(1)
+
+    def test_run_due_periodic_scans_empty_disabled_modules(self) -> None:
+        scheduler = self._get_scheduler_module()
+        scheduler.db = MagicMock()
+        scheduler.db.get_due_periodic_scans.return_value = [
+            {
+                "id": 2,
+                "targets": "10.0.0.1",
+                "tag": None,
+                "disabled_modules": "",
+                "interval_hours": 12,
+                "priority": "high",
+                "enabled": True,
+                "last_run_at": datetime.datetime(2026, 1, 1),
+                "next_run_at": datetime.datetime(2026, 1, 1, 12),
+            }
+        ]
+        self._mock_producer_module.create_tasks.return_value = ["task-id-1"]
+
+        scheduler.run_due_periodic_scans()
+
+        call_args = self._mock_producer_module.create_tasks.call_args
+        self.assertEqual(call_args[0][0], ["10.0.0.1"])
+        self.assertIsNone(call_args[0][1])
+        self.assertEqual(call_args[1]["disabled_modules"], [])
+
+    def test_run_due_scan_marks_as_run_even_on_create_tasks_error(self) -> None:
+        scheduler = self._get_scheduler_module()
+        scheduler.db = MagicMock()
+        scheduler.db.get_due_periodic_scans.return_value = [
+            {
+                "id": 3,
+                "targets": "example.com",
+                "tag": None,
+                "disabled_modules": "",
+                "interval_hours": 24,
+                "priority": "normal",
+                "enabled": True,
+                "last_run_at": None,
+                "next_run_at": datetime.datetime(2026, 1, 1),
+            }
+        ]
+        self._mock_producer_module.create_tasks.side_effect = Exception("connection failed")
+
+        scheduler.run_due_periodic_scans()
+
+        scheduler.db.mark_periodic_scan_as_run.assert_called_once_with(3)
+
+    def test_run_due_periodic_scans_multiple_scans(self) -> None:
+        scheduler = self._get_scheduler_module()
+        scheduler.db = MagicMock()
+        scheduler.db.get_due_periodic_scans.return_value = [
+            {
+                "id": 10,
+                "targets": "a.com",
+                "tag": "tag-a",
+                "disabled_modules": "",
+                "interval_hours": 6,
+                "priority": "normal",
+                "enabled": True,
+                "last_run_at": None,
+                "next_run_at": datetime.datetime(2026, 1, 1),
+            },
+            {
+                "id": 20,
+                "targets": "b.com",
+                "tag": "tag-b",
+                "disabled_modules": "nuclei",
+                "interval_hours": 12,
+                "priority": "high",
+                "enabled": True,
+                "last_run_at": None,
+                "next_run_at": datetime.datetime(2026, 1, 1),
+            },
+        ]
+        self._mock_producer_module.create_tasks.return_value = ["id1"]
+
+        scheduler.run_due_periodic_scans()
+
+        self.assertEqual(self._mock_producer_module.create_tasks.call_count, 2)
+        self.assertEqual(scheduler.db.mark_periodic_scan_as_run.call_count, 2)
+        scheduler.db.mark_periodic_scan_as_run.assert_any_call(10)
+        scheduler.db.mark_periodic_scan_as_run.assert_any_call(20)
+
+    def test_targets_are_stripped(self) -> None:
+        scheduler = self._get_scheduler_module()
+        scheduler.db = MagicMock()
+        scheduler.db.get_due_periodic_scans.return_value = [
+            {
+                "id": 5,
+                "targets": "  example.com  \n  example.org  \n",
+                "tag": None,
+                "disabled_modules": "",
+                "interval_hours": 24,
+                "priority": "normal",
+                "enabled": True,
+                "last_run_at": None,
+                "next_run_at": datetime.datetime(2026, 1, 1),
+            }
+        ]
+        self._mock_producer_module.create_tasks.return_value = ["id1"]
+
+        scheduler.run_due_periodic_scans()
+
+        call_args = self._mock_producer_module.create_tasks.call_args
+        self.assertEqual(sorted(call_args[0][0]), ["example.com", "example.org"])
+
+    def test_empty_lines_in_targets_are_skipped(self) -> None:
+        scheduler = self._get_scheduler_module()
+        scheduler.db = MagicMock()
+        scheduler.db.get_due_periodic_scans.return_value = [
+            {
+                "id": 6,
+                "targets": "example.com\n\n\nexample.org\n\n",
+                "tag": None,
+                "disabled_modules": "",
+                "interval_hours": 24,
+                "priority": "normal",
+                "enabled": True,
+                "last_run_at": None,
+                "next_run_at": datetime.datetime(2026, 1, 1),
+            }
+        ]
+        self._mock_producer_module.create_tasks.return_value = ["id1"]
+
+        scheduler.run_due_periodic_scans()
+
+        call_args = self._mock_producer_module.create_tasks.call_args
+        self.assertEqual(sorted(call_args[0][0]), ["example.com", "example.org"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #1286

Previously, periodic scanning required external tooling (e.g. cron jobs) to call the `POST /api/add` endpoint repeatedly. This PR adds **built-in periodic scan schedules** that can be managed through both the web UI and the REST API.

### Changes

- **Database**: New `PeriodicScan` model with fields for targets, tag, interval (hours), disabled modules, priority, enabled/disabled state, and last/next run timestamps. Includes Alembic migration.
- **API endpoints**:
  - `POST /api/periodic-scans` — Create a periodic scan schedule
  - `GET /api/periodic-scans` — List all periodic scans
  - `DELETE /api/periodic-scans/{id}` — Delete a periodic scan
  - `PATCH /api/periodic-scans/{id}` — Enable/disable a periodic scan
- **Web UI**: Full pages for listing, creating (with module selection matching the existing "Add targets" form), toggling, and deleting periodic scans. New "Periodic scans" link in the navbar.
- **Background scheduler**: New `periodic-scan-scheduler` Docker service that checks every 60 seconds for due scans and triggers them via the existing `create_tasks()` function.
- **Tests**: 15 unit tests covering the model schema and scheduler logic (target parsing, empty lines, disabled modules, error handling, multiple scans).

### How it works

1. User creates a periodic scan via the UI or API, specifying targets, interval (e.g. 24h = daily), tag, priority, and which modules to enable.
2. The `periodic-scan-scheduler` service runs in a loop and checks for scans where `next_run_at <= now` and `enabled = True`.
3. For each due scan, it calls `create_tasks()` (the same function used by the manual "Add targets" form and the `/api/add` endpoint).
4. After triggering, `last_run_at` is updated and `next_run_at` is set to `now + interval_hours`.

## Test plan

- [x] Unit tests for PeriodicScan model (schema, column constraints)
- [x] Unit tests for scheduler logic (no due scans, single scan, multiple scans, empty targets, error handling)
- [ ] Manual testing: create periodic scan via UI, verify it appears in list, toggle enable/disable, delete
- [ ] Manual testing: verify scheduler triggers scans at configured interval
- [ ] Manual testing: create periodic scan via API endpoints


