### PR TITLE
add retry to test_simple in domain expiration scanner to handle WHOIS flakiness

### DIFF
--- a/test/modules/test_domain_expiration_scanner.py
+++ b/test/modules/test_domain_expiration_scanner.py
@@ -3,6 +3,7 @@ from test.base import ArtemisModuleTestCase
 from unittest.mock import patch
 
 from karton.core import Task
+from retry import retry   
 
 from artemis.binds import TaskStatus, TaskType
 from artemis.modules.domain_expiration_scanner import DomainExpirationScanner
@@ -10,7 +11,8 @@ from artemis.modules.domain_expiration_scanner import DomainExpirationScanner
 
 class TestDomainExpirationScanner(ArtemisModuleTestCase):
     karton_class = DomainExpirationScanner  # type: ignore
-
+    
+    @retry(tries=3, delay=10)  
     def test_simple(self) -> None:
         task = Task(
             {"type": TaskType.DOMAIN.value},


### PR DESCRIPTION
Fixes part of #2465.
test_simple in test_domain_expiration_scanner.py calls perform_whois_or_sleep which makes a live external WHOIS request for google.com with no retry logic. WHOIS servers can be slow or rate-limit requests causing random test failures. Adding @retry(tries=3, delay=10) gives the test three attempts with a 10-second gap between them.
