### PR TITLE
Close psycopg2 connections after successful auth in postgresql_bruter

### DIFF
--- a/artemis/modules/postgresql_bruter.py
+++ b/artemis/modules/postgresql_bruter.py
@@ -39,11 +39,20 @@ class PostgreSQLBruter(ArtemisBase):
         result = PostgreSQLBruterResult()
 
         for username, password in BRUTE_CREDENTIALS:
+            conn = None
             try:
-                self.throttle_request(lambda: psycopg2.connect(host=host, port=port, user=username, password=password))
+                conn = self.throttle_request(
+                    lambda: psycopg2.connect(host=host, port=port, user=username, password=password)
+                )
                 result.credentials.append((username, password))
             except psycopg2.OperationalError:
                 pass
+            finally:
+                if conn is not None:
+                    try:
+                        conn.close()
+                    except Exception:
+                        pass
 
         if result.credentials:
             status = TaskStatus.INTERESTING


### PR DESCRIPTION
## Fix: close PostgreSQL connections to prevent session leak

### Summary  
Fixes a resource leak in `postgresql_bruter` where successful `psycopg2.connect()` calls were not closed, leaving idle PostgreSQL sessions open for each valid credential. :contentReference[oaicite:0]{index=0}  

### Root Cause  
Connections were created inside a lambda passed to `throttle_request` and never assigned or explicitly closed, causing sessions to persist longer than expected.

### Fix  
Assign the connection to a variable and close it in a `finally` block, mirroring the pattern used in `mysql_bruter`.

### Impact  
Prevents exhaustion of `max_connections` on target PostgreSQL servers and ensures proper resource cleanup.