### PR TITLE
Fix nuclei batch crash on unmatched findings

### DIFF
--- a/artemis/modules/nuclei.py
+++ b/artemis/modules/nuclei.py
@@ -707,7 +707,9 @@ class Nuclei(ArtemisBase):
                         findings_per_task[task.uid].append(finding)
                         found = True
                         break
-                assert found, "Cannot match finding: %s" % finding
+                if not found:
+                    self.log.warning("Cannot match finding to any task, assigning to first task: %s", finding)
+                    findings_per_task[tasks[0].uid].append(finding)
 
         for task in tasks:
             result = []


### PR DESCRIPTION
## Fix: Prevent batch crash on unmatched Nuclei findings

### Problem
`Nuclei.run_multiple()` currently uses an assertion when a finding cannot be matched to a task:

```python
assert found, "Cannot match finding: %s" % finding