### PR TITLE
Fix: karton logger gzip timeout

### DIFF
--- a/artemis/karton_logger.py
+++ b/artemis/karton_logger.py
@@ -61,7 +61,7 @@ class FileLogger(LogConsumer):
                         # Do nothing if failed to acquire the lock
                         continue
                     try:
-                        subprocess.call(["gzip", LOGS_PATH / file_name], timeout=3600)
+                        subprocess.call(["gzip", LOGS_PATH / file_name], timeout=300)
                     except subprocess.TimeoutExpired:
                         pass
 

--- a/artemis/karton_logger.py
+++ b/artemis/karton_logger.py
@@ -60,7 +60,10 @@ class FileLogger(LogConsumer):
                     except OSError:
                         # Do nothing if failed to acquire the lock
                         continue
-                    subprocess.call(["gzip", LOGS_PATH / file_name])
+                    try:
+                        subprocess.call(["gzip", LOGS_PATH / file_name], timeout=3600)
+                    except subprocess.TimeoutExpired:
+                        pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description
This PR resolves an issue in `artemis/karton_logger.py` where the background log rotation operation ran `subprocess.call(["gzip", ...])` without any timeout constraints. For exceptionally large log files or during heavy I/O conditions, this process could lead to indefinite blocking.

### Changes
- Added `timeout=300` to the `gzip` subprocess command to ensure the system is highly resilient against slow disk operations while actively preventing infinite hangs.
- Catching `subprocess.TimeoutExpired` to cleanly recover if a timeout occurs without propagating an error and crashing the logger background loop.
