### PR TITLE
feat: add type hints to data modules for better maintainability

### DIFF
--- a/artemis/modules/data/api_scanner_data.py
+++ b/artemis/modules/data/api_scanner_data.py
@@ -1,10 +1,11 @@
 from os.path import dirname
+from typing import Dict, List
 
 with open(f"{dirname(__file__)}/swagger.txt", "r") as f:
-    COMMON_SPEC_PATHS = f.read().splitlines()
+    COMMON_SPEC_PATHS: List[str] = f.read().splitlines()
     COMMON_SPEC_PATHS = [payload.strip() for payload in COMMON_SPEC_PATHS if not payload.startswith("#")]
 
-VULN_DETAILS_MAP = {
+VULN_DETAILS_MAP: Dict[str, str] = {
     "Endpoint performs HTTP verb which is not documented": "Unsupported HTTP Method",
     "One or more parameter is vulnerable to SQL Injection Attack": "SQL Injection",
     "Endpoint might be vulnerable to SQli": "SQL Injection",

--- a/artemis/modules/data/common_sql_credentials.py
+++ b/artemis/modules/data/common_sql_credentials.py
@@ -1,4 +1,6 @@
-COMMON_SQL_CREDENTIALS = [
+from typing import List, Tuple
+
+COMMON_SQL_CREDENTIALS: List[Tuple[str, str]] = [
     ("root", ""),
     ("admin", "admin"),
     ("root", "root"),

--- a/artemis/sql_injection_data.py
+++ b/artemis/sql_injection_data.py
@@ -1,6 +1,8 @@
+from typing import Dict, List
+
 from artemis.config import Config
 
-SQL_ERROR_MESSAGES = [
+SQL_ERROR_MESSAGES: List[str] = [
     "SQL syntax.{0,200}?MySQL",
     "Warning.{0,200}?\\Wmysqli?_",
     "MySQLSyntaxErrorException",
@@ -185,7 +187,7 @@ SQL_ERROR_MESSAGES = [
     "\\[(Virtuoso Driver|Virtuoso iODBC Driver)\\]\\[Virtuoso Server\\]",
 ]
 
-HEADERS = {
+HEADERS: Dict[str, str] = {
     "Accept": "application/xml, application/json, text/plain, text/html",
     "Accept-Encoding": "acceptencoding",
     "Accept-Language": "acceptlanguage",


### PR DESCRIPTION
## Description

Added type hints to data modules to improve code maintainability and enable better IDE support and static analysis with mypy.
Fixed- #2397 

## Changes

- artemis/sql_injection_data.py: Added List[str] and Dict[str, str] type hints
- artemis/modules/data/common_sql_credentials.py: Added List[Tuple[str, str]] type hint
- artemis/modules/data/api_scanner_data.py: Added List[str] and Dict[str, str] type hints

## Type of Change

- Code quality improvement