### PR TITLE
fix: correct typo 'databaee' to 'database' in config.py

### DIFF
--- a/artemis/config.py
+++ b/artemis/config.py
@@ -35,7 +35,7 @@ class Config:
         SAVE_LOGS_IN_DATABASE: Annotated[
             bool,
             """
-            Whether Artemis should save task logs in the database to be viewed in the UI. Turn it off to save space in the databaee.
+            Whether Artemis should save task logs in the database to be viewed in the UI. Turn it off to save space in the database.
             """,
         ] = get_config("SAVE_LOGS_IN_DATABASE", default=True, cast=bool)
 


### PR DESCRIPTION
## Description

Fixed a typo in the documentation string for SAVE_LOGS_IN_DATABASE configuration option.
Fixed- #2396

## Changes

- File: artemis/config.py (line 38)
- Changed: "databaee" -> "database"

## Type of Change

- Documentation fix