### PR TITLE
Fix fd corruption in OutputRedirector when SIGALRM interrupts cleanup

### DIFF
--- a/artemis/output_redirector.py
+++ b/artemis/output_redirector.py
@@ -1,4 +1,5 @@
 import os
+import signal
 import subprocess
 import sys
 import tempfile
@@ -26,15 +27,23 @@ class OutputRedirector:
             os.dup2(self._tee.stdin.fileno(), fd)  # type: ignore
 
     def __exit__(self, *args: typing.Any) -> None:
-        for stream in self._streams:
-            fd = stream.fileno()
-            stream.flush()
-            os.dup2(self._stream_copy[fd].fileno(), fd)
-            self._stream_copy[fd].close()
-        if self._tee.stdin:
-            self._tee.stdin.close()
-        self._tee.kill()
-        self._tee.wait()
+        # Block SIGALRM during fd restoration to prevent timeout_decorator from
+        # interrupting between restoring stdout and stderr. If SIGALRM fires in
+        # this window, stderr would still point to the dead tee pipe, causing
+        # zombie tee processes, fd leaks, and permanent stderr corruption.
+        old_handler = signal.signal(signal.SIGALRM, signal.SIG_IGN)
+        try:
+            for stream in self._streams:
+                fd = stream.fileno()
+                stream.flush()
+                os.dup2(self._stream_copy[fd].fileno(), fd)
+                self._stream_copy[fd].close()
+            if self._tee.stdin:
+                self._tee.stdin.close()
+            self._tee.kill()
+            self._tee.wait()
+        finally:
+            signal.signal(signal.SIGALRM, old_handler)
 
     def get_output(self) -> bytes:
         self._output_collector_file.seek(0)


### PR DESCRIPTION
## Fix race condition in OutputRedirector cleanup causing fd corruption during timeouts

### Summary
Fix a signal interruption race condition in `OutputRedirector.__exit__()` that can corrupt `stdout`/`stderr` file descriptors when `timeout_decorator` raises `TimeoutError` via `SIGALRM` during cleanup.

### Problem
If `SIGALRM` fires while `__exit__()` is restoring file descriptors using `os.dup2`, the cleanup sequence can be interrupted between restoring `stdout` and `stderr`. This leaves `stderr` pointing to the dead `tee` pipe and prevents the remaining cleanup steps from running.

This leads to:
- zombie `tee` processes
- broken `stderr` causing lost logs or `BrokenPipeError`
- file descriptor leaks across retries
- eventual worker crashes with `Too many open files`

### Fix
Temporarily block `SIGALRM` during the critical cleanup section of `OutputRedirector.__exit__()` so the file descriptor restoration and process cleanup complete atomically.

The original signal handler is restored after cleanup.

### Impact
- prevents stdout/stderr corruption
- prevents zombie tee processes
- avoids fd leaks during retries
- ensures logs are preserved for timed out tasks