### PR TITLE
Use constant-time comparison for API token verification

### DIFF
--- a/artemis/api.py
+++ b/artemis/api.py
@@ -1,5 +1,6 @@
 import asyncio
 import datetime
+import hmac
 from typing import Annotated, Any, Dict, List, Optional
 
 import aiohttp
@@ -60,7 +61,7 @@ def verify_api_token(x_api_token: Annotated[str, Header()]) -> None:
             status_code=401,
             detail="Please fill the API_TOKEN variable in .env in order to use the API",
         )
-    elif x_api_token != Config.Miscellaneous.API_TOKEN:
+    elif not hmac.compare_digest(x_api_token, Config.Miscellaneous.API_TOKEN):
         raise HTTPException(status_code=401, detail="Invalid API token")
 
 


### PR DESCRIPTION
## Summary
Replace the standard string comparison in `verify_api_token` with constant‑time comparison using `hmac.compare_digest()` to prevent timing attacks.

## Details
- **Vulnerability**: The original `x_api_token != Config.Miscellaneous.API_TOKEN` is vulnerable to timing side‑channel attacks, allowing an attacker to brute‑force the token character by character.
- **Fix**: Use `hmac.compare_digest()` (Python standard library) which performs a constant‑time comparison.
- **Testing**: Existing e2e tests in `test_automated_interaction.py` already cover both valid and invalid tokens, so no test changes are needed.
- **Pre‑commit note**: The mypy errors observed locally are pre‑existing and unrelated to this change; they do not appear in the Linux CI environment.

## Change
- Added `import hmac` at the top of `api.py`.
- Replaced the equality check with `not hmac.compare_digest(x_api_token, Config.Miscellaneous.API_TOKEN)`.

### Why it matters
Although the token is meant to be secret, timing attacks are a well‑known class of vulnerability that can be exploited to recover secrets if enough measurements can be made. Using a constant‑time comparison eliminates this side‑channel.