### PR TITLE
 remove live DNS lookup in test_classifier to stabilize flaky test

### DIFF
--- a/test/modules/test_classifier.py
+++ b/test/modules/test_classifier.py
@@ -1,4 +1,3 @@
-from socket import gethostbyname
 from test.base import ArtemisModuleTestCase
 from typing import Any, Dict, List, NamedTuple
 
@@ -48,7 +47,7 @@ class ClassifierTest(ArtemisModuleTestCase):
         self.assertFalse(Classifier.is_supported("ssh://127.0.0.1"))
 
     def test_parsing(self) -> None:
-        cert_ip = gethostbyname("cert.pl")
+        cert_ip = "188.184.100.20"
 
         entries = [
             TestData(


### PR DESCRIPTION
Test_parsing called gethostbyname("cert.pl") only to build a test input string like "188.184.100.20:80". The classifier itself never resolves DNS for IP inputs, so the lookup was unnecessary and made the test fragile — it would fail if DNS was slow, unreachable, or cert.pl's IP changed.
Replaced with a hardcoded stable IP. Part of #2465.