### PR TITLE
Fix distributed lock corruption caused by unconditional Redis.delete in ResourceLock.release

### DIFF
--- a/artemis/resource_lock.py
+++ b/artemis/resource_lock.py
@@ -30,6 +30,18 @@ LOCKS_TO_SUSTAIN_LOCK = threading.Lock()
 
 REDIS = Redis.from_url(Config.Data.REDIS_CONN_STR)
 
+# Lua script for atomic check-and-delete: only deletes the key if its value matches the caller's lock ID.
+# This prevents a process from releasing a lock that was re-acquired by a different process.
+_RELEASE_SCRIPT = REDIS.register_script(
+    """
+    if redis.call("get", KEYS[1]) == ARGV[1] then
+        return redis.call("del", KEYS[1])
+    else
+        return 0
+    end
+    """
+)
+
 
 def sustain_locks() -> None:
     while True:
@@ -56,9 +68,9 @@ class ResourceLock:
     @staticmethod
     def release_all_locks(logger: Logger) -> None:
         with LOCKS_TO_SUSTAIN_LOCK:
-            for lock in list(LOCKS_TO_SUSTAIN.keys()):
-                logger.info(f"Releasing lock: {lock} -> {LOCKS_TO_SUSTAIN[lock]}")
-                REDIS.delete(lock)
+            for lock_name, lock_lid in list(LOCKS_TO_SUSTAIN.items()):
+                logger.info(f"Releasing lock: {lock_name} -> {lock_lid}")
+                _RELEASE_SCRIPT(keys=[lock_name], args=[lock_lid])
             LOCKS_TO_SUSTAIN.clear()
 
     def acquire(self) -> None:
@@ -84,7 +96,9 @@ class ResourceLock:
         with LOCKS_TO_SUSTAIN_LOCK:
             if self.res_name in LOCKS_TO_SUSTAIN:
                 del LOCKS_TO_SUSTAIN[self.res_name]
-        REDIS.delete(self.res_name)
+        # Atomically check that we still own the lock before deleting, so we never
+        # release a lock that was re-acquired by a different process/object.
+        _RELEASE_SCRIPT(keys=[self.res_name], args=[self.lid])
 
     def __enter__(self) -> None:
         self.acquire()

--- a/test/unit/test_resource_lock.py
+++ b/test/unit/test_resource_lock.py
@@ -8,6 +8,7 @@ from artemis.resource_lock import (
     LOCKS_TO_SUSTAIN_LOCK,
     FailedToAcquireLockException,
     ResourceLock,
+    _RELEASE_SCRIPT,
 )
 
 
@@ -25,21 +26,21 @@ class TestReleaseAllLocks(unittest.TestCase):
         with LOCKS_TO_SUSTAIN_LOCK:
             LOCKS_TO_SUSTAIN.clear()
 
-    @patch("artemis.resource_lock.REDIS")
-    def test_release_all_locks_deletes_redis_keys(self, mock_redis: MagicMock) -> None:
-        """release_all_locks must call REDIS.delete for every held lock."""
+    @patch("artemis.resource_lock._RELEASE_SCRIPT")
+    def test_release_all_locks_deletes_redis_keys(self, mock_release_script: MagicMock) -> None:
+        """release_all_locks must call the release script for every held lock."""
         with LOCKS_TO_SUSTAIN_LOCK:
             LOCKS_TO_SUSTAIN["lock-1.2.3.4"] = "uuid-1"
             LOCKS_TO_SUSTAIN["lock-5.6.7.8"] = "uuid-2"
 
         ResourceLock.release_all_locks(self.logger)
 
-        mock_redis.delete.assert_any_call("lock-1.2.3.4")
-        mock_redis.delete.assert_any_call("lock-5.6.7.8")
-        self.assertEqual(mock_redis.delete.call_count, 2)
+        mock_release_script.assert_any_call(keys=["lock-1.2.3.4"], args=["uuid-1"])
+        mock_release_script.assert_any_call(keys=["lock-5.6.7.8"], args=["uuid-2"])
+        self.assertEqual(mock_release_script.call_count, 2)
 
-    @patch("artemis.resource_lock.REDIS")
-    def test_release_all_locks_clears_sustain_dict(self, mock_redis: MagicMock) -> None:
+    @patch("artemis.resource_lock._RELEASE_SCRIPT")
+    def test_release_all_locks_clears_sustain_dict(self, mock_release_script: MagicMock) -> None:
         """After release_all_locks, LOCKS_TO_SUSTAIN must be empty so the
         heartbeat thread stops refreshing the deleted keys."""
         with LOCKS_TO_SUSTAIN_LOCK:
@@ -51,17 +52,18 @@ class TestReleaseAllLocks(unittest.TestCase):
         with LOCKS_TO_SUSTAIN_LOCK:
             self.assertEqual(len(LOCKS_TO_SUSTAIN), 0)
 
-    @patch("artemis.resource_lock.REDIS")
-    def test_release_all_locks_noop_when_empty(self, mock_redis: MagicMock) -> None:
+    @patch("artemis.resource_lock._RELEASE_SCRIPT")
+    def test_release_all_locks_noop_when_empty(self, mock_release_script: MagicMock) -> None:
         """Calling release_all_locks with no held locks must not raise."""
         ResourceLock.release_all_locks(self.logger)
 
