### PR TITLE
Fix lost stdout/stderr output on failed task attempts

### DIFF
--- a/artemis/module_base.py
+++ b/artemis/module_base.py
@@ -706,6 +706,7 @@ class ArtemisBase(Karton):
                             break
 
                     except Exception:
+                        output += output_redirector.get_output()
                         if i < self.num_retries - 1:
                             self.log.exception("Task(s) failed, retrying (try %d/%d)", i + 1, self.num_retries)
                         else:


### PR DESCRIPTION
## Fix: Preserve task logs when module execution fails

### Summary
`ArtemisBase.process_multiple` silently discards captured stdout/stderr when a task attempt raises an exception. Because `OutputRedirector.get_output()` is only called on the success path, any logs generated before a crash are lost. As a result, failed tasks are stored in the database with empty or incomplete logs.

This PR ensures that output is collected in both the success and exception paths so diagnostic logs from failed attempts are preserved.

### Problem
When a task fails inside the `with OutputRedirector:` block, execution jumps directly to the `except` block and skips:

```python
output += output_redirector.get_output()
