### PR TITLE
Restart lock-sustain thread after fork in parallel_loop workers

### DIFF
--- a/artemis/resource_lock.py
+++ b/artemis/resource_lock.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import sys
 import threading
 import time
@@ -42,9 +43,28 @@ def sustain_locks() -> None:
         time.sleep(1)
 
 
-LOCK_SUSTAIN_THREAD = threading.Thread(target=sustain_locks)
-LOCK_SUSTAIN_THREAD.daemon = True
-LOCK_SUSTAIN_THREAD.start()
+def _start_sustain_thread() -> None:
+    t = threading.Thread(target=sustain_locks)
+    t.daemon = True
+    t.start()
+
+
+_start_sustain_thread()
+
+
+def _reinit_after_fork_in_child() -> None:
+    # Only the calling thread survives fork(), so the sustain thread started at import
+    # time is gone in the child. Reset the tracked-locks state (the parent still owns
+    # those entries) and start a fresh heartbeat, otherwise acquired locks would silently
+    # expire after LOCK_HEARTBEAT_TIMEOUT seconds.
+    global LOCKS_TO_SUSTAIN, LOCKS_TO_SUSTAIN_LOCK
+    LOCKS_TO_SUSTAIN = dict()
+    LOCKS_TO_SUSTAIN_LOCK = threading.Lock()
+    _start_sustain_thread()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reinit_after_fork_in_child)
 
 
 class ResourceLock:


### PR DESCRIPTION
## Fix: Ensure lock sustain thread runs in forked worker processes

### Summary
Fixes an issue where the lock sustain daemon thread (`LOCK_SUSTAIN_THREAD`) is not present in forked worker processes, causing Redis-backed locks to expire prematurely.

### Root Cause
The sustain thread is started at import time in the parent process. When `multiprocessing.Process.start()` uses `fork()`, only the calling thread is preserved in the child process, resulting in the absence of the sustain thread in workers.

### Impact
- Locks acquired in worker processes are not refreshed and expire after `LOCK_HEARTBEAT_TIMEOUT`
- Leads to duplicate concurrent scans on the same target
- Breaks request rate limits and may trigger remote bans
- Causes inconsistent queue state and incorrect lock releases

### Fix
- Register `os.register_at_fork(after_in_child=...)` in `resource_lock.py`
- In child process:
  - Reset `LOCKS_TO_SUSTAIN` and reinitialize its lock
  - Start a new sustain daemon thread to handle TTL refresh

### Result
Each worker process independently maintains lock heartbeats, preventing premature expiration and ensuring correct synchronization across parallel execution.