### PR TITLE
Add LFI parameter minimization cap and corresponding test

### DIFF
--- a/artemis/config.py
+++ b/artemis/config.py
@@ -1135,6 +1135,10 @@ class Config:
                 bool,
                 "Whether to display only the first LFI and stop scanning.",
             ] = get_config("LFI_STOP_ON_FIRST_MATCH", default=True, cast=bool)
+            LFI_MINIMAL_PARAMS_MAX_LEN: Annotated[
+                int,
+                "Maximum number of parameters kept after LFI parameter minimization.",
+            ] = get_config("LFI_MINIMAL_PARAMS_MAX_LEN", default=5, cast=int)
 
     @staticmethod
     def verify_each_variable_is_annotated() -> None:

--- a/artemis/modules/lfi_detector.py
+++ b/artemis/modules/lfi_detector.py
@@ -88,12 +88,13 @@ class LFIDetector(ArtemisBase):
                 minimal_params.append(param)
 
         if minimal_params:
+            capped_minimal_params = minimal_params[: Config.Modules.LFIDetector.LFI_MINIMAL_PARAMS_MAX_LEN]
             self.log.info(
                 "LFI parameter minimization: %s -> %s",
                 params,
-                minimal_params,
+                capped_minimal_params,
             )
-            return minimal_params
+            return capped_minimal_params
 
         # fallback if no single param triggers LFI
         return params

--- a/test/modules/test_lfi_detector.py
+++ b/test/modules/test_lfi_detector.py
@@ -19,6 +19,7 @@ class LFIDetectorTestCase(ArtemisModuleTestCase):
 
         with patch("artemis.config.Config.Modules.LFIDetector") as mocked_config:
             mocked_config.LFI_STOP_ON_FIRST_MATCH = False
+            mocked_config.LFI_MINIMAL_PARAMS_MAX_LEN = 5
             self.run_task(task)
             (call,) = self.mock_db.save_task_result.call_args_list
 
@@ -41,3 +42,33 @@ class LFIDetectorTestCase(ArtemisModuleTestCase):
                 "%0a/bin/cat%20/etc/passwd",
                 call.kwargs["status_reason"],
             )
+
+
+class LFIParameterMinimizationTestCase(ArtemisModuleTestCase):
+    karton_class = LFIDetector
+
+    def test_minimize_parameters_caps(self) -> None:
+        params = ["a", "b", "c", "d", "e", "f", "g"]
+
+        def mocked_create_url(url: str, param_batch: list[str], payload: str) -> str:
+            return f"{param_batch[0]}::{payload}"
+
+        def mocked_indicator(_original_response: object, response: object) -> str | None:
+            param_name = str(response).split("::", maxsplit=1)[0]
+            if param_name in {"a", "b", "c", "d", "e", "f"}:
+                return "/etc/passwd"
+            return None
+
+        with patch("artemis.config.Config.Modules.LFIDetector") as mocked_config:
+            mocked_config.LFI_MINIMAL_PARAMS_MAX_LEN = 5
+            with patch.object(self.karton, "create_url_with_batch_payload", side_effect=mocked_create_url):
+                with patch.object(self.karton, "http_get", side_effect=lambda test_url: test_url):
+                    with patch.object(self.karton, "contains_lfi_indicator", side_effect=mocked_indicator):
+                        minimal_params = self.karton.minimize_parameters(
+                            url="http://example.com/login",
+                            params=params,
+                            payload="../../etc/passwd",
+                            original_response=object(),
+                        )
+
+        self.assertEqual(minimal_params, ["a", "b", "c", "d", "e"])

--- a/test/reporting/test_lfi_detector_integration.py
+++ b/test/reporting/test_lfi_detector_integration.py
@@ -24,6 +24,7 @@ class LFIDetectorIntegrationTest(BaseReportingTest):
     def test_reporting_lfi_and_rce(self) -> None:
         with patch("artemis.config.Config.Modules.LFIDetector") as mocked_config:
             mocked_config.LFI_STOP_ON_FIRST_MATCH = False
+            mocked_config.LFI_MINIMAL_PARAMS_MAX_LEN = 5
             data = self.obtain_http_task_result("lfi_detector", "test-apache-with-lfi-and-rce")
             message = self.task_result_to_message(data)
 


### PR DESCRIPTION
Closes #2524 

Add a configurable cap on the number of parameters retained after LFI parameter minimization, ensuring that the minimization process doesn't return a large/long URL