### PR TITLE
Guard against None copyrights in WordFence report enrichment

### DIFF
--- a/artemis/reporting/modules/wordpress_plugins/reporter.py
+++ b/artemis/reporting/modules/wordpress_plugins/reporter.py
@@ -96,7 +96,10 @@ class WordpressPluginsReporter(Reporter):
             }
 
             for cve in additional_data["cves"]:
-                for key, value in cve["copyrights"].items():
+                copyrights = cve.get("copyrights") or {}
+                if not isinstance(copyrights, dict):
+                    continue
+                for key, value in copyrights.items():
                     if not isinstance(value, dict):
                         continue
                     additional_data["copyrights"].append(value)


### PR DESCRIPTION
## Title
fix: handle missing copyrights field in WordFence CVE data

## Summary
Fixes a crash during report generation when the `copyrights` field is missing or `None` in WordFence CVE data.

## Bug
The reporter assumed `cve["copyrights"]` is always a dictionary and directly called `.items()`, causing an `AttributeError` when the field was `None`. This resulted in the entire report generation task failing instead of skipping invalid data. :contentReference[oaicite:0]{index=0}

## Fix
- Safely fetch `copyrights` using `cve.get("copyrights") or {}`
- Added type check to ensure it is a dictionary before iterating
- Skip invalid or non-dict values

## Impact
Prevents full task failure due to missing optional fields and ensures robust report generation.