### PR TITLE
fix: raise on retry exhaustion so ERROR tasks get CRASHED status

### DIFF
--- a/artemis/module_base.py
+++ b/artemis/module_base.py
@@ -702,6 +702,14 @@ class ArtemisBase(Karton):
                                 self.log.error(
                                     "Task(s) returned error status, retrying (try %d/%d)", i + 1, self.num_retries
                                 )
+                            elif self.num_retries > 1:
+                                self.log.error(
+                                    "Task(s) still have error status after %d retries, marking as crashed",
+                                    self.num_retries,
+                                )
+                                raise RuntimeError(
+                                    f"Task(s) still have ERROR status after {self.num_retries} retries"
+                                )
                         else:
                             break
 


### PR DESCRIPTION
## Summary

Fixes a critical issue where tasks with `ERROR` status were incorrectly marked as `FINISHED` after all retry attempts were exhausted in `process_multiple()`.

##  Problem

When tasks saved `TaskStatus.ERROR` without raising an exception, the retry loop would complete all attempts but never propagate the failure. As a result:

- Tasks were marked as `FINISHED` instead of `CRASHED`
- Failed tasks were not picked up by `restart_crashed_tasks()`
- Silent failures occurred in core scanning modules

## Fix

- Added explicit error propagation after retry exhaustion
- Raised `RuntimeError` when tasks still have `ERROR` status after all retries (only when `num_retries > 1`)

## Impact

- Ensures failed tasks are correctly marked as `CRASHED`
- Enables proper recovery via `restart_crashed_tasks()`
- Eliminates silent failures and state inconsistency between DB and Karton

##  Notes

- No change to success path
- No change for single-attempt (`num_retries=1`) behavior