### PR TITLE
docs: Fix typos across documentation

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -44,7 +44,7 @@ It is possible to rate-limit the scanning. This feature is disabled by default. 
  - ``REQUESTS_PER_SECOND`` - e.g. when set to 0.5, Artemis will strive to make no more than
    one HTTP/MySQL connect/... request per two seconds for any IP from each module,
  - ``SCANNING_PACKETS_PER_SECOND`` - this configures the port scanning speed. For example, when set to 5, Artemis will strive to send no more than
-   5 port scanning packets per seconds to any IP.
+   5 port scanning packets per second to any IP.
 
 For CERT PL scans, the settings are:
 

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -73,7 +73,7 @@ To view results, click the ``View results`` link in the top navigation bar:
 Exporting reports
 -----------------
 Besides viewing the raw results, you may want to generate HTML reports containing
-descriptions of found vulnerabilities, so thay you can notify the administrators to get
+descriptions of found vulnerabilities, so that you can notify the administrators to get
 the vulnerabilities fixed.
 
 To do that, please refer to :ref:`generating-reports`.


### PR DESCRIPTION
Fixes #2403
 
## Description 
Fixed typos across the documentation to improve Readability.

## Changes
(docs/quick-start.rst - Line 76 ) `thay` -> `that`
(docs/features.rst - line 47 )  `seconds` -> `second`

## type of change

- > Type fixed in the document. 