### PR TITLE
Fix silent subprocess failures in API scanner

### DIFF
--- a/artemis/modules/api_scanner.py
+++ b/artemis/modules/api_scanner.py
@@ -16,6 +16,7 @@ from artemis.module_base import ArtemisBase
 from artemis.modules.data.api_scanner_data import COMMON_SPEC_PATHS, VULN_DETAILS_MAP
 from artemis.sql_injection_data import SQL_ERROR_MESSAGES
 from artemis.task_utils import get_target_url
+from artemis.utils import check_output_log_on_error
 
 
 class APIResult(BaseModel):
@@ -42,11 +43,11 @@ class APIScanner(ArtemisBase):
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
         if not os.path.exists("/offat"):
-            subprocess.call(["git", "clone", "https://github.com/OWASP/OFFAT", "/offat"])
+            subprocess.check_call(["git", "clone", "https://github.com/OWASP/OFFAT", "/offat"])
             patch_file_path = os.path.join(os.path.dirname(__file__), "data/offat/offat_artemis.patch")
-            subprocess.call(["git", "-C", "/offat", "apply", patch_file_path])
+            subprocess.check_call(["git", "-C", "/offat", "apply", patch_file_path])
 
-        subprocess.call(["pip", "install", "-e", "/offat/src"])
+        subprocess.check_call(["pip", "install", "-e", "/offat/src"])
 
     def discover_spec(self, base_url: str) -> Tuple[str, ...]:
         """Try to discover OpenAPI/Swagger specification from common paths."""
@@ -76,7 +77,7 @@ class APIScanner(ArtemisBase):
         return "", ""
 
     def scan(self, target_api_specification: str) -> Dict[str, Any]:
-        output_file = "/tmp/output.json"
+        output_file = f"/tmp/offat_output_{os.urandom(8).hex()}.json"
 
         offat_cmd = [
             "offat",
@@ -97,14 +98,19 @@ class APIScanner(ArtemisBase):
         if self.requests_per_second_for_current_tasks:
             offat_cmd.extend(["-rl", str(self.requests_per_second_for_current_tasks)])
 
-        subprocess.call(offat_cmd)
+        try:
+            check_output_log_on_error(offat_cmd, self.log)
 
-        with open(output_file, encoding="utf-8") as f:
-            file_contents = f.read()
+            with open(output_file, encoding="utf-8") as f:
+                file_contents = f.read()
 
-        report: Dict[str, Any] = json.loads(file_contents)
-        os.unlink(output_file)
-        return report
+            report: Dict[str, Any] = json.loads(file_contents)
+            return report
+        finally:
+            try:
+                os.unlink(output_file)
+            except FileNotFoundError:
+                pass
 
     def run(self, current_task: Task) -> None:
         url = get_target_url(current_task)


### PR DESCRIPTION
## Fix: Properly Handle OFFAT Failures in API Scanner

### Problem
The API scanner was using `subprocess.call()` to execute OFFAT without checking the return code. If OFFAT failed, execution still continued and attempted to read `/tmp/output.json`. This could lead to:

- Missing vulnerability results when OFFAT fails
- `FileNotFoundError` when the output file is not created
- Stale results being read from a previous scan due to the hardcoded `/tmp/output.json` path
- Silent initialization failures if `git clone`, `git apply`, or `pip install` fail in `__init__`

### Changes
- Replaced `subprocess.call()` with `check_output_log_on_error()` when executing OFFAT to properly capture failures and logs.
- Switched from a shared `/tmp/output.json` to a unique temporary output file per scan.
- Added a `finally` block to ensure the output file is always cleaned up.
- Replaced initialization `subprocess.call()` with `subprocess.check_call()` so OFFAT setup failures are detected during module startup.

### Impact
- OFFAT execution failures are now properly detected and logged.
- Prevents stale scan results from being attributed to the wrong target.
- Ensures initialization issues are surfaced early instead of silently breaking scans.