### PR TITLE
fix: robots parser crashes on allow/disallow rule before user-agent line

### DIFF
--- a/artemis/modules/robots.py
+++ b/artemis/modules/robots.py
@@ -62,11 +62,13 @@ class RobotsScanner(ArtemisBase):
                 current_group.user_agents.append(agent_match.group(1))
             elif allow_path := self._parse_rule(line, RE_ALLOW):
                 if len(current_group.user_agents) == 0:
-                    raise ValueError("'allow' rule before start group line")
+                    self.log.warning("Skipping 'allow' rule before any 'user-agent' line in robots.txt: %s", line)
+                    continue
                 current_group.allow.append(allow_path)
             elif disallow_path := self._parse_rule(line, RE_DISALLOW):
                 if len(current_group.user_agents) == 0:
-                    raise ValueError("'disallow' rule before start group line")
+                    self.log.warning("Skipping 'disallow' rule before any 'user-agent' line in robots.txt: %s", line)
+                    continue
                 current_group.disallow.append(disallow_path)
 
         if len(current_group.user_agents) > 0:

--- a/test/modules/test_robots.py
+++ b/test/modules/test_robots.py
@@ -1,5 +1,8 @@
+import logging
+import unittest
 from test.base import ArtemisModuleTestCase
 from typing import NamedTuple
+from unittest.mock import MagicMock
 
 from karton.core import Task
 
@@ -56,3 +59,42 @@ class RobotsTest(ArtemisModuleTestCase):
                 [path["url"] for path in call.kwargs["data"]["result"]["found_urls"]],
                 ["http://test-robots-service:80/secret-url/"],
             )
+
+
+class RobotsParserTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.scanner = RobotsScanner.__new__(RobotsScanner)
+        self.scanner.log = MagicMock(spec=logging.Logger)
+
+    def test_normal_robots_txt(self) -> None:
+        content = "User-agent: *\nDisallow: /admin/\nAllow: /public/\n"
+        groups = self.scanner._parse_robots(content)
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0].user_agents, ["*"])
+        self.assertEqual(groups[0].disallow, ["/admin/"])
+        self.assertEqual(groups[0].allow, ["/public/"])
+
+    def test_multiple_user_agents_in_group(self) -> None:
+        content = "User-agent: Googlebot\nUser-agent: Bingbot\nDisallow: /private/\n"
+        groups = self.scanner._parse_robots(content)
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0].user_agents, ["Googlebot", "Bingbot"])
+        self.assertEqual(groups[0].disallow, ["/private/"])
+
+    def test_disallow_rule_before_user_agent_does_not_crash(self) -> None:
+        content = "Disallow: /early/\nUser-agent: *\nDisallow: /admin/\n"
+        groups = self.scanner._parse_robots(content)
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0].disallow, ["/admin/"])
+        self.scanner.log.warning.assert_called()
+
+    def test_allow_rule_before_user_agent_does_not_crash(self) -> None:
+        content = "Allow: /early/\nUser-agent: *\nDisallow: /private/\n"
+        groups = self.scanner._parse_robots(content)
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(groups[0].disallow, ["/private/"])
+        self.scanner.log.warning.assert_called()
+
+    def test_empty_content(self) -> None:
+        groups = self.scanner._parse_robots("")
+        self.assertEqual(groups, [])


### PR DESCRIPTION
## Problem

`_parse_robots` in `artemis/modules/robots.py` raised `ValueError` when it encountered an `Allow:` or `Disallow:` directive before any `User-agent:` line. That exception was not caught anywhere in `download_robots` or `run`, so the entire task died silently.

Some real-world robots.txt files include directives before the first `User-agent` block. Serving a crash instead of a warning for a malformed-but-common input is too strict.

## Fix

Replace the `raise ValueError(...)` with `self.log.warning(...)` and `continue`. The parser now skips the orphan rule, logs what it found, and continues processing the rest of the file normally. Valid groups that follow are still parsed correctly.

## Tests

Added `RobotsParserTest` to `test/modules/test_robots.py` covering:

- normal robots.txt parses correctly
- multiple `User-agent` values in one group
- `Disallow:` before `User-agent` does not crash and logs a warning
- `Allow:` before `User-agent` does not crash and logs a warning
- empty content returns an empty list