### PR TITLE
Avoid per-row KartonBackend in analyses table

### DIFF
--- a/artemis/api.py
+++ b/artemis/api.py
@@ -294,7 +294,10 @@ def get_analyses_table(
     search_query = _get_search_query(request)
 
     result = db.get_paginated_analyses(start, length, ordering, search_query=search_query)
-    num_pending_tasks = get_num_pending_tasks(KartonBackend(config=KartonConfig()))
+    backend = KartonBackend(config=KartonConfig())
+    num_pending_tasks = get_num_pending_tasks(backend)
+    all_bind_identities = {bind.identity for bind in backend.get_binds()}
+    disableable_bind_identities = {bind.identity for bind in get_binds_that_can_be_disabled()}
 
     entries = []
     for entry in result.data:
@@ -321,7 +324,10 @@ def get_analyses_table(
         "draw": draw,
         "recordsTotal": result.records_count_total,
         "recordsFiltered": result.records_count_filtered,
-        "data": [render_analyses_table_row(request, entry) for entry in entries],
+        "data": [
+            render_analyses_table_row(request, entry, all_bind_identities, disableable_bind_identities)
+            for entry in entries
+        ],
     }
 
 

--- a/artemis/templating.py
+++ b/artemis/templating.py
@@ -1,15 +1,11 @@
 import html
 import textwrap
 from os import path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Set
 
 import markdown
 from fastapi import Request
 from fastapi.templating import Jinja2Templates
-from karton.core.backend import KartonBackend
-from karton.core.config import Config as KartonConfig
-
-from artemis.karton_utils import get_binds_that_can_be_disabled
 
 TEMPLATES_DIR = path.join(path.dirname(__file__), "..", "templates")
 templates = Jinja2Templates(directory=TEMPLATES_DIR)
@@ -48,15 +44,18 @@ def render_task_table_row(request: Request, task_result: Dict[str, Any]) -> List
     ]
 
 
-def render_analyses_table_row(request: Request, entry: Dict[str, Any]) -> List[str]:
-    backend = KartonBackend(config=KartonConfig())
-
+def render_analyses_table_row(
+    request: Request,
+    entry: Dict[str, Any],
+    all_bind_identities: Set[str],
+    disableable_bind_identities: Set[str],
+) -> List[str]:
     if entry["disabled_modules"]:
         enabled_modules = ", ".join(
             sorted(
-                (set([bind.identity for bind in backend.get_binds()]) - set(entry["disabled_modules"].split(",")))
+                (all_bind_identities - set(entry["disabled_modules"].split(",")))
                 # We don't show modules that can't be disabled
-                & set([bind.identity for bind in get_binds_that_can_be_disabled()])
+                & disableable_bind_identities
             )
         )
     else:


### PR DESCRIPTION
## Fix: Redis connection leak and N+1 queries in analyses table

### Problem
`/api/analyses-table` was creating multiple `KartonBackend` instances per row inside `render_analyses_table_row`, leading to:
- Redis connection pool leaks (no cleanup)
- N+1 query pattern (`karton.binds` fetched repeatedly)
- Increased latency and risk of hitting Redis `maxclients` limit

### Fix
- Instantiate a single `KartonBackend` per request in `get_analyses_table`
- Precompute:
  - `all_bind_identities`
  - `disableable_bind_identities`
- Pass these sets to `render_analyses_table_row` instead of recomputing per row

### Impact
- Redis calls reduced from `2N` → `2` per request
- Eliminates connection leak under repeated dashboard refresh
- Improves response latency significantly
- No functional changes to API response

### Notes
- Output remains identical
- Fix is fully backward-compatible