### PR TITLE
fix: log warning instead of silently swallowing exception in bruter.py line 95

### DIFF
--- a/artemis/modules/bruter.py
+++ b/artemis/modules/bruter.py
@@ -92,7 +92,7 @@ class Bruter(ArtemisBase):
                     full_url, allow_redirects=Config.Modules.Bruter.BRUTER_FOLLOW_REDIRECTS
                 )
             except Exception:
-                pass
+                self.log.warning("Failed to scan URL %s", full_url)
 
         self.log.info("bruter finished")
         # For downloading URLs, we don't use an existing tool (such as e.g. dirbuster or gobuster) as we


### PR DESCRIPTION
## Summary
Fixes #2459

## Problem
In artemis/modules/bruter.py line 95, a bare except Exception: pass 
silently swallows all errors during URL scanning with no logging.

## Change
Before:
    except Exception:
        pass

After:
    except Exception:
        self.log.warning("Failed to scan URL %s", full_url)

## Impact
- Failed scans now produce a warning log entry
- Easier to debug network errors and timeouts
- No behavioral change to scanning logic