### PR TITLE
Fix tee process killed before flushing output buffer

### DIFF
--- a/artemis/output_redirector.py
+++ b/artemis/output_redirector.py
@@ -33,8 +33,11 @@ class OutputRedirector:
             self._stream_copy[fd].close()
         if self._tee.stdin:
             self._tee.stdin.close()
-        self._tee.kill()
-        self._tee.wait()
+        try:
+            self._tee.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self._tee.kill()
+            self._tee.wait()
 
     def get_output(self) -> bytes:
         self._output_collector_file.seek(0)


### PR DESCRIPTION
## Summary
Fix an issue where OutputRedirector.__exit__ terminated the tee process immediately after closing stdin, which could truncate the final part of task output logs.

## Changes
- Removed the immediate kill of the tee process.
- Wait for tee to exit naturally after receiving EOF on stdin.
- Added a timeout based fallback to kill the process only if it does not exit.

## Why
When writing to a file, tee uses buffered I/O. Killing the process before it flushes its buffers can silently drop the final portion of logs.

## Result
Ensures that all task output is properly flushed and written to the log file while still preventing potential hangs.