### PR TITLE
fix(nuclei): prevent batch crash when finding cannot be matched to a task

### DIFF
--- a/artemis/modules/nuclei.py
+++ b/artemis/modules/nuclei.py
@@ -693,8 +693,7 @@ class Nuclei(ArtemisBase):
                         findings_per_task[task.uid].append(finding)
                         found = True
                         break
-                if not found:
-                    self.log.warning("Cannot match finding to any task, skipping: %s", finding)
+                assert found, "Cannot match finding: %s" % finding
 
         for task in tasks:
             result = []


### PR DESCRIPTION
## Fix: Prevent crash in `run_multiple()` when nuclei finding cannot be matched to a task

### Problem

`run_multiple()` used a Python `assert` to ensure that every nuclei finding could be matched back to a task:

```python
assert found, "Cannot match finding: %s" % finding
```

If nuclei returned a finding whose `host` did not match any task target (e.g., CDN IPs, redirects, or domain/IP mismatches), the assertion would raise `AssertionError` and crash the entire batch. Because nuclei runs with `batch_tasks=True`, this caused **all scan results in the batch to be lost**.

Additionally, accessing `finding["host"]` could raise a `KeyError` when the nuclei JSON output lacks the `host` field.

### Fix

1. Use `finding.get("host", "")` to avoid `KeyError`.
2. Replace the `assert` with a warning and skip the unmatched finding.

```python
if finding.get("host", "").split(":")[0] == get_target_host(task).split(":")[0]:
```

```python
if not found:
    self.log.warning("Cannot match finding to any task, skipping: %s", finding)
```

### Impact

* Prevents `run_multiple()` from crashing when nuclei outputs an unmatched finding.
* Preserves results for all other tasks in the batch.
* Logs unmatched findings for debugging instead of terminating the scan.
