### PR TITLE
Fix API scanner skipping large OpenAPI specs due to response truncation

### DIFF
--- a/artemis/config.py
+++ b/artemis/config.py
@@ -330,6 +330,12 @@ class Config:
             ] = get_config("ADMIN_PANEL_LOGIN_BRUTER_NUM_RECHECKS", default=10, cast=int)
 
         class APIScanner:
+            API_SPEC_MAX_SIZE: Annotated[
+                int,
+                "Maximum size in bytes for downloading OpenAPI/Swagger specification files. "
+                "The default CONTENT_PREFIX_SIZE (100KB) is too small for most real-world API specs.",
+            ] = get_config("API_SPEC_MAX_SIZE", default=5 * 1024 * 1024, cast=int)
+
             ONLY_GET_REQUESTS: Annotated[
                 bool,
                 "If set to True, API scanner will only use GET requests to scan. If to False, a more intrusive scan "

--- a/artemis/modules/api_scanner.py
+++ b/artemis/modules/api_scanner.py
@@ -53,7 +53,7 @@ class APIScanner(ArtemisBase):
         for path in COMMON_SPEC_PATHS:
             try_url = base_url.rstrip("/") + "/" + path
             try:
-                response = http_requests.get(try_url)
+                response = http_requests.get(try_url, max_size=Config.Modules.APIScanner.API_SPEC_MAX_SIZE)
                 if response.status_code == 200 and (
                     "openapi" in response.text.lower() or "swagger" in response.text.lower()
                 ):


### PR DESCRIPTION
## Fix API scanner skipping large OpenAPI specs due to response truncation

### Problem
`APIScanner.discover_spec()` fetched OpenAPI/Swagger specs using `http_requests.get()` without overriding the default response size limit.

The underlying `http_requests.request()` truncates responses to `CONTENT_PREFIX_SIZE` (100KB). Many real-world API specifications exceed this size. When a spec larger than 100KB is downloaded, it gets truncated, resulting in invalid JSON/YAML that fails parsing. The exception is silently caught, causing the scanner to incorrectly report that no API specification was found and skip the scan.

### Root Cause
`http_requests.get()` was called without specifying `max_size`, causing large OpenAPI specifications to be truncated.

### Fix
Add a configurable maximum download size for API specifications and pass it to `http_requests.get()`.

### Changes
- Added `API_SPEC_MAX_SIZE` configuration under `Config.Modules.APIScanner` (default **5MB**).
- Updated `api_scanner.py` to pass `max_size=Config.Modules.APIScanner.API_SPEC_MAX_SIZE` when downloading specs.

### Impact
- Prevents truncation of OpenAPI/Swagger specifications.
- Ensures large real-world API specs can be parsed and scanned.
- Allows the OFFAT integration to run correctly on APIs with complex specifications.
- Eliminates false negatives where APIs were previously skipped.

### Files Modified
- `artemis/modules/api_scanner.py`
- `artemis/config.py`