### PR TITLE
Only re-raise last DNS retry exception when no attempt succeeded

### DIFF
--- a/artemis/retrying_resolver.py
+++ b/artemis/retrying_resolver.py
@@ -39,7 +39,7 @@ def retry(function: Callable[..., Any], function_args: Tuple[Any, ...], function
             function_kwargs,
         )
 
-    if last_exception and not result:
+    if last_exception is not None and result is None:
         raise last_exception
 
     return result


### PR DESCRIPTION
## Fix: correct retry behavior for falsy DNS results

### Summary
Fixes incorrect exception handling in `retry()` where valid falsy results (e.g., empty set from NXDOMAIN) were treated as failures and caused the last exception to be raised.

### Root Cause
The condition `if last_exception and not result` incorrectly treats legitimate falsy results as failed attempts instead of checking whether all retries failed.

### Fix
``python
if last_exception is not None and result is None:
    raise last_exception


Impact
Preserves valid NXDOMAIN responses instead of misclassifying them as resolution errors
Prevents wildcard DNS filtering from breaking under flaky conditions
Avoids unintended task drops during domain existence checks