### PR TITLE
Use SCAN instead of KEYS in cleanup to avoid blocking Redis

### DIFF
--- a/artemis/cleanup.py
+++ b/artemis/cleanup.py
@@ -23,20 +23,20 @@ def _cleanup_tasks_not_in_queues() -> None:
     # Until https://github.com/CERT-Polska/karton/issues/262 gets fixed, let's have our own cleanup routine
     backend = KartonBackend(config=KartonConfig())
 
-    keys = backend.redis.keys()
+    # Use SCAN (non-blocking, cursor-based) instead of KEYS (blocks Redis for
+    # the entire enumeration): this cleanup shares Redis with Karton queues and
+    # ResourceLock, so a blocking scan of the full keyspace stalls every worker.
     tasks = set()
-    for key in keys:
-        if key.startswith("karton.task"):
-            if ":" in key:
-                tasks.add(key.split(":")[1])
-            else:
-                logger.error("Invalid key: %s", key)
+    for key in backend.redis.scan_iter(match="karton.task*"):
+        if ":" in key:
+            tasks.add(key.split(":")[1])
+        else:
+            logger.error("Invalid key: %s", key)
 
     queued_tasks = set()
-    for key in keys:
-        if key.startswith("karton.queue"):
-            for task in backend.redis.lrange(key, 0, -1):
-                queued_tasks.add(task)
+    for key in backend.redis.scan_iter(match="karton.queue*"):
+        for task in backend.redis.lrange(key, 0, -1):
+            queued_tasks.add(task)
 
     num_tasks_cleaned_up = 0
     for item in tasks - queued_tasks:

--- a/artemis/cleanup.py
+++ b/artemis/cleanup.py
@@ -23,9 +23,6 @@ def _cleanup_tasks_not_in_queues() -> None:
     # Until https://github.com/CERT-Polska/karton/issues/262 gets fixed, let's have our own cleanup routine
     backend = KartonBackend(config=KartonConfig())
 
-    # Use SCAN (non-blocking, cursor-based) instead of KEYS (blocks Redis for
-    # the entire enumeration): this cleanup shares Redis with Karton queues and
-    # ResourceLock, so a blocking scan of the full keyspace stalls every worker.
     tasks = set()
     for key in backend.redis.scan_iter(match="karton.task*"):
         if ":" in key:


### PR DESCRIPTION
## Fix: replace Redis KEYS with SCAN to prevent blocking

### Summary
Replaces `backend.redis.keys()` with `scan_iter()` in cleanup to avoid blocking the Redis instance during key enumeration.

### Root Cause
Using `KEYS *` scans the entire keyspace in a single blocking operation. Since Redis is single-threaded, this stalls all other operations (queues, locks, cache) during execution.

### Fix
Switched to `scan_iter(match=...)` for `karton.task*` and `karton.queue*` keys. SCAN is cursor-based and non-blocking, ensuring smooth operation even with large keyspaces.

### Impact
Prevents periodic Redis stalls during cleanup without changing cleanup behavior. :contentReference[oaicite:0]{index=0}