### PR TITLE
Fix IPv6 crash in blocklist IP range checks

### DIFF
--- a/artemis/blocklist.py
+++ b/artemis/blocklist.py
@@ -137,7 +137,7 @@ def should_block_scanning(
         if item.ip_range:
             if not ip:
                 continue
-            if ipaddress.IPv4Address(ip) not in item.ip_range:
+            if ipaddress.ip_address(ip) not in item.ip_range:
                 continue
 
         if item.until:
@@ -211,7 +211,7 @@ def blocklist_reports(reports: List[Report], blocklist: List[BlocklistItem]) -> 
             if item.ip_range:
                 if not report.target_ip:
                     continue
-                if ipaddress.IPv4Address(report.target_ip) not in item.ip_range:
+                if ipaddress.ip_address(report.target_ip) not in item.ip_range:
                     continue
 
             if item.until:


### PR DESCRIPTION
The blocklist's IP range checks in `should_block_scanning()` and `blocklist_reports()` hardcoded `ipaddress.IPv4Address()`, which crashes with a `ValueError` when encountering IPv6 targets. This is inconsistent with the rest of the blocklist code, which already supports IPv6 - the `ip_range` field is typed as `Union[IPv4Network, IPv6Network]` and loaded via `ip_network()`. This fix replaces both occurrences with `ipaddress.ip_address()`, which handles both IPv4 and IPv6 correctly