### PR TITLE
Add timeout to WordFence feed fetch to prevent worker deadlock

### DIFF
--- a/artemis/wordfence.py
+++ b/artemis/wordfence.py
@@ -54,6 +54,7 @@ def _get_index() -> Dict[str, List[Dict[str, Any]]]:
                 response = requests.get(
                     WORDFENCE_PRODUCTION_FEED_URL,
                     headers={"Authorization": "Bearer " + Config.Modules.WordPressPlugins.WORDFENCE_API_KEY},
+                    timeout=Config.Limits.REQUEST_TIMEOUT_SECONDS,
                 )
                 if errors := response.json().get("errors", None):
                     logger.info("Unable to retrieve WordFence vulnerability feed. Errors: %s", errors)


### PR DESCRIPTION
### Fix: prevent worker deadlock on WordFence feed fetch

#### Summary
Adds a request timeout to the WordFence vulnerability feed call to prevent indefinite blocking when the external service is slow or unresponsive.

#### Root Cause
`requests.get()` was called without a timeout inside a global `ResourceLock`, causing all workers to hang indefinitely if the request stalled.

#### Fix
- Added `timeout=Config.Limits.REQUEST_TIMEOUT_SECONDS` to the request.

#### Impact
Prevents cluster-wide worker blockage and ensures WordPress plugin processing does not stall due to external API delays.

Refs: :contentReference[oaicite:0]{index=0}