### PR TITLE
Add HTTP client timeout and response size limit to wappalyzer

### DIFF
--- a/artemis/modules/utils/wappalyzer/main.go
+++ b/artemis/modules/utils/wappalyzer/main.go
@@ -10,11 +10,18 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	wappalyzer "github.com/projectdiscovery/wappalyzergo"
 )
 
+const (
+	httpClientTimeout = 30 * time.Second
+	maxResponseBytes  = 10 * 1024 * 1024
+)
+
 var client = &http.Client{
+	Timeout: httpClientTimeout,
 	Transport: &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	},
@@ -30,7 +37,7 @@ func scan(url string, wappalyzerClient *wappalyzer.Wappalyze) map[string][]strin
 	}
 	defer resp.Body.Close()
 
-	data, _ := io.ReadAll(resp.Body)
+	data, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
 	fingerprints := wappalyzerClient.Fingerprint(resp.Header, data)
 
 	techs := []string{}


### PR DESCRIPTION
## Fix: Wappalyzer Go HTTP client timeout and response size limit

### Summary
The Wappalyzer Go HTTP client was created without a timeout, causing requests to hang indefinitely on unresponsive targets. This could block the subprocess and stall Karton workers until the global timeout is hit.

Additionally, response bodies were read without any size limit, risking excessive memory usage or OOM.

### Changes
- Added a 30s timeout to `http.Client`
- Limited response body size to 10MB using `io.LimitReader`

### Impact
- Prevents indefinite hangs in `webapp_identifier`
- Avoids worker stalls and task crashes
- Reduces risk of OOM from large responses