### PR TITLE
Increase Grafana healthcheck start_period to 60s

### DIFF
--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -276,7 +276,7 @@ services:
       interval: 5s
       timeout: 10s
       retries: 12
-      start_period: 30s
+      start_period: 60s
 
 volumes:
   data-test:


### PR DESCRIPTION
Every time I ran the compose stack for local testing, it would randomly fail with :
<img width="1816" height="425" alt="image" src="https://github.com/user-attachments/assets/508dc01b-2ee2-4e86-8736-23ee8d1be42e" />
This happened because the `test` service depends on `test-grafana` being healthy before it can start. But during cold startup, Grafana sometimes wasn't ready fast enough when docker compose checked its health, so it got marked as unhealthy.

#2465 