### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/artemis/modules/utils/wappalyzer/main.go
+++ b/artemis/modules/utils/wappalyzer/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bufio"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -22,9 +21,6 @@ const (
 
 var client = &http.Client{
 	Timeout: httpClientTimeout,
-	Transport: &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	},
 }
 
 func scan(url string, wappalyzerClient *wappalyzer.Wappalyze) map[string][]string {

--- a/artemis/web_technology_identification.py
+++ b/artemis/web_technology_identification.py
@@ -18,11 +18,6 @@ def run_tech_detection(urls: List[str], logger: logging.Logger) -> Any:
         raise FileNotFoundError(f"Wappalyzer main.go not found at {main_go_path}")
 
     try:
-        # Update the Wappalyzer package once
-        subprocess.run(
-            ["go", "-C", WAPPALYZER_PATH, "get", "-u", "./..."], cwd=wappalyzer_path, check=True, capture_output=True
-        )
-
         with tempfile.NamedTemporaryFile(mode="w") as temp_file:
             for url in urls:
                 temp_file.write(url + "\n")


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `artemis/modules/utils/wappalyzer/main.go:L24`

The Wappalyzer helper client sets `InsecureSkipVerify: true`, which disables TLS certificate validation for all HTTPS requests. This allows man-in-the-middle interference and can cause incorrect fingerprinting results or interception/modification of scanned content.

## Solution

Remove `InsecureSkipVerify: true` and use default TLS verification. If exceptions are needed for specific targets, make this behavior explicitly configurable and disabled by default, with strong warning/audit logging.

## Changes

- `artemis/modules/utils/wappalyzer/main.go` (modified)
- `artemis/web_technology_identification.py` (modified)