### PR TITLE
fix: handle git clone failure in BaseNewerVersionComparerModule

### DIFF
--- a/artemis/modules/base/base_newer_version_comparer.py
+++ b/artemis/modules/base/base_newer_version_comparer.py
@@ -25,8 +25,7 @@ class BaseNewerVersionComparerModule(ArtemisBase):
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as e:
             shutil.rmtree(self.endoflife_data_folder, ignore_errors=True)
             raise RuntimeError(
-                f"Failed to clone endoflife data repository: {e}. "
-                "Check network connectivity to github.com."
+                f"Failed to clone endoflife data repository: {e}. " "Check network connectivity to github.com."
             ) from e
 
         endoflife_data_path = Path(self.endoflife_data_folder) / "products" / (self.software_name + ".md")


### PR DESCRIPTION
## Fix crash when endoflife repository clone fails during module initialization

### Summary
BaseNewerVersionComparerModule was cloning the endoflife.date repository
using subprocess.call without checking the return code. If the clone failed
(for example due to network issues or GitHub being unreachable), the code
would still continue and try to read a file from the repository that was
never created. This resulted in a FileNotFoundError during module
initialization.

Because this happens in the constructor, the worker process would crash
during startup and containers such as joomla_scanner and drupal_scanner
could enter restart loops.

### Changes
- Replace subprocess.call with subprocess.check_call to ensure failures are detected
- Add a timeout to prevent git clone from hanging indefinitely
- Clean up the temporary directory if the clone fails
- Raise a clearer error message when the repository cannot be fetched

### Impact
This prevents startup crash loops when GitHub is temporarily unreachable and
provides a clearer failure path during initialization. It also avoids leaving
temporary directories behind when the clone operation fails.