### PR TITLE
Add timeout to FallbackAPICache cache-miss fetch to prevent worker hang

### DIFF
--- a/artemis/fallback_api_cache.py
+++ b/artemis/fallback_api_cache.py
@@ -68,7 +68,7 @@ class FallbackAPICache:
         if not allow_unknown:
             assert found
 
-        response = FallbackAPICache.CACHE.get(url, headers=headers)
+        response = FallbackAPICache.CACHE.get(url, headers=headers, timeout=Config.Limits.REQUEST_TIMEOUT_SECONDS)
 
         if found:
             if not found.validator(response.json()):


### PR DESCRIPTION
## Summary
Add a request timeout to `FallbackAPICache.get()` to prevent workers from hanging on slow or unresponsive upstream APIs.

## Bug
`FallbackAPICache.CACHE.get()` was called without a `timeout`, allowing indefinite blocking when upstream requests stall at the network level. The existing `stale_if_error=True` does not mitigate this scenario.

## Fix
Pass `timeout=Config.Limits.REQUEST_TIMEOUT_SECONDS` to the `.get()` call.

## Impact
- Prevents worker hangs during module initialization, task execution, and reporting
- Ensures consistency with other recent fixes adding timeouts to outbound HTTP calls
- No impact on cache hits, as they do not trigger network requests

## Changes
- Updated `artemis/fallback_api_cache.py` to include timeout in the HTTP request