### PR TITLE
fix: remaining blocking I/O in async endpoints

### DIFF
--- a/artemis/api.py
+++ b/artemis/api.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 from typing import Annotated, Any, Dict, List, Optional
 
@@ -232,7 +233,7 @@ def download_zip(id: int) -> RedirectResponse:
 @router.post("/export/delete/{id}", dependencies=[Depends(verify_api_token)])
 async def post_export_delete(id: int) -> Dict[str, Any]:
     """Delete an export."""
-    db.delete_report_generation_task(id)
+    await asyncio.to_thread(db.delete_report_generation_task, id)
     return {
         "ok": True,
     }
@@ -265,7 +266,8 @@ async def post_export(
     skip_suspicious_reports: bool = Body(False),
 ) -> Dict[str, Any]:
     """Create a new export. An export is a request to create human-readable messages that may be sent to scanned entities."""
-    db.create_report_generation_task(
+    await asyncio.to_thread(
+        db.create_report_generation_task,
         skip_previously_exported=skip_previously_exported,
         tag=tag,
         comment=comment,

--- a/artemis/frontend.py
+++ b/artemis/frontend.py
@@ -182,7 +182,7 @@ async def post_add(
             csrf_protect,
         )
 
-    create_tasks(total_list, tag, disabled_modules, TaskPriority(priority))
+    await asyncio.to_thread(create_tasks, total_list, tag, disabled_modules, TaskPriority(priority))
     if redirect:
         return RedirectResponse(request.url_for("get_root"), status_code=303)
     else:


### PR DESCRIPTION
## Fix blocking I/O in async endpoints

Some async endpoints were still calling synchronous DB/Redis operations directly, which can block the asyncio event loop under load.

This wraps the blocking calls with `asyncio.to_thread(...)` so they run in a background thread instead of freezing the event loop.

### Changes
- `frontend.py`: run `create_tasks()` via `await asyncio.to_thread(...)` in `post_add`
- `api.py`: wrap `db.delete_report_generation_task()` in `post_export_delete`
- `api.py`: wrap `db.create_report_generation_task()` in `post_export`

### Impact
Keeps the event loop responsive during large submissions or export operations and prevents request hangs for other users.