### PR TITLE
Open today's log file in append mode in FileLogger

### DIFF
--- a/artemis/karton_logger.py
+++ b/artemis/karton_logger.py
@@ -26,7 +26,7 @@ class FileLogger(LogConsumer):
                     self.opened_file.close()
                 self._rotate_logs()
                 self.opened_file_date = datetime.datetime.now().date()
-                self.opened_file = open(LOGS_PATH / f"{self.opened_file_date.strftime(LOG_DATE_FORMAT)}.log", "w")
+                self.opened_file = open(LOGS_PATH / f"{self.opened_file_date.strftime(LOG_DATE_FORMAT)}.log", "a")
                 # There should be one instance of the consumer, but for extra safety let's lock the file.
                 # From the documentation (https://docs.python.org/3/library/fcntl.html):
                 # "If LOCK_NB is used and the lock cannot be acquired, an OSError will be raised"


### PR DESCRIPTION
## Fix: Prevent log truncation on restart in FileLogger

### Summary
Fixes an issue where the current day's log file was being truncated on every service restart due to opening the file in write (`"w"`) mode.

### Changes
- Switched file open mode from `"w"` to `"a"` to ensure logs are appended instead of overwritten.

### Impact
- Prevents loss of log data across restarts
- Maintains correct log rotation behavior

### Notes
- Rotation logic already handles old logs, so append mode is the correct behavior for the active log file