### PR TITLE
Add Wayback CDX passive parameter discovery

### DIFF
--- a/artemis/crawling.py
+++ b/artemis/crawling.py
@@ -7,7 +7,12 @@ import requests
 from bs4 import BeautifulSoup
 from bs4.exceptions import ParserRejectedMarkup  # type: ignore
 
-from artemis import http_requests
+from artemis import http_requests, utils
+
+logger = utils.build_logger(__name__)
+
+WAYBACK_CDX_URL = "https://web.archive.org/cdx/search/cdx"
+WAYBACK_CDX_LIMIT = 5000
 
 
 def get_links_and_resources_on_same_domain(url: str) -> List[str]:
@@ -54,8 +59,52 @@ def _fetch_injectable_parameters(url: str) -> Tuple[str, ...]:
 
 def get_injectable_parameters(url: str) -> List[str]:
     try:
-        return list(_fetch_injectable_parameters(url))
+        html_params = list(_fetch_injectable_parameters(url))
     except Exception:
+        html_params = []
+
+    try:
+        wayback_params = get_wayback_parameters(url)
+    except Exception:
+        wayback_params = []
+
+    return list(set(html_params + wayback_params))
+
+
+@functools.lru_cache(maxsize=1024)
+def _fetch_wayback_parameters(domain: str) -> Tuple[str, ...]:
+    response = requests.get(
+        WAYBACK_CDX_URL,
+        params={
+            "url": f"{domain}/*",
+            "output": "json",
+            "fl": "original",
+            "collapse": "urlkey",
+            "limit": str(WAYBACK_CDX_LIMIT),
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+    rows = response.json()
+
+    params: set[str] = set()
+    for row in rows[1:]:  # skip header row
+        try:
+            parsed = urlparse(row[0])
+            params.update(parse_qs(parsed.query).keys())
+        except IndexError:
+            continue
+    return tuple(params)
+
+
+def get_wayback_parameters(url: str) -> List[str]:
+    domain = urlparse(url).hostname
+    if not domain:
+        return []
+    try:
+        return list(_fetch_wayback_parameters(domain))
+    except Exception:
+        logger.exception("Failed to fetch Wayback CDX data for %s", domain)
         return []
 
 

--- a/test/unit/test_wayback_parameters.py
+++ b/test/unit/test_wayback_parameters.py
@@ -1,0 +1,135 @@
+import socket
+import unittest
+from unittest.mock import MagicMock, patch
+
+from artemis.crawling import _fetch_wayback_parameters, get_wayback_parameters
+
+
+def _has_internet_access() -> bool:
+    try:
+        socket.setdefaulttimeout(3)
+        socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect(("8.8.8.8", 53))
+        return True
+    except OSError:
+        return False
+
+
+def _make_cdx_response(urls: list[str], status_code: int = 200) -> MagicMock:
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.json.return_value = [["original"]] + [[url] for url in urls]
+    mock.raise_for_status = MagicMock()
+    return mock
+
+
+class TestGetWaybackParameters(unittest.TestCase):
+    def setUp(self) -> None:
+        _fetch_wayback_parameters.cache_clear()
+
+    def tearDown(self) -> None:
+        _fetch_wayback_parameters.cache_clear()
+
+    @patch("artemis.crawling.requests.get")
+    def test_extracts_parameters_from_historical_urls(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = _make_cdx_response(
+            [
+                "http://example.com/search?q=test&lang=en",
+                "http://example.com/page?id=1",
+                "http://example.com/page?id=2&category=news",
+            ]
+        )
+
+        result = get_wayback_parameters("http://example.com/")
+        self.assertEqual(sorted(result), ["category", "id", "lang", "q"])
+
+    @patch("artemis.crawling.requests.get")
+    def test_deduplicates_parameters(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = _make_cdx_response(
+            [
+                "http://example.com/page?id=1",
+                "http://example.com/page?id=2",
+                "http://example.com/page?id=3",
+            ]
+        )
+
+        result = get_wayback_parameters("http://example.com/")
+        self.assertEqual(result, ["id"])
+
+    @patch("artemis.crawling.requests.get")
+    def test_empty_response_returns_empty_list(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = _make_cdx_response([])
+
+        result = get_wayback_parameters("http://example.com/")
+        self.assertEqual(result, [])
+
+    @patch("artemis.crawling.requests.get")
+    def test_urls_without_params_return_empty_list(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = _make_cdx_response(
+            [
+                "http://example.com/about",
+                "http://example.com/contact",
+            ]
+        )
+
+        result = get_wayback_parameters("http://example.com/")
+        self.assertEqual(result, [])
+
+    @patch("artemis.crawling.requests.get")
+    def test_network_failure_returns_empty_list(self, mock_get: MagicMock) -> None:
+        mock_get.side_effect = Exception("connection error")
+
+        result = get_wayback_parameters("http://example.com/")
+        self.assertEqual(result, [])
+
+    @patch("artemis.crawling.requests.get")
+    def test_results_cached_per_domain(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = _make_cdx_response(
+            [
+                "http://example.com/page?foo=1",
+            ]
+        )
+
+        get_wayback_parameters("http://example.com/path/a")
+        get_wayback_parameters("http://example.com/path/b")
+
+        # Both calls share the same domain, only one CDX request
+        mock_get.assert_called_once()
+
+    @patch("artemis.crawling.requests.get")
+    def test_different_domains_cached_independently(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = _make_cdx_response(
+            [
+                "http://example.com/page?foo=1",
+            ]
+        )
+
+        get_wayback_parameters("http://example.com/")
+        get_wayback_parameters("http://other.com/")
+
+        self.assertEqual(mock_get.call_count, 2)
+
+    def test_invalid_url_returns_empty_list(self) -> None:
+        result = get_wayback_parameters("not-a-url")
+        self.assertEqual(result, [])
+
+
+@unittest.skipUnless(_has_internet_access(), "No internet access")
+class TestGetWaybackParametersIntegration(unittest.TestCase):
+    """Integration tests — require network access to web.archive.org."""
+
+    def setUp(self) -> None:
+        _fetch_wayback_parameters.cache_clear()
+
+    def tearDown(self) -> None:
+        _fetch_wayback_parameters.cache_clear()
+
+    def test_real_wayback_cdx_response_format(self) -> None:
+        result = get_wayback_parameters("http://google.com/")
+        self.assertIsInstance(result, list)
+        for param in result:
+            self.assertIsInstance(param, str)
+        self.assertIn("q", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unit/test_wayback_parameters.py
+++ b/test/unit/test_wayback_parameters.py
@@ -5,15 +5,6 @@ from unittest.mock import MagicMock, patch
 from artemis.crawling import _fetch_wayback_parameters, get_wayback_parameters
 
 
-def _has_internet_access() -> bool:
-    try:
-        socket.setdefaulttimeout(3)
-        socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect(("8.8.8.8", 53))
-        return True
-    except OSError:
-        return False
-
-
 def _make_cdx_response(urls: list[str], status_code: int = 200) -> MagicMock:
     mock = MagicMock()
     mock.status_code = status_code
@@ -111,24 +102,6 @@ class TestGetWaybackParameters(unittest.TestCase):
     def test_invalid_url_returns_empty_list(self) -> None:
         result = get_wayback_parameters("not-a-url")
         self.assertEqual(result, [])
-
-
-@unittest.skipUnless(_has_internet_access(), "No internet access")
-class TestGetWaybackParametersIntegration(unittest.TestCase):
-    """Integration tests — require network access to web.archive.org."""
-
-    def setUp(self) -> None:
-        _fetch_wayback_parameters.cache_clear()
-
-    def tearDown(self) -> None:
-        _fetch_wayback_parameters.cache_clear()
-
-    def test_real_wayback_cdx_response_format(self) -> None:
-        result = get_wayback_parameters("http://google.com/")
-        self.assertIsInstance(result, list)
-        for param in result:
-            self.assertIsInstance(param, str)
-        self.assertIn("q", result)
 
 
 if __name__ == "__main__":

--- a/test/unit/test_wayback_parameters.py
+++ b/test/unit/test_wayback_parameters.py
@@ -1,4 +1,3 @@
-import socket
 import unittest
 from unittest.mock import MagicMock, patch
 


### PR DESCRIPTION
Add Wayback CDX passive parameter discovery

Mines historical query parameters from the Wayback Machine CDX API (zero requests to target).
Parameters are extracted per domain, cached, and merged with existing HTML input param extraction
in get_injectable_parameters, feeding directly into XSS/SQLi modules.

Unit tests added for parameter extraction, deduplication, caching behavior, and error handling.

The next step is to integrate ParamSpider as an additional passive source for broader historical param coverage.

Part of #1200 