### PR TITLE
add master-addons to PLUGINS_BAD_VERSION_IN_README to stabilize flaky test`

### DIFF
--- a/artemis/modules/wordpress_plugins.py
+++ b/artemis/modules/wordpress_plugins.py
@@ -62,7 +62,7 @@ PLUGINS_TO_SKIP_STABLE_TAG = [
     "testimonial-slider-and-showcase",
     "wow-carousel-for-divi-lite",
 ]
- PLUGINS_BAD_VERSION_IN_README = [
+PLUGINS_BAD_VERSION_IN_README = [
     "coming-soon",
     "disable-wordpress-updates",
     "famethemes-demo-importer",
@@ -79,6 +79,7 @@ PLUGINS_TO_SKIP_STABLE_TAG = [
     "wp-migrate-db",
     "zapier",
 ]
+
 
 def strip_trailing_zeros(version: Optional[str]) -> Optional[str]:
     if not version:


### PR DESCRIPTION
Master-addons readme version doesn't match the actual plugin version,
causing test_plugin_identification_from_readme to fail in CI.

Adding it to PLUGINS_BAD_VERSION_IN_README to fix the flaky test,
consistent with how other such plugins are handled.