### PR TITLE
fix(resource_lock): enforce lock ownership with CAS to prevent race condition

### DIFF
--- a/artemis/resource_lock.py
+++ b/artemis/resource_lock.py
@@ -31,12 +31,29 @@ LOCKS_TO_SUSTAIN_LOCK = threading.Lock()
 REDIS = Redis.from_url(Config.Data.REDIS_CONN_STR)
 
 
+LUA_SUSTAIN_SCRIPT = """
+if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("expire", KEYS[1], ARGV[2])
+else
+    return 0
+end
+"""
+
+LUA_RELEASE_SCRIPT = """
+if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("del", KEYS[1])
+else
+    return 0
+end
+"""
+
+
 def sustain_locks() -> None:
     while True:
         try:
             with LOCKS_TO_SUSTAIN_LOCK:
                 for key, value in LOCKS_TO_SUSTAIN.items():
-                    REDIS.set(key, value, ex=LOCK_HEARTBEAT_TIMEOUT)
+                    REDIS.eval(LUA_SUSTAIN_SCRIPT, 1, key, value, LOCK_HEARTBEAT_TIMEOUT)
         except Exception:
             logger.exception("Failed to sustain locks, will retry")
         time.sleep(1)
@@ -84,7 +101,7 @@ class ResourceLock:
         with LOCKS_TO_SUSTAIN_LOCK:
             if self.res_name in LOCKS_TO_SUSTAIN:
                 del LOCKS_TO_SUSTAIN[self.res_name]
-        REDIS.delete(self.res_name)
+        REDIS.eval(LUA_RELEASE_SCRIPT, 1, self.res_name, self.lid)
 
     def __enter__(self) -> None:
         self.acquire()


### PR DESCRIPTION
Title: Fix race condition in Redis distributed lock (CAS for sustain & release)

Summary:

This PR fixes a critical race condition in Artemis' distributed locking
(ResourceLock) that could break concurrency guarantees under load.

Bug:

The lock lifecycle used unsafe Redis operations:

- sustain_locks() blindly executed:
  REDIS.set(key, value, ex=60)

- release() blindly executed:
  REDIS.delete(key)

If a worker missed heartbeats (e.g., due to CPU starvation or I/O delays),
the lock would expire and be correctly acquired by another worker.
However, when the original worker resumed:

- It overwrote the new owner's lock (blind SET)
- It deleted the lock entirely on release (blind DEL)

This caused multiple workers to concurrently scan the same target,
breaking rate limits and potentially generating DDoS-like traffic.

Fix:

Replaced unsafe operations with atomic Redis Lua CAS checks:

- Sustain:
  Only extend TTL if GET(key) == worker_id

- Release:
  Only delete key if GET(key) == worker_id

This ensures only the current lock owner can modify or release the lock.

Impact:

- Restores correct distributed lock ownership semantics
- Prevents concurrent scans on the same target
- Eliminates silent race conditions under worker stalls
- Improves reliability in high-load / containerized environments