### PR TITLE
fix: typo 'sef' -> 'self' in nuclei.py line 289 (fixes #2441)

### DIFF
--- a/artemis/modules/nuclei.py
+++ b/artemis/modules/nuclei.py
@@ -286,7 +286,7 @@ class Nuclei(ArtemisBase):
         url_parsed = urllib.parse.urlparse(url)
         return urllib.parse.urlunparse(url_parsed._replace(query="", fragment=""))
 
-    def _get_requests_per_second_statistics(sef, stderr_lines: List[str]) -> str:
+    def _get_requests_per_second_statistics(self, stderr_lines: List[str]) -> str:
         current_second_host_requests: Dict[str, int] = collections.defaultdict(int)
         requests_per_second_per_host: List[int] = []
 


### PR DESCRIPTION
## Summary
Fixes #2441

## Problem
In `artemis/modules/nuclei.py` line 289, the instance parameter `self` 
was misspelled as `sef` in the method signature of 
`_get_requests_per_second_statistics()`.

## Change
Before:
def _get_requests_per_second_statistics(sef, stderr_lines: List[str]) -> str:

After:
def _get_requests_per_second_statistics(self, stderr_lines: List[str]) -> str:

## Impact
Without this fix, any internal reference to `self` inside this method 
would raise a NameError at runtime, breaking Nuclei statistics reporting.

## Testing
No tests required — single character typo fix with no logic change.