### PR TITLE
Fix: Prevent worker stall with subprocess timeout in humble.py

### DIFF
--- a/artemis/modules/humble.py
+++ b/artemis/modules/humble.py
@@ -100,19 +100,29 @@ class Humble(ArtemisBase):
 
         base_url = get_target_url(current_task)
 
-        data = subprocess.check_output(
-            [
-                "python3",
-                "humble.py",
-                "-u",
-                base_url,
-                "-b",
-                "-o",
-                "json",
-            ],
-            cwd="/humble",
-            stderr=subprocess.DEVNULL,
-        )
+        try:
+            data = subprocess.check_output(
+                [
+                    "python3",
+                    "humble.py",
+                    "-u",
+                    base_url,
+                    "-b",
+                    "-o",
+                    "json",
+                ],
+                cwd="/humble",
+                stderr=subprocess.DEVNULL,
+                timeout=Config.Limits.REQUEST_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            self.log.error("Humble timed out for %s", base_url)
+            self.db.save_task_result(
+                task=current_task,
+                status=TaskStatus.ERROR,
+                status_reason="Humble timed out",
+            )
+            return
 
         # strip boilerplatetext from the output to get the location and filename of the output file
         filename = (


### PR DESCRIPTION
### Description
This PR resolves an issue in the `humble` module where `subprocess.check_output()` ran the external `humble.py` tool with no timeout. Previously, if the target was unresponsive or humble hung, the worker would block indefinitely. 

### Changes
- Introduced the existing `Config.Limits.REQUEST_TIMEOUT_SECONDS` config parameter as a timeout to the `humble.py` subprocess.
- Handled the resulting `subprocess.TimeoutExpired` exception so that if the subprocess runs out of time, the incomplete task is safely caught and cleanly marked as `ERRORED` without stalling the rest of the worker.
