### PR TITLE
Fix global log handler side-effect causing permanent log suppression after export

### DIFF
--- a/artemis/reporting/export/main.py
+++ b/artemis/reporting/export/main.py
@@ -175,63 +175,67 @@ def export(
     skip_suspicious_reports: bool = False,
     include_only_results_since: Optional[datetime.datetime] = None,
 ) -> Path:
+    original_log_level = CONSOLE_LOG_HANDLER.level
     if silent:
         CONSOLE_LOG_HANDLER.setLevel(level=logging.ERROR)
-    blocklist = load_blocklist(Config.Miscellaneous.BLOCKLIST_FILE)
+    try:
+        blocklist = load_blocklist(Config.Miscellaneous.BLOCKLIST_FILE)
 
-    if previous_reports_directory:
-        previous_reports = load_previous_reports(previous_reports_directory)
-    else:
-        previous_reports = []
+        if previous_reports_directory:
+            previous_reports = load_previous_reports(previous_reports_directory)
+        else:
+            previous_reports = []
 
-    db = DB()
-    export_db_connector = DataLoader(
-        db, blocklist, language, tag, silent, include_only_results_since=include_only_results_since
-    )
-    timestamp = datetime.datetime.now()
-    export_data = build_export_data(
-        previous_reports,
-        tag,
-        language,
-        export_db_connector,
-        custom_template_arguments,
-        timestamp,
-        skip_suspicious_reports,
-    )
-    date_str = timestamp.isoformat(timespec="microseconds")
-    output_dir = OUTPUT_LOCATION / str(tag) / date_str
-    os.makedirs(output_dir)
-    os.makedirs(output_dir / "advanced")
+        db = DB()
+        export_db_connector = DataLoader(
+            db, blocklist, language, tag, silent, include_only_results_since=include_only_results_since
+        )
+        timestamp = datetime.datetime.now()
+        export_data = build_export_data(
+            previous_reports,
+            tag,
+            language,
+            export_db_connector,
+            custom_template_arguments,
+            timestamp,
+            skip_suspicious_reports,
+        )
+        date_str = timestamp.isoformat(timespec="microseconds")
+        output_dir = OUTPUT_LOCATION / str(tag) / date_str
+        os.makedirs(output_dir)
+        os.makedirs(output_dir / "advanced")
 
-    environment = create_environment()
-    install_translations_and_print_path(language, environment, output_dir, silent)
+        environment = create_environment()
+        install_translations_and_print_path(language, environment, output_dir, silent)
 
-    if not skip_hooks:
-        run_export_hooks(output_dir, export_data, silent)
+        if not skip_hooks:
+            run_export_hooks(output_dir, export_data, silent)
 
-    message_template = build_message_template_and_print_path(environment, output_dir, silent)
-    _build_messages_and_print_path(message_template, export_data, output_dir, silent)
-    _dump_export_data_and_print_path(export_data, output_dir, silent)
+        message_template = build_message_template_and_print_path(environment, output_dir, silent)
+        _build_messages_and_print_path(message_template, export_data, output_dir, silent)
+        _dump_export_data_and_print_path(export_data, output_dir, silent)
 
-    print_and_save_stats(export_data, output_dir, silent)
+        print_and_save_stats(export_data, output_dir, silent)
 
-    if silent:
-        print(output_dir)
+        if silent:
+            print(output_dir)
 
-    if verbose and not silent:
-        print_long_unseen_report_types(previous_reports + export_db_connector.reports)
+        if verbose and not silent:
+            print_long_unseen_report_types(previous_reports + export_db_connector.reports)
 
-        print("Available tags (and the counts of raw task results - not to be confused with vulnerabilities):")
-        if None in export_db_connector.tag_stats:
-            print(f"\tEmpty tag: {export_db_connector.tag_stats[None]}")  # type: ignore
+            print("Available tags (and the counts of raw task results - not to be confused with vulnerabilities):")
+            if None in export_db_connector.tag_stats:
+                print(f"\tEmpty tag: {export_db_connector.tag_stats[None]}")  # type: ignore
 
-        for tag in sorted([key for key in export_db_connector.tag_stats.keys() if key]):
-            print(f"\t{tag}: {export_db_connector.tag_stats[tag]}")
+            for tag in sorted([key for key in export_db_connector.tag_stats.keys() if key]):
+                print(f"\t{tag}: {export_db_connector.tag_stats[tag]}")
 
-    if not silent:
-        for alert in export_data.alerts:
-            print(termcolor.colored("ALERT:" + alert, color="red"))
-    return output_dir
+        if not silent:
+            for alert in export_data.alerts:
+                print(termcolor.colored("ALERT:" + alert, color="red"))
+        return output_dir
+    finally:
+        CONSOLE_LOG_HANDLER.setLevel(original_log_level)
 
 
 def export_cli(


### PR DESCRIPTION
### Fix: Prevent permanent global log suppression after report export

#### Problem
`export(silent=True)` permanently modifies the global `CONSOLE_LOG_HANDLER` log level to `ERROR` without restoring it.

Since this handler is a shared singleton used across the entire application, all `INFO`, `DEBUG`, and `WARNING` logs are suppressed after the first report generation. The autoreporter (which always calls `export(silent=True)`) loses all non-error observability for the rest of its lifecycle.

#### Impact
- Autoreporter appears idle in logs after first report
- Loss of critical operational signals:
  - Task pickup logs
  - Success confirmations
  - Memory usage reporting
  - General system visibility
- Only `ERROR` logs remain visible, hiding degraded states

#### Root Cause
Global log handler level is modified but never restored:
```python
if silent:
    CONSOLE_LOG_HANDLER.setLevel(logging.ERROR)
    
   original_log_level = CONSOLE_LOG_HANDLER.level
if silent:
    CONSOLE_LOG_HANDLER.setLevel(logging.ERROR)

try:
    # existing export logic
    ...
finally:
    CONSOLE_LOG_HANDLER.setLevel(original_log_level)