### PR TITLE
Add Artemis-modules-extra folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ cython_debug/
 docker-compose.dev.yaml
 karton-logs
 output
+
+# Artemis additional modules
+Artemis-modules-extra


### PR DESCRIPTION
Since the folder exists as a separate repo due to licensing reasons, it will never be part of the main repo, so there's no point in tracking it. This just keeps git status clean for contributors who have it cloned locally