### PR TITLE
Handle empty blocklist file in load_blocklist

### DIFF
--- a/artemis/blocklist.py
+++ b/artemis/blocklist.py
@@ -54,7 +54,7 @@ def load_blocklist(file_path: Optional[str]) -> List[BlocklistItem]:
         return []
 
     with open(file_path, "r") as file:
-        data = yaml.safe_load(file)
+        data = yaml.safe_load(file) or []
 
     expected_keys = {
         "mode",


### PR DESCRIPTION
## Fix: handle empty blocklist file to prevent startup crashes

### Summary
Fixes a crash when the blocklist file is empty or contains only comments/null. `yaml.safe_load()` returns `None`, causing a `TypeError` during iteration.

### Root Cause
`load_blocklist()` assumed parsed YAML is always iterable:
``python
data = yaml.safe_load(file)
for item in data:
Empty or comment-only files return None.

Fix

Default to an empty list if YAML parsing returns None:
data = yaml.safe_load(file) or []
Impact
Prevents worker crash loops on startup
Keeps API and reporting functional
Treats empty/comment-only blocklist as "no entries"
Scope

Minimal, safe change with no impact on valid non-empty blocklist files.