### PR TITLE
Prevent tempdir leak in handle_single_task

### DIFF
--- a/artemis/reporting/task_handler.py
+++ b/artemis/reporting/task_handler.py
@@ -8,6 +8,7 @@ import threading
 import time
 import traceback
 from pathlib import Path
+from typing import Optional
 
 import psutil
 
@@ -27,26 +28,25 @@ DUMP_TRACEBACKS_IF_RUNNING_LONGER_THAN__SECONDS = 300
 
 
 def handle_single_task(report_generation_task: ReportGenerationTask) -> Path:
-    if report_generation_task.skip_previously_exported:
-        previous_reports_directory = tempfile.mkdtemp()
-        # We want to treat only the reports visible from web as already known
-        for existing_task in db.list_report_generation_tasks():
-            if existing_task.output_location:
-                try:
-                    shutil.copy(
-                        Path(existing_task.output_location) / "advanced" / "output.json",
-                        Path(previous_reports_directory)
-                        / (hashlib.sha256(existing_task.output_location.encode("ascii")).hexdigest() + ".json"),
-                    )
-                except FileNotFoundError:
-                    logger.warning(
-                        "Previous export output missing at %s, skipping for deduplication",
-                        existing_task.output_location,
-                    )
-    else:
-        previous_reports_directory = None
-
+    previous_reports_directory: Optional[str] = None
     try:
+        if report_generation_task.skip_previously_exported:
+            previous_reports_directory = tempfile.mkdtemp()
+            # We want to treat only the reports visible from web as already known
+            for existing_task in db.list_report_generation_tasks():
+                if existing_task.output_location:
+                    try:
+                        shutil.copy(
+                            Path(existing_task.output_location) / "advanced" / "output.json",
+                            Path(previous_reports_directory)
+                            / (hashlib.sha256(existing_task.output_location.encode("ascii")).hexdigest() + ".json"),
+                        )
+                    except FileNotFoundError:
+                        logger.warning(
+                            "Previous export output missing at %s, skipping for deduplication",
+                            existing_task.output_location,
+                        )
+
         return export(
             previous_reports_directory=Path(previous_reports_directory) if previous_reports_directory else None,
             tag=report_generation_task.tag,
@@ -59,7 +59,7 @@ def handle_single_task(report_generation_task: ReportGenerationTask) -> Path:
         )
     finally:
         if previous_reports_directory:
-            shutil.rmtree(previous_reports_directory)
+            shutil.rmtree(previous_reports_directory, ignore_errors=True)
 
 
 def report_mem() -> None:


### PR DESCRIPTION
Title: Fix tempdir leak in report generation when skip_previously_exported is enabled

Summary:
This PR fixes a temp directory leak caused by improper placement of the try/finally block in handle_single_task. Previously, tempfile.mkdtemp() was executed before entering the try block, allowing exceptions raised during file copy or DB access to bypass cleanup.

Changes:
- Moved temp directory creation inside the try block
- Ensured cleanup always runs via finally
- Added ignore_errors=True to shutil.rmtree for safer deletion
- Introduced Optional typing for previous_reports_directory

Impact:
Prevents accumulation of leaked temp directories in /tmp during repeated failures, avoiding disk or inode exhaustion in long-running workers

Root Cause:
Exceptions like OSError, PermissionError, or DB failures occurring before the try/finally block caused cleanup to be skipped, leaving temp directories behind

Testing:
- Simulated failures in shutil.copy and DB calls
- Verified temp directory is always cleaned up