### PR TITLE
Alert on day-of-expiry domains in DomainExpirationScanner

### DIFF
--- a/artemis/modules/domain_expiration_scanner.py
+++ b/artemis/modules/domain_expiration_scanner.py
@@ -65,7 +65,10 @@ class DomainExpirationScanner(ArtemisBase):
             days_to_expire = (expiration_date - now).days
         result["name"] = name
         result["expiration_date"] = expiration_date
-        if days_to_expire and days_to_expire <= Config.Modules.DomainExpirationScanner.DOMAIN_EXPIRATION_TIMEFRAME_DAYS:
+        if (
+            days_to_expire is not None
+            and days_to_expire <= Config.Modules.DomainExpirationScanner.DOMAIN_EXPIRATION_TIMEFRAME_DAYS
+        ):
             result["close_expiration_date"] = True
             result["days_to_expire"] = days_to_expire
         return result


### PR DESCRIPTION
## Fix: handle day-zero domain expiration detection

### Summary
Fixes a logic bug where domains expiring on the current day (`days_to_expire == 0`) were not flagged as close to expiration.

### Root Cause
The condition `if days_to_expire and ...` treated `0` as falsy, skipping the alert for domains on their final day.

### Fix
Replaced the truthiness check with an explicit `None` check:
`days_to_expire is not None and days_to_expire <= threshold`

### Impact
Ensures domains expiring today are correctly detected and reported as high priority. :contentReference[oaicite:0]{index=0}