### PR TITLE
add delay to @retry in test_simple to stabilize WordPress bruter test

### DIFF
--- a/test/modules/test_wordpress_bruter.py
+++ b/test/modules/test_wordpress_bruter.py
@@ -11,7 +11,7 @@ class WordPressBruterTest(ArtemisModuleTestCase):
     # The reason for ignoring mypy error is https://github.com/CERT-Polska/karton/issues/201
     karton_class = WordPressBruter  # type: ignore
 
-    @retry(tries=3)
+    @retry(tries=3, delay=10)
     def test_simple(self) -> None:
         self.setUp()  # @retry() will not rerun setUp
 


### PR DESCRIPTION
Fixes part of #2465.
test_simple in test_wordpress_bruter.py already had @retry(tries=3) but with no delay, all three retries fired instantly — before the test-wordpress-easy-password Docker container had finished starting. Adding delay=10 gives the container 10 seconds between retries to become ready.