### PR TITLE
fix: add pool_pre_ping=True to prevent stale DB connections

### DIFF
--- a/artemis/db.py
+++ b/artemis/db.py
@@ -239,7 +239,9 @@ class DB:
         self.logger = build_logger(__name__)
 
         self._engine = create_engine(
-            Config.Data.POSTGRES_CONN_STR, json_serializer=functools.partial(json.dumps, cls=JSONEncoderAdditionalTypes)
+            Config.Data.POSTGRES_CONN_STR,
+            json_serializer=functools.partial(json.dumps, cls=JSONEncoderAdditionalTypes),
+            pool_pre_ping=True,
         )
         self.session = sessionmaker(bind=self._engine)
 
@@ -723,7 +725,9 @@ class TestDB:
         self.logger = build_logger(__name__)
 
         self._engine = create_engine(
-            Config.Data.POSTGRES_CONN_STR, json_serializer=functools.partial(json.dumps, cls=JSONEncoderAdditionalTypes)
+            Config.Data.POSTGRES_CONN_STR,
+            json_serializer=functools.partial(json.dumps, cls=JSONEncoderAdditionalTypes),
+            pool_pre_ping=True,
         )
         self.session = sessionmaker(bind=self._engine)
 


### PR DESCRIPTION
## Fix: Enable `pool_pre_ping` for SQLAlchemy engines

### Problem
The SQLAlchemy engines in `artemis/db.py` are created without `pool_pre_ping=True`.  
When PostgreSQL drops idle connections (e.g., due to container restarts or timeouts), the connection pool may return a stale connection, causing `sqlalchemy.exc.OperationalError` on the next query.

This particularly affects long-running services with long idle periods (e.g., cleanup and autoarchiver workers).

### Fix
Enable connection health checks by adding `pool_pre_ping=True` to both `create_engine()` calls:

- `DB.__init__`
- `TestDB.__init__`

### Result
SQLAlchemy now validates pooled connections before use and automatically replaces stale ones, preventing crashes caused by dropped PostgreSQL connections.