### PR TITLE
Fix TypeError in dangling_dns_detector whois error handling

### DIFF
--- a/artemis/modules/dangling_dns_detector.py
+++ b/artemis/modules/dangling_dns_detector.py
@@ -360,7 +360,7 @@ class DanglingDnsDetector(ArtemisBase):
             whois_data = IPWhois(ip).lookup_whois()
         except HTTPLookupError as e:
             if any(
-                token in e
+                token in str(e)
                 for token in (
                     "429",
                     "too many requests",
@@ -371,7 +371,9 @@ class DanglingDnsDetector(ArtemisBase):
                 )
             ):
                 self.log.info("Quota exceeded for whois query for %s", ip)
-                return False
+            else:
+                self.log.warning("Whois lookup failed for %s: %s", ip, e)
+            return False
 
         descriptions: list[str] = []
         if "asn_description" in whois_data and whois_data["asn_description"]:


### PR DESCRIPTION
## Fix TypeError crash in check_for_public_entities when handling HTTPLookupError

### Problem
`check_for_public_entities` incorrectly performs a containment check using `token in e`, where `e` is an Exception object.  
Since exceptions are not iterable, this raises:

TypeError: argument of type 'HTTPLookupError' is not iterable

This occurs when `IPWhois.lookup_whois()` throws `HTTPLookupError` (commonly due to WHOIS rate limiting).

Additionally, if the condition failed, execution would fall through and reference `whois_data`, which was never assigned, causing an `UnboundLocalError`.

### Fix
- Convert the exception to string before performing the containment check (`token in str(e)`).
- Add a fallback branch to log non-rate-limit errors.
- Ensure the function safely returns `False` for all `HTTPLookupError` cases to prevent fallthrough.

### Impact
- Prevents scanner crashes caused by WHOIS rate limiting or other lookup failures.
- Ensures dangling DNS detection continues running instead of terminating the module.