-        mock_redis.delete.assert_not_called()
+        mock_release_script.assert_not_called()
         with LOCKS_TO_SUSTAIN_LOCK:
             self.assertEqual(len(LOCKS_TO_SUSTAIN), 0)
 
+    @patch("artemis.resource_lock._RELEASE_SCRIPT")
     @patch("artemis.resource_lock.REDIS")
-    def test_acquire_then_release_all_cleans_up(self, mock_redis: MagicMock) -> None:
+    def test_acquire_then_release_all_cleans_up(self, mock_redis: MagicMock, mock_release_script: MagicMock) -> None:
         """Simulates a lock leak: acquire a lock, then call release_all_locks
         instead of the normal release path. The lock must be fully cleaned up."""
         mock_redis.set.return_value = True  # simulate successful SET NX
@@ -76,12 +78,13 @@ class TestReleaseAllLocks(unittest.TestCase):
         # Simulate the safety-net cleanup
         ResourceLock.release_all_locks(self.logger)
 
-        mock_redis.delete.assert_any_call("lock-leaked-target")
+        mock_release_script.assert_any_call(keys=["lock-leaked-target"], args=[lock.lid])
         with LOCKS_TO_SUSTAIN_LOCK:
             self.assertNotIn("lock-leaked-target", LOCKS_TO_SUSTAIN)
 
+    @patch("artemis.resource_lock._RELEASE_SCRIPT")
     @patch("artemis.resource_lock.REDIS")
-    def test_release_all_locks_is_thread_safe(self, mock_redis: MagicMock) -> None:
+    def test_release_all_locks_is_thread_safe(self, mock_redis: MagicMock, mock_release_script: MagicMock) -> None:
         """release_all_locks must not corrupt state when called concurrently
         with lock acquire/release on other threads."""
         mock_redis.set.return_value = True
@@ -137,8 +140,9 @@ class TestResourceLockBasics(unittest.TestCase):
         with LOCKS_TO_SUSTAIN_LOCK:
             self.assertIn("lock-test-target", LOCKS_TO_SUSTAIN)
 
+    @patch("artemis.resource_lock._RELEASE_SCRIPT")
     @patch("artemis.resource_lock.REDIS")
-    def test_release_removes_from_sustain_dict_and_redis(self, mock_redis: MagicMock) -> None:
+    def test_release_removes_from_sustain_dict_and_redis(self, mock_redis: MagicMock, mock_release_script: MagicMock) -> None:
         mock_redis.set.return_value = True
 
         lock = ResourceLock("lock-test-target", max_tries=1)
@@ -147,7 +151,7 @@ class TestResourceLockBasics(unittest.TestCase):
 
         with LOCKS_TO_SUSTAIN_LOCK:
             self.assertNotIn("lock-test-target", LOCKS_TO_SUSTAIN)
-        mock_redis.delete.assert_called_with("lock-test-target")
+        mock_release_script.assert_called_with(keys=["lock-test-target"], args=[lock.lid])
 
     @patch("artemis.resource_lock.REDIS")
     def test_failed_acquire_raises(self, mock_redis: MagicMock) -> None:
@@ -161,8 +165,9 @@ class TestResourceLockBasics(unittest.TestCase):
         with LOCKS_TO_SUSTAIN_LOCK:
             self.assertNotIn("lock-contended", LOCKS_TO_SUSTAIN)
 
+    @patch("artemis.resource_lock._RELEASE_SCRIPT")
     @patch("artemis.resource_lock.REDIS")
-    def test_context_manager_releases_on_exit(self, mock_redis: MagicMock) -> None:
+    def test_context_manager_releases_on_exit(self, mock_redis: MagicMock, mock_release_script: MagicMock) -> None:
         mock_redis.set.return_value = True
 
         with ResourceLock("lock-ctx", max_tries=1):
@@ -171,7 +176,7 @@ class TestResourceLockBasics(unittest.TestCase):
 
         with LOCKS_TO_SUSTAIN_LOCK:
             self.assertNotIn("lock-ctx", LOCKS_TO_SUSTAIN)
-        mock_redis.delete.assert_called_with("lock-ctx")
+        mock_release_script.assert_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Fix: Prevent distributed lock corruption caused by unconditional Redis.delete

### Problem
`ResourceLock.release()` unconditionally called `REDIS.delete(self.res_name)` without verifying that the caller still owns the lock.

This allowed a deterministic double-release scenario where:
1. One object releases a lock it never acquired.
2. Another process legitimately acquires the same lock.
3. The original object later deletes the Redis key during cleanup.

As a result, one module process could destroy another process's lock, breaking the distributed locking guarantees.

### Impact
This could cause multiple module containers to scan the same destination concurrently, leading to:
- Rate-limit violations against targets
- WAF triggering and scanner IP blocking
- Duplicate scan results
- Corruption of scan task coordination across modules

### Fix
Replace the unconditional `REDIS.delete` with an ownership-aware atomic check-and-delete using a Lua script.

The lock is now removed **only if the stored Redis value matches the caller's lock ID (`lid`)**, preventing cross-process lock deletion.

### Changes
- Added an atomic Redis Lua script for safe lock release
- Updated `ResourceLock.release()` to use ownership-aware deletion
- Updated `ResourceLock.release_all_locks()` to respect lock ownership
- Adjusted unit tests to mock the release script instead of `REDIS.delete`

This preserves the existing architecture while restoring correct distributed lock semantics.