### PR TITLE
Skip whois heuristic when IP resolution returns None

### DIFF
--- a/artemis/modules/dangling_dns_detector.py
+++ b/artemis/modules/dangling_dns_detector.py
@@ -360,6 +360,13 @@ class DanglingDnsDetector(ArtemisBase):
         filters = ["university", "educational", "academic", "education", "institute of technology"]
 
         ip = self.get_ip_from_domain(domain)
+        if not ip:
+            self.log.info(
+                "Could not resolve %s to an IP for public-entity whois check; "
+                "skipping heuristic and keeping existing findings.",
+                domain,
+            )
+            return False
         try:
             whois_data = IPWhois(ip).lookup_whois()
         except HTTPLookupError as e:


### PR DESCRIPTION
## Bug Fix: Prevent crash when IP resolution fails

### Summary
Fixes an issue where `dangling_dns_detector` crashes due to an unhandled `ValueError` when `get_ip_from_domain` returns `None`.

### Problem
- `IPWhois(None)` raises a `ValueError`
- Exception was not caught (only `HTTPLookupError` handled)
- Caused Karton tasks to be marked as **CRASHED** instead of completing normally :contentReference[oaicite:0]{index=0}

### Fix
- Added a guard clause to check if `ip` is `None`
- Logs the failure and safely returns `False` before calling `IPWhois`

### Impact
- Prevents task crashes and retry loops
- Ensures dangling DNS findings are still reported
- No change in behavior for valid IP resolution paths

### Changes
```diff
ip = self.get_ip_from_domain(domain)
+ if not ip:
+     self.log.info("Could not resolve %s to an IP...", domain)
+     return False