### PR TITLE
fix: count only current chunk in nuclei METRIC_WORK_UNITS

### DIFF
--- a/artemis/modules/nuclei.py
+++ b/artemis/modules/nuclei.py
@@ -559,7 +559,7 @@ class Nuclei(ArtemisBase):
                 stdout, stderr = check_output_log_on_error_with_stderr(command, self.log, env=env)
                 METRIC_BATCH_COMMAND_DURATION.labels(scan_type=scan_using).observe(time.time() - command_start_time)
 
-                units = len(targets) * len(templates_or_workflows_filtered)
+                units = len(targets) * len(chunk)
                 METRIC_WORK_UNITS.labels(scan_type=scan_using).inc(units)
 
                 stdout_utf8 = stdout.decode("utf-8", errors="ignore")


### PR DESCRIPTION
## Fix: Correct over-counting in nuclei work units metric

### Summary
Fixes an issue where `METRIC_WORK_UNITS` was over-counted within the per-chunk processing loop in `nuclei.py`.

### Problem
The metric increment used:

### Impact
- Ensures accurate work unit tracking per scan
- Prevents inflated metrics in Prometheus
- Improves reliability of dashboards and alerting