### PR TITLE
Ignore blank lines when loading placeholder-page keywords

### DIFF
--- a/artemis/placeholder_page_detector.py
+++ b/artemis/placeholder_page_detector.py
@@ -11,7 +11,8 @@ PLACEHOLDER_PAGE_CONTENT_FILENAME = Config.Modules.PlaceholderPageContent.PLACEH
 PLACEHOLDER_PAGE_CONTENT = []
 with open(PLACEHOLDER_PAGE_CONTENT_FILENAME, "r", encoding="utf-8") as file:
     for keyword in file:
-        PLACEHOLDER_PAGE_CONTENT.append(keyword)
+        if keyword.strip():
+            PLACEHOLDER_PAGE_CONTENT.append(keyword)
 
 
 class PlaceholderPageDetector:


### PR DESCRIPTION
## Fix: ignore blank lines in placeholder keyword loader

### Summary
Prevents false-positive placeholder detection caused by blank or whitespace-only lines in the keyword file.

### Root Cause
The loader included empty lines, and `keywords.strip() == ""` always matches any HTML content, making all domains appear as placeholders. :contentReference[oaicite:0]{index=0}

### Fix
Skip empty/whitespace-only lines while loading keywords to ensure only valid entries are used.

### Impact
- Restores correct domain filtering behavior
- Prevents entire scan pipeline from being silently skipped
- Improves robustness against manual file edits