### PR TITLE
fix: add timeout to requests.get() in reverse_dns_lookup.py

### DIFF
--- a/artemis/modules/reverse_dns_lookup.py
+++ b/artemis/modules/reverse_dns_lookup.py
@@ -36,7 +36,7 @@ class ReverseDNSLookup(ArtemisBase):
             if not api.endswith("/"):
                 api = api + "/"
 
-            response = requests.get(api + ip)
+            response = requests.get(api + ip, timeout=Config.Limits.REQUEST_TIMEOUT_SECONDS)
             json_data = response.json()
             if "hostnames" in json_data:
                 self.log.info(f"Got hosts {json_data['hostnames']} from {api}")


### PR DESCRIPTION
## Problem

`requests.get(api + ip)` on line 39 of `reverse_dns_lookup.py` has no `timeout` parameter. If the external reverse-DNS API hangs, the worker thread will block indefinitely, stalling the entire module.

## Fix

Added `timeout=Config.Limits.REQUEST_TIMEOUT_SECONDS` to the `requests.get()` call, which defaults to **5 seconds** and is the standard timeout constant already used across the codebase in:
- `artemis/http_requests.py`
- `artemis/wordfence.py`
- `artemis/modules/admin_panel_login_bruter.py`
- `artemis/modules/nuclei.py`

## Changes

- **`artemis/modules/reverse_dns_lookup.py`**: Added `timeout=Config.Limits.REQUEST_TIMEOUT_SECONDS` to `requests.get()` call in `_lookup()` method (line 39).

## Testing

- All pre-commit hooks pass (black, isort, mypy, flake8).
- No new imports needed — `Config` is already imported on line 10.
