### PR TITLE
fix: make Dependabot work with pip-compile by moving no-header to pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,9 +65,9 @@ repos:
   hooks:
   - id: pip-compile
     name: pip-compile main
-    args: [requirements.in, -o, requirements.txt, --no-header]
+    args: [requirements.in, -o, requirements.txt]
     files: ^requirements\.(in|txt)$
   - id: pip-compile
     name: pip-compile docs
-    args: [docs/requirements.in, -o, docs/requirements.txt, --no-header, --no-annotate]
+    args: [docs/requirements.in, -o, docs/requirements.txt, --no-annotate]
     files: ^docs/requirements\.(in|txt)$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,3 +45,6 @@ aiofiles = "0.7.0"
 
 # Apache 2 (https://github.com/c0fec0de/anytree), not properly provided in package metadata
 anytree = "2.11.1"
+
+[tool.pip-tools]
+no-header = true


### PR DESCRIPTION
Fixes #2553

## Problem
Dependabot was unable to keep [requirements.txt](cci:7://file:///Users/mpal_08/Desktop/Github/Artemis/requirements.txt:0:0-0:0) files up to date because the `--no-header` flag was passed as a CLI arg in [.pre-commit-config.yaml](cci:7://file:///Users/mpal_08/Desktop/Github/Artemis/.pre-commit-config.yaml:0:0-0:0). Dependabot detects `--no-header` by checking whether [requirements.txt](cci:7://file:///Users/mpal_08/Desktop/Github/Artemis/requirements.txt:0:0-0:0) includes the `autogenerated by pip-c` string. Since the header was absent, Dependabot correctly inferred `--no-header` and added it when re-running `pip-compile`. 

## Fix
Move `no-header = true` from CLI args into [pyproject.toml](cci:7://file:///Users/mpal_08/Desktop/Github/Artemis/pyproject.toml:0:0-0:0) under `[tool.pip-tools]`. `pip-tools` reads this config natively, so it applies to every invocation — pre-commit hooks, local runs, and Dependabot's runner — without needing it as a CLI flag.

## Changes
- **[pyproject.toml](cci:7://file:///Users/mpal_08/Desktop/Github/Artemis/pyproject.toml:0:0-0:0)** — Added `[tool.pip-tools]` config section with `no-header = true`
- **[.pre-commit-config.yaml](cci:7://file:///Users/mpal_08/Desktop/Github/Artemis/.pre-commit-config.yaml:0:0-0:0)** — Removed the now-redundant `--no-header` flag from both pip-compile hooks (`--no-annotate` stays for the docs hook)

## Verification
- Ran `pre-commit run --all-files`.
- Ran `pre-commit run pip-compile --all-files`: `pip-compile main` passes.
