### PR TITLE
fix: make Dependabot work with pip-compile flow

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,9 +65,9 @@ repos:
   hooks:
   - id: pip-compile
     name: pip-compile main
-    args: [requirements.in, -o, requirements.txt, --no-header]
+    args: [requirements.in, -o, requirements.txt]
     files: ^requirements\.(in|txt)$
   - id: pip-compile
     name: pip-compile docs
-    args: [docs/requirements.in, -o, docs/requirements.txt, --no-header, --no-annotate]
+    args: [docs/requirements.in, -o, docs/requirements.txt, --no-annotate]
     files: ^docs/requirements\.(in|txt)$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,10 @@ aiofiles = "0.7.0"
 
 # Apache 2 (https://github.com/c0fec0de/anytree), not properly provided in package metadata
 anytree = "2.11.1"
+
+[tool.pip-tools]
+# no-header prevents pip-compile from emitting a Python-version-specific header
+# which would differ between developer machines, CI (Python 3.11), and Dependabot's
+# runner — causing the pre-commit hook to perpetually flag requirements.txt as modified.
+# Dependabot reads this config natively and adds --no-header automatically.
+no-header = true


### PR DESCRIPTION
Fixes #2553

The issue was that Dependabot was unable to keep requirements up to date because of the `--no-header` flag in the pip-compile pre-commit hooks. However, simply removing that flag causes CI to break — the generated header contains an environment-specific Python version (e.g. `Python 3.11` in CI vs `Python 3.13` on a dev machine), so the lockfile keeps changing between runs.

The fix is to move `no-header = true` into `pyproject.toml` under `[tool.pip-tools]`. pip-tools reads this config natively, so it applies to every invocation — pre-commit hooks, local runs, and Dependabot's runner — without needing it as a CLI flag. The result is that all environments always produce identical, headerless lockfiles.

Changes:
- `pyproject.toml` — added `[tool.pip-tools]` config section with `no-header = true`
- `.pre-commit-config.yaml` — removed the now-redundant `--no-header` flag from both pip-compile hooks

Verified by running `pre-commit run pip-compile --all-files` inside a `python:3.11-slim` Docker container (matching the CI environment exactly). Both hooks pass cleanly on repeated runs with no file modifications.