### PR TITLE
Skip unparseable files in karton log rotation to prevent ingestion crash

### DIFF
--- a/artemis/karton_logger.py
+++ b/artemis/karton_logger.py
@@ -38,8 +38,13 @@ class FileLogger(LogConsumer):
 
     def _rotate_logs(self) -> None:
         for file_name in os.listdir(LOGS_PATH):
-            log_date_str, _ = tuple(file_name.split(".", 1))
-            log_date = datetime.datetime.strptime(log_date_str, LOG_DATE_FORMAT).date()
+            if "." not in file_name:
+                continue
+            log_date_str, _ = file_name.split(".", 1)
+            try:
+                log_date = datetime.datetime.strptime(log_date_str, LOG_DATE_FORMAT).date()
+            except ValueError:
+                continue
 
             if (
                 log_date


### PR DESCRIPTION
## Fix: prevent crash in karton log rotation on unexpected files

### Summary
Fixes a crash in `FileLogger._rotate_logs` when encountering files that do not match the expected `YYYY-MM-DD.log[.gz]` format, which previously broke log ingestion.

### Root Cause
The implementation assumed all filenames were valid and directly unpacked and parsed them. Unexpected files caused `ValueError` during split or date parsing, aborting the entire rotation process. :contentReference[oaicite:0]{index=0}

### Fix
- Skip files without a `.` in the name  
- Wrap date parsing in `try/except`  
- Ignore invalid entries instead of failing the loop  

### Impact
Prevents ingestion failure and ensures log rotation continues even with stray or malformed files.