### PR TITLE
Handle None cvss value in get_severity to prevent TypeError

### DIFF
--- a/artemis/reporting/severity.py
+++ b/artemis/reporting/severity.py
@@ -99,7 +99,7 @@ def get_severity(report: Any) -> Severity:
         and "cves" in report.additional_data
         and report.additional_data["cves"]
     ):
-        cvss = max(item.get("cvss", 0) for item in report.additional_data["cves"])
+        cvss = max((item.get("cvss") or 0) for item in report.additional_data["cves"])
         if cvss < 4.0:
             return Severity.LOW
         if cvss < 7.0:


### PR DESCRIPTION
## Fix: handle None CVSS values to prevent crash in severity calculation

### Summary
Fixes a crash in `get_severity` when CVE entries contain `cvss=None`. Ensures safe handling by defaulting to `0` during aggregation.

### Root Cause
`item.get("cvss", 0)` returns `None` if the key exists with a `None` value. This causes `max()` to fail with a `TypeError` when comparing `NoneType` and `int`.

### Fix
Replace direct access with a fallback:
```python
cvss = max((item.get("cvss") or 0) for item in report.additional_data["cves"])