### PR TITLE
fix: close SSH connections on failed auth to prevent socket leak

### DIFF
--- a/artemis/modules/ssh_bruter.py
+++ b/artemis/modules/ssh_bruter.py
@@ -59,8 +59,8 @@ class SSHBruter(ArtemisBase):
 
         result = SSHBruterResult()
         for username, password in BRUTE_CREDENTIALS:
+            client = paramiko.client.SSHClient()
             try:
-                client = paramiko.client.SSHClient()
                 client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
                 self.log.info(
                     "Attempting connect: hostname=%s, port=%s, username=%s, password=%s", host, port, username, password
@@ -72,7 +72,6 @@ class SSHBruter(ArtemisBase):
                     lambda: client.connect(hostname=host, port=port, username=username, password=password)
                 )
                 result.credentials.append((username, password))
-                client.close()
             except (
                 paramiko.AuthenticationException,
                 paramiko.BadHostKeyException,
@@ -82,6 +81,8 @@ class SSHBruter(ArtemisBase):
                 paramiko.ssh_exception.SSHException,
             ):
                 pass
+            finally:
+                client.close()
 
         if result.credentials:
             status = TaskStatus.INTERESTING


### PR DESCRIPTION
### Fix: Prevent SSH connection leak in `SSHBruter.run()`

#### Summary
Fixes a resource leak where `paramiko.SSHClient` connections were not closed on failed authentication attempts.

#### Problem
`client.close()` was only called on successful authentication. On failure, exceptions were caught and ignored, leaving SSH connections open.

This caused:
- File descriptor exhaustion (`Too many open files`)
- SSH service disruption (hitting `MaxStartups` limits)
- Worker instability under load

#### Root Cause
Cleanup logic (`client.close()`) was only present in the success path and missing in failure paths.

#### Fix
- Initialize `SSHClient` before the `try` block
- Move `client.close()` into a `finally` block to ensure it always executes

#### Impact
- Eliminates SSH connection leaks
- Prevents FD exhaustion during large scans
- Avoids unintended impact on target SSH services
- Aligns with existing FTP bruter cleanup pattern

#### Notes
Matches the cleanup approach used in `ftp_bruter.py` (`finally: ftp.close()`).