### PR TITLE
 add missing retry import in test_subdomain_enumeration to fix NameError

### DIFF
--- a/test/modules/test_subdomain_enumeration.py
+++ b/test/modules/test_subdomain_enumeration.py
@@ -1,4 +1,5 @@
 from test.base import ArtemisModuleTestCase
+from retry import retry
 from typing import NamedTuple
 
 from karton.core import Task


### PR DESCRIPTION
test_subdomain_enumeration.py` uses @retry(tries=3, delay=10)on two
test methods but was missing the import, causing a `NameError` at
collection time and preventing all tests in the file from running.

### Change
- Add `from retry import retry` to `test/modules/test_subdomain_enumeration.py`

### Verified
- Ran all three previously flaky tests locally via Docker
- All 8 tests pass
- Consistent with the pattern used in `test_wordpress_bruter.py`

Closes part of #2465
 