### PR TITLE
Implement parameter minimization to SqlInjectionDetector

### DIFF
--- a/artemis/config.py
+++ b/artemis/config.py
@@ -1117,6 +1117,10 @@ class Config:
                 bool,
                 "Whether to display only the first SQL injection and stop scanning.",
             ] = get_config("SQL_INJECTION_STOP_ON_FIRST_MATCH", default=True, cast=bool)
+            SQL_INJECTION_MINIMAL_PARAMS_MAX_LEN: Annotated[
+                int,
+                "Maximum number of parameters kept after SQLi parameter minimization.",
+            ] = get_config("SQL_INJECTION_MINIMAL_PARAMS_MAX_LEN", default=5, cast=int)
             SQL_INJECTION_NUM_RETRIES_TIME_BASED: Annotated[
                 int,
                 "How many times to re-check whether long request duration with inject (and short without inject) is indeed a vulnerability or a random fluctuation ",

--- a/artemis/modules/sql_injection_detector.py
+++ b/artemis/modules/sql_injection_detector.py
@@ -137,7 +137,8 @@ class SqlInjectionDetector(ArtemisBase):
     ) -> List[str]:
         """
         Try to find the minimal set of parameters that still triggers SQLi. Currently minimizes to single parameters only.
-        Falls back to original params if none work individually.
+        Falls back to original params if none work individually. When minimized parameters are found,
+        the result is capped to SQL_INJECTION_MINIMAL_PARAMS_MAX_LEN.
         """
         if minimization_mode == "error" and baseline_payload is None:
             raise ValueError("baseline_payload is required for error-based minimization")
@@ -175,14 +176,17 @@ class SqlInjectionDetector(ArtemisBase):
                 minimal_params.append(param)
 
         if minimal_params:
+            capped_minimal_params = minimal_params[
+                : Config.Modules.SqlInjectionDetector.SQL_INJECTION_MINIMAL_PARAMS_MAX_LEN
+            ]
             mode_label = "error-based" if minimization_mode == "error" else "time-based"
             self.log.info(
                 "SQLi %s parameter minimization: %s -> %s",
                 mode_label,
                 params,
-                minimal_params,
+                capped_minimal_params,
             )
-            return minimal_params
+            return capped_minimal_params
 
         # fallback if no single param triggers SQLi
         return params

--- a/test/modules/test_sql_injection_detector.py
+++ b/test/modules/test_sql_injection_detector.py
@@ -1,5 +1,6 @@
 # type: ignore
 from test.base import ArtemisModuleTestCase
+from unittest.mock import patch
 
 from karton.core import Task
 
@@ -137,3 +138,35 @@ class MysqlSqlInjectionDetectorTestCase(ArtemisModuleTestCase):
                 url_to_headers_vuln, http_requests.get(url_to_headers_vuln, headers={"User-Agent": "'"})
             )
         )
+
+
+class SqlInjectionParameterMinimizationTestCase(ArtemisModuleTestCase):
+    karton_class = SqlInjectionDetector
+
+    def test_minimize_parameters_caps_error_mode(self) -> None:
+        params = ["a", "b", "c", "d", "e", "f", "g"]
+
+        def mocked_create_url(url: str, payload: str, param_batch: tuple[str, ...], use_change_url_params: bool) -> str:
+            return f"{param_batch[0]}::{payload}"
+
+        def mocked_contains_error(url: str, response: object) -> str | None:
+            param_name, payload = url.split("::", maxsplit=1)
+            if payload == "'\"" and param_name in {"a", "b", "c", "d", "e", "f"}:
+                return "error"
+            return None
+
+        with patch("artemis.config.Config.Modules.SqlInjectionDetector") as mocked_config:
+            mocked_config.SQL_INJECTION_MINIMAL_PARAMS_MAX_LEN = 5
+            with patch.object(self.karton, "_create_injected_url", side_effect=mocked_create_url):
+                with patch.object(self.karton, "contains_error", side_effect=mocked_contains_error):
+                    with patch.object(self.karton, "forgiving_http_get", return_value=None):
+                        minimal_params = self.karton.minimize_parameters(
+                            url="http://example.com/login",
+                            params=params,
+                            payload="'\"",
+                            baseline_payload="-1",
+                            use_change_url_params=True,
+                            minimization_mode="error",
+                        )
+
+        self.assertEqual(minimal_params, ["a", "b", "c", "d", "e"])


### PR DESCRIPTION
Closes #2410 

This PR implements parameter minimization for generated SQLi PoCs.

Before the change, when SQL injection (error-based or time-based) was detected, the PoC URL contained the full injected parameter batch, which often made it unnecessarily long and noisy. After detection, the module now re-tests each parameter individually and keeps only those that independently reproduce the issue. If none of them works alone, it falls back to the original batch to avoid changing detection behavior.

The same minimization approach is applied in both query-parameter handling paths (URLs with existing parameters and URLs without them), so reported PoCs stay focused while preserving current detection logic.

The tests were updated accordingly to validate behavior.
