### PR TITLE
Fix cleanup tight-loop on error by moving sleep outside try

### DIFF
--- a/artemis/cleanup.py
+++ b/artemis/cleanup.py
@@ -125,6 +125,6 @@ if __name__ == "__main__":
     while True:
         try:
             cleanup()
-            time.sleep(DELAY_BETWEEN_CLEANUPS__SECONDS)
         except Exception:
             logger.exception("Error during cleanup")
+        time.sleep(DELAY_BETWEEN_CLEANUPS__SECONDS)


### PR DESCRIPTION
## Fix: Prevent tight loop & log flood in cleanup service

### Bug
- Cleanup loop entered a **tight infinite loop** on exceptions
- No `sleep` in the `except` path caused:
  - High CPU usage
  - Massive log flooding
  - Excessive Redis/Postgres reconnection attempts

### Fix
- Moved `time.sleep(DELAY_BETWEEN_CLEANUPS__SECONDS)` **outside the try block**
- Ensures delay runs on both success and failure paths

### Impact
- Prevents CPU spikes and log flooding
- Avoids overwhelming Redis/Postgres during outages
- Keeps behavior unchanged on the success path

### Reference
- `artemis/cleanup.py` loop fix :contentReference[oaicite:0]{index=0}