### PR TITLE
Remove scheduledtask deduplication original data

### DIFF
--- a/artemis/db.py
+++ b/artemis/db.py
@@ -69,7 +69,6 @@ class ScheduledTask(Base):  # type: ignore
 
     :ivar analysis_id: Unique identifier for the analysis associated with this scheduled task.
     :ivar deduplication_data: Hash used for deduplication of scheduled tasks.
-    :ivar deduplication_data_original: Original string used for deduplication.
     :ivar task_id: Unique identifier for the underlying task.
     :ivar created_at: Timestamp when the scheduled task was created.
     """
@@ -78,11 +77,10 @@ class ScheduledTask(Base):  # type: ignore
     created_at = Column(DateTime, server_default=text("NOW()"))
     analysis_id = Column(String, primary_key=True)
     # The purpose of this column is to be able to quickly find identical scheduled tasks. Therefore
-    # we convert them to a string form (deduplication_data_original, created by the
+    # we convert them to a string form (created by the
     # _get_task_deduplication_data method) and store the hash of the string in the indexed
     # deduplication_data column (because PostgreSQL limits the max length of indexed column).
     deduplication_data = Column(String, primary_key=True)
-    deduplication_data_original = Column(String)
     task_id = Column(String)
 
 
@@ -478,7 +476,6 @@ class DB:
             "analysis_id": task.root_uid,
             # PostgreSQL limits the length of string if it's an indexed column
             "deduplication_data": hashlib.sha256(self._get_task_deduplication_data(task).encode("utf-8")).hexdigest(),
-            "deduplication_data_original": self._get_task_deduplication_data(task),
         }
 
         statement = postgres_insert(ScheduledTask).values([created_task])

--- a/migrations/versions/7243ed9d7f98_remove_scheduled_task_deduplication_.py
+++ b/migrations/versions/7243ed9d7f98_remove_scheduled_task_deduplication_.py
@@ -1,0 +1,26 @@
+"""remove scheduled_task.deduplication_data_original
+
+Revision ID: 7243ed9d7f98
+Revises: 3d5b256854bb
+Create Date: 2026-03-11 13:07:16.054460
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "7243ed9d7f98"
+down_revision = "3d5b256854bb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("scheduled_task", "deduplication_data_original")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "scheduled_task", sa.Column("deduplication_data_original", sa.VARCHAR(), autoincrement=False, nullable=True)
+    )


### PR DESCRIPTION
Original deduplication data was only stored in database. The only possible purpose was for some investigation during debugging - which can be done separately anyway. Therefore removing to free the space.