### PR TITLE
Fix: check hidden fields before username heuristics in form parser

### DIFF
--- a/artemis/modules/admin_panel_login_bruter.py
+++ b/artemis/modules/admin_panel_login_bruter.py
@@ -112,7 +112,9 @@ class AdminPanelLoginBruter(ArtemisBase):
                     input_name = input_tag.get("name")
                     input_value = input_tag.get("value", "")
                     if input_name:
-                        if (
+                        if input_tag.get("type", "").lower() == "hidden":
+                            form_data[input_name] = input_value
+                        elif (
                             "user" in input_name.lower()
                             or "name" in input_name.lower()
                             or "usr" in input_name.lower()


### PR DESCRIPTION
If a hidden field's name (e.g. a CSRF token field) matched keywords like "user" or "log", it was being overwritten by the username instead of kept. Now hidden inputs are stored first, so CSRF tokens are always preserved.

Part of #2378