### PR TITLE
fix: handle missing previous export output in report generation

### DIFF
--- a/artemis/reporting/task_handler.py
+++ b/artemis/reporting/task_handler.py
@@ -32,11 +32,17 @@ def handle_single_task(report_generation_task: ReportGenerationTask) -> Path:
         # We want to treat only the reports visible from web as already known
         for existing_task in db.list_report_generation_tasks():
             if existing_task.output_location:
-                shutil.copy(
-                    Path(existing_task.output_location) / "advanced" / "output.json",
-                    Path(previous_reports_directory)
-                    / (hashlib.sha256(existing_task.output_location.encode("ascii")).hexdigest() + ".json"),
-                )
+                try:
+                    shutil.copy(
+                        Path(existing_task.output_location) / "advanced" / "output.json",
+                        Path(previous_reports_directory)
+                        / (hashlib.sha256(existing_task.output_location.encode("ascii")).hexdigest() + ".json"),
+                    )
+                except FileNotFoundError:
+                    logger.warning(
+                        "Previous export output missing at %s, skipping for deduplication",
+                        existing_task.output_location,
+                    )
     else:
         previous_reports_directory = None
 


### PR DESCRIPTION
## Summary
Prevents report generation from failing when previous export outputs are missing on disk while `skip_previously_exported=True`.

## Problem
`handle_single_task` copies `advanced/output.json` from all historical exports returned by `db.list_report_generation_tasks()`.  
If any previous export directory has been removed (disk cleanup, migration, or bind mount reset), `shutil.copy` raises `FileNotFoundError`, causing the entire report generation task to fail.

## Fix
Wrap the `shutil.copy` operation in a `try/except FileNotFoundError` block and skip missing exports while logging a warning.

## Result
- Prevents pipeline failure due to stale DB records
- Deduplication still works for exports whose outputs exist
- Missing historical exports are safely ignored