### PR TITLE
refactor: factor out common parts of lfi_detector and sql_injection_d…

### DIFF
--- a/artemis/modules/injection_detector_base.py
+++ b/artemis/modules/injection_detector_base.py
@@ -1,0 +1,104 @@
+import random
+import re
+from abc import abstractmethod
+from typing import Any, Dict, List
+from urllib.parse import urlparse, urlunparse
+
+from karton.core import Task
+
+from artemis.binds import Service, TaskStatus, TaskType
+from artemis.config import Config
+from artemis.crawling import get_links_and_resources_on_same_domain
+from artemis.module_base import ArtemisBase
+from artemis.modules.data.static_extensions import STATIC_EXTENSIONS
+from artemis.task_utils import get_target_url
+
+
+class InjectionDetectorBase(ArtemisBase):
+    """
+    Base class for injection detection modules (LFI, SQL injection, etc.).
+
+    Subclasses must define:
+      - identity (str): unique karton identity
+      - scan(urls, task): scanning logic returning a list of finding dicts
+      - create_status_reason(messages): format messages into a status reason string
+      - create_data(messages): build the data dict saved with the task result
+    """
+
+    num_retries = Config.Miscellaneous.SLOW_MODULE_NUM_RETRIES
+    filters = [
+        {"type": TaskType.SERVICE.value, "service": Service.HTTP.value},
+    ]
+
+    # --- shared utility methods ---
+
+    @staticmethod
+    def _strip_query_string(url: str) -> str:
+        url_parsed = urlparse(url)
+        return urlunparse(url_parsed._replace(query="", fragment=""))
+
+    @staticmethod
+    def is_url_with_parameters(url: str) -> bool:
+        return bool(re.search(r"/?/*=", url))
+
+    def create_url_with_batch_payload(self, url: str, param_batch: Any, payload: str) -> str:
+        assignments = {key: payload for key in param_batch}
+        concatenation = "&" if self.is_url_with_parameters(url) else "?"
+        return f"{url}{concatenation}" + "&".join([f"{key}={value}" for key, value in assignments.items()])
+
+    def _collect_urls(self, url: str) -> List[str]:
+        """Gather, deduplicate, filter and shuffle URLs to scan."""
+        links = get_links_and_resources_on_same_domain(url)
+        links.append(url)
+        links = list(set(links) | set([self._strip_query_string(link) for link in links]))
+
+        links = [
+            link.split("#")[0]
+            for link in links
+            if not any(link.split("?")[0].lower().endswith(extension) for extension in STATIC_EXTENSIONS)
+        ]
+
+        random.shuffle(links)
+        return links[: Config.Miscellaneous.MAX_URLS_TO_SCAN]
+
+    # --- hooks for subclasses ---
+
+    def _pre_run_check(self, current_task: Task) -> bool:
+        """Override to add pre-run checks. Return False to skip scanning."""
+        return True
+
+    @abstractmethod
+    def scan(self, urls: List[str], task: Task) -> List[Dict[str, Any]]:
+        """Scan the given URLs and return a list of finding dicts."""
+        ...
+
+    @abstractmethod
+    def create_status_reason(self, messages: List[Dict[str, Any]]) -> str:
+        """Build a human-readable status reason from the scan messages."""
+        ...
+
+    @abstractmethod
+    def create_data(self, messages: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Build the data payload to save with the task result."""
+        ...
+
+    # --- template run method ---
+
+    def run(self, current_task: Task) -> None:
+        if not self._pre_run_check(current_task):
+            return
+
+        url = get_target_url(current_task)
+        urls = self._collect_urls(url)
+
+        messages = self.scan(urls=urls, task=current_task)
+
+        if messages:
+            status = TaskStatus.INTERESTING
+            status_reason = self.create_status_reason(messages)
+        else:
+            status = TaskStatus.OK
+            status_reason = None
+
+        data = self.create_data(messages)
+        self.db.save_task_result(task=current_task, status=status, status_reason=status_reason, data=data)

--- a/artemis/modules/lfi_detector.py
+++ b/artemis/modules/lfi_detector.py
@@ -1,27 +1,18 @@
-import random
-import re
 from enum import Enum
 from typing import Any, Dict, List, Optional
-from urllib.parse import urlparse, urlunparse
 
 from karton.core import Task
 
 from artemis import load_risk_class
-from artemis.binds import Service, TaskStatus, TaskType
 from artemis.config import Config
-from artemis.crawling import (
-    get_injectable_parameters,
-    get_links_and_resources_on_same_domain,
-)
+from artemis.crawling import get_injectable_parameters
 from artemis.http_requests import HTTPResponse
-from artemis.module_base import ArtemisBase
 from artemis.modules.data.lfi_detector.lfi_detector_data import (
     LFI_PAYLOADS,
     RCE_PAYLOADS,
 )
 from artemis.modules.data.parameters import URL_PARAMS
-from artemis.modules.data.static_extensions import STATIC_EXTENSIONS
-from artemis.task_utils import get_target_url
+from artemis.modules.injection_detector_base import InjectionDetectorBase
 
 
 class LFIFindings(Enum):
@@ -36,28 +27,15 @@ vulnerability_to_message = {
 
 
 @load_risk_class.load_risk_class(load_risk_class.LoadRiskClass.HIGH)
-class LFIDetector(ArtemisBase):
+class LFIDetector(InjectionDetectorBase):
     """
     Module for detecting Local File Inclusion (LFI) vulnerabilities.
     """
 
-    num_retries = Config.Miscellaneous.SLOW_MODULE_NUM_RETRIES
     identity = "lfi_detector"
-    filters = [
-        {"type": TaskType.SERVICE.value, "service": Service.HTTP.value},
-    ]
 
-    def _strip_query_string(self, url: str) -> str:
-        url_parsed = urlparse(url)
-        return urlunparse(url_parsed._replace(query="", fragment=""))
-
-    def create_url_with_batch_payload(self, url: str, param_batch: List[str], payload: str) -> str:
-        assignments = {key: payload for key in param_batch}
-        concatenation = "&" if self.is_url_with_parameters(url) else "?"
-        return f"{url}{concatenation}" + "&".join([f"{key}={value}" for key, value in assignments.items()])
-
-    def is_url_with_parameters(self, url: str) -> bool:
-        return bool(re.search(r"/?/*=", url))
+    def _pre_run_check(self, current_task: Task) -> bool:
+        return self.check_connection_to_base_url_and_save_error(current_task)
 
     def contains_lfi_indicator(self, original_response: HTTPResponse, response: HTTPResponse) -> Optional[str]:
         """Check if the response contains indicators of LFI."""
@@ -114,35 +92,11 @@ class LFIDetector(ArtemisBase):
 
         return messages
 
-    def run(self, current_task: Task) -> None:
-        """Run the LFI detection module."""
-        if self.check_connection_to_base_url_and_save_error(current_task):
-            url = get_target_url(current_task)
+    def create_status_reason(self, messages: List[Dict[str, Any]]) -> str:
+        return ", ".join([m["statement"] for m in messages])
 
-            links = get_links_and_resources_on_same_domain(url)
-            links.append(url)
-            links = list(set(links) | set([self._strip_query_string(link) for link in links]))
-
-            links = [
-                link.split("#")[0]
-                for link in links
-                if not any(link.split("?")[0].lower().endswith(extension) for extension in STATIC_EXTENSIONS)
-            ]
-
-            random.shuffle(links)
-
-            messages = self.scan(urls=links[: Config.Miscellaneous.MAX_URLS_TO_SCAN], task=current_task)
-
-            if messages:
-                status = TaskStatus.INTERESTING
-                status_reason = ", ".join([m["statement"] for m in messages])
-            else:
-                status = TaskStatus.OK
-                status_reason = None
-
-            data = {"result": messages, "statements": {e.value: e.name for e in LFIFindings}}
-
-            self.db.save_task_result(task=current_task, status=status, status_reason=status_reason, data=data)
+    def create_data(self, messages: List[Dict[str, Any]]) -> Dict[str, Any]:
+        return {"result": messages, "statements": {e.value: e.name for e in LFIFindings}}
 
 
 if __name__ == "__main__":

--- a/artemis/modules/sql_injection_detector.py
+++ b/artemis/modules/sql_injection_detector.py
@@ -1,7 +1,5 @@
 import datetime
-import random
 import re
-import urllib
 from enum import Enum
 from timeit import default_timer as timer
 from typing import Any, Dict, List, Optional
@@ -12,18 +10,12 @@ import requests
 from karton.core import Task
 
 from artemis import load_risk_class
-from artemis.binds import Service, TaskStatus, TaskType
 from artemis.config import Config
-from artemis.crawling import (
-    get_injectable_parameters,
-    get_links_and_resources_on_same_domain,
-)
+from artemis.crawling import get_injectable_parameters
 from artemis.http_requests import HTTPResponse
-from artemis.module_base import ArtemisBase
 from artemis.modules.data.parameters import URL_PARAMS
-from artemis.modules.data.static_extensions import STATIC_EXTENSIONS
+from artemis.modules.injection_detector_base import InjectionDetectorBase
 from artemis.sql_injection_data import HEADERS, SQL_ERROR_MESSAGES
-from artemis.task_utils import get_target_url
 
 
 class Statements(Enum):
@@ -34,41 +26,18 @@ class Statements(Enum):
 
 
 @load_risk_class.load_risk_class(load_risk_class.LoadRiskClass.HIGH)
-class SqlInjectionDetector(ArtemisBase):
+class SqlInjectionDetector(InjectionDetectorBase):
     """
     Module for detecting SQL injection and time-based SQL injection vulnerabilities.
     """
 
-    num_retries = Config.Miscellaneous.SLOW_MODULE_NUM_RETRIES
     identity = "sql_injection_detector"
-    filters = [
-        {"type": TaskType.SERVICE.value, "service": Service.HTTP.value},
-    ]
-
-    @staticmethod
-    def _strip_query_string(url: str) -> str:
-        url_parsed = urllib.parse.urlparse(url)
-        return urllib.parse.urlunparse(url_parsed._replace(query="", fragment=""))
-
-    def create_url_with_batch_payload(self, url: str, param_batch: tuple[Any], payload: str) -> str:
-        assignments = {key: payload for key in param_batch}
-        concatenation = "&" if self.is_url_with_parameters(url) else "?"
-
-        url_with_payload = f"{url}{concatenation}" + "&".join([f"{key}={value}" for key, value in assignments.items()])
-
-        return url_with_payload
 
     @staticmethod
     def change_sleep_to_0(payload: str) -> str:
         # This is to replace sleep(5) with sleep(0) so that we inject an empty sleep instead of keeping the variable
         # empty as keeping it empty may trigger different, faster code paths.
         return payload.replace(f"({Config.Modules.SqlInjectionDetector.SQL_INJECTION_TIME_THRESHOLD})", "(0)")
-
-    @staticmethod
-    def is_url_with_parameters(url: str) -> bool:
-        if re.search("/?/*=", url):
-            return True
-        return False
 
     @staticmethod
     def change_url_params(url: str, payload: str, param_batch: tuple[Any]) -> str:
@@ -126,18 +95,16 @@ class SqlInjectionDetector(ArtemisBase):
             headers.update({key: value + payload})
         return headers
 
-    @staticmethod
-    def create_status_reason(message: Any) -> str:
+    def create_status_reason(self, messages: List[Dict[str, Any]]) -> str:
         status_reason = []
-        for injection_message in message:
+        for injection_message in messages:
             status_reason.append(f"{injection_message.get('url')}: {injection_message.get('statement')}")
         return ", ".join(set(status_reason))
 
-    @staticmethod
-    def create_data(message: Any) -> Dict[str, List[str] | dict[str, Any]]:
-        message = list(more_itertools.unique_everseen(message))
-        data = {
-            "result": message,
+    def create_data(self, messages: List[Dict[str, Any]]) -> Dict[str, Any]:
+        messages = list(more_itertools.unique_everseen(messages))
+        return {
+            "result": messages,
             "statements": {
                 "sql_injection": Statements.sql_injection.value,
                 "sql_time_based_injection": Statements.sql_time_based_injection.value,
@@ -145,7 +112,6 @@ class SqlInjectionDetector(ArtemisBase):
                 "headers_time_based_sql_injection": Statements.headers_time_based_sql_injection.value,
             },
         }
-        return data
 
     def scan(self, urls: List[str], task: Task) -> List[Dict[str, Any]]:
         self.log.info("Scanning URLs: %s", urls)
@@ -345,34 +311,6 @@ class SqlInjectionDetector(ArtemisBase):
                         return message
 
         return message
-
-    def run(self, current_task: Task) -> None:
-        url = get_target_url(current_task)
-
-        links = get_links_and_resources_on_same_domain(url)
-        links.append(url)
-        links = list(set(links) | set([self._strip_query_string(link) for link in links]))
-
-        links = [
-            link.split("#")[0]
-            for link in links
-            if not any(link.split("?")[0].lower().endswith(extension) for extension in STATIC_EXTENSIONS)
-        ]
-
-        random.shuffle(links)
-
-        message = self.scan(urls=links[: Config.Miscellaneous.MAX_URLS_TO_SCAN], task=current_task)
-
-        if message:
-            status = TaskStatus.INTERESTING
-            status_reason = self.create_status_reason(message=message)
-        else:
-            status = TaskStatus.OK
-            status_reason = None
-
-        data = self.create_data(message=message)
-
-        self.db.save_task_result(task=current_task, status=status, status_reason=status_reason, data=data)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #2409

## Summary

Both `lfi_detector` and `sql_injection_detector` had a lot of duplicated structure and logic. This PR introduces `InjectionDetectorBase`, a shared base class that centralizes the common parts, while each module retains its specific scanning logic.

## What was factored out into `InjectionDetectorBase`

| Element | Description |
|---|---|
| `num_retries` | Class attribute (both used the same `SLOW_MODULE_NUM_RETRIES`) |
| `filters` | HTTP service filter (identical in both) |
| `_strip_query_string()` | URL utility method (duplicated) |
| `is_url_with_parameters()` | Static method (duplicated) |
| `create_url_with_batch_payload()` | Payload URL builder (duplicated) |
| `_collect_urls()` | URL collection, deduplication, filtering & shuffling (was ~10 identical lines in each `run()`) |
| `run()` | Template method pattern — calls hooks for scanning and result formatting |

## How the subclasses work

Each module implements three abstract methods:
- **`scan(urls, task)`** — module-specific vulnerability scanning logic
- **`create_status_reason(messages)`** — formats findings into a status string
- **`create_data(messages)`** — builds the data payload for task results

`LFIDetector` also overrides `_pre_run_check()` to call `check_connection_to_base_url_and_save_error()` before scanning.

## No test changes needed

All existing imports (`LFIDetector`, `SqlInjectionDetector`, `LFIFindings`, `Statements`) are still exported from the same modules. The public API, output format, and behavior are fully preserved.

## Files changed

- **New:** `artemis/modules/injection_detector_base.py` — shared base class
- **Modified:** `artemis/modules/lfi_detector.py` — now extends `InjectionDetectorBase`
- **Modified:** `artemis/modules/sql_injection_detector.py` — now extends `InjectionDetectorBase`