### PR TITLE
Fix Nuclei retry cap walrus operator precedence

### DIFF
--- a/artemis/modules/nuclei.py
+++ b/artemis/modules/nuclei.py
@@ -460,8 +460,11 @@ class Nuclei(ArtemisBase):
             )
         )
 
-        if capped := Config.Modules.Nuclei.NUCLEI_MAX_SECONDS_PER_REQUEST_ON_RETRY > 0:
-            milliseconds_per_request_retry = min(milliseconds_per_request_retry, 1000 * capped)
+        max_seconds_per_request_on_retry = Config.Modules.Nuclei.NUCLEI_MAX_SECONDS_PER_REQUEST_ON_RETRY
+        if max_seconds_per_request_on_retry > 0:
+            milliseconds_per_request_retry = min(
+                milliseconds_per_request_retry, int(1000 * max_seconds_per_request_on_retry)
+            )
 
         milliseconds_per_request_candidates = [milliseconds_per_request_initial, milliseconds_per_request_retry]
 


### PR DESCRIPTION
## Title
fix(nuclei): correct retry cap due to walrus operator precedence bug

## Summary
Fixes an issue where the retry delay cap was incorrectly limited to 1 second regardless of configuration. This was caused by operator precedence in a walrus assignment, where the comparison executed before assignment, resulting in a boolean value instead of the intended config value.

## Changes
- Removed walrus operator usage in the conditional.
- Explicitly assigned `NUCLEI_MAX_SECONDS_PER_REQUEST_ON_RETRY` to a variable.
- Applied correct comparison and calculation using the actual config value.
- Ensured retry delay cap respects configured limits.

## Impact
Retry slowdown behavior now correctly honors the configured value (default 2.0s), preventing premature timeouts and improving request stability.

## Root Cause
The expression:
```python
if capped := Config.Modules.Nuclei.NUCLEI_MAX_SECONDS_PER_REQUEST_ON_RETRY > 0: