### PR TITLE
Fix blocking I/O in async endpoints freezing the event loop

### DIFF
--- a/artemis/frontend.py
+++ b/artemis/frontend.py
@@ -342,7 +342,10 @@ async def post_remove_finished_analyses(request: Request, csrf_protect: CsrfProt
     def _remove_finished_analyses() -> None:
         karton_state = KartonState(backend=KartonBackend(config=KartonConfig()))
         for analysis in db.list_analysis():
-            if analysis["id"] not in karton_state.analyses or len(karton_state.analyses[analysis["id"]].pending_tasks) == 0:
+            if (
+                analysis["id"] not in karton_state.analyses
+                or len(karton_state.analyses[analysis["id"]].pending_tasks) == 0
+            ):
                 db.delete_analysis(analysis["id"])
 
     await asyncio.to_thread(_remove_finished_analyses)


### PR DESCRIPTION
Fix blocking Redis operations inside async FastAPI endpoints

Some endpoints in artemis/frontend.py were declared as async but were performing synchronous Redis operations through KartonBackend.get_all_tasks(). Since async endpoints run on the FastAPI event loop, these blocking calls could freeze the entire server while scanning Redis tasks.

This change prevents event loop blocking by:
- converting get_pending_tasks to a synchronous endpoint
- moving blocking Redis and DB work in CSRF protected endpoints to asyncio.to_thread()

Affected endpoints:
get_pending_tasks
post_remove_pending_tasks
post_remove_finished_analyses
post_restart_crashed_tasks

This ensures heavy Redis scans do not block the event loop and keeps the web UI responsive.