### PR TITLE
feat(lfi): Fix Windows LFI detection bug and expand indicator coverage

### DIFF
--- a/artemis/modules/data/lfi_detector/lfi_detector_payloads.txt
+++ b/artemis/modules/data/lfi_detector/lfi_detector_payloads.txt
@@ -48,3 +48,8 @@ Li4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4vLi4v
 ..%ef%b9%a8..%ef%b9%a8..%ef%b9%a8..%ef%b9%a8..%ef%b9%a8..%ef%b9%a8boot.ini
 ..%ef%bc%bc..%ef%bc%bc..%ef%bc%bc..%ef%bc%bc..%ef%bc%bc..%ef%bc%bc..%ef%bc%bcboot.ini
 ///////../../../etc/passwd
+# PHP wrapper payloads - php://filter returns file content as base64,
+# bypassing WAF filters and preventing PHP files from being executed.
+php://filter/convert.base64-encode/resource=/etc/passwd
+php://filter/read=convert.base64-encode/resource=/etc/passwd
+php://filter/convert.base64-encode/resource=../../../etc/passwd

--- a/artemis/modules/lfi_detector.py
+++ b/artemis/modules/lfi_detector.py
@@ -60,10 +60,36 @@ class LFIDetector(ArtemisBase):
         return bool(re.search(r"/?/*=", url))
 
     def contains_lfi_indicator(self, original_response: HTTPResponse, response: HTTPResponse) -> Optional[str]:
-        """Check if the response contains indicators of LFI."""
+        """Check if the response contains indicators of LFI.
+
+        Each indicator is a file-content signature that proves actual file contents
+        were leaked, not just an error message. The differential check (indicator
+        present in response but NOT in original response) prevents false positives.
+
+        Indicators cover:
+        - Linux /etc/passwd: root:x:, daemon:x:, bin:x:, nobody:x:
+        - Windows win.ini: [fonts], [extensions]
+        - Windows boot.ini (legacy NT/2000/XP/2003): [boot loader], [operating systems]
+        - PHP php://filter base64 wrapper output: base64 substrings of root:x: and <?php
+        """
         indicators = [
+            # Linux /etc/passwd - multiple lines for resilience
             ("root:x:", "/etc/passwd"),
-            ("Windows Registry Editor", "Windows .ini file"),
+            ("daemon:x:", "/etc/passwd"),
+            ("bin:x:", "/etc/passwd"),
+            ("nobody:x:", "/etc/passwd"),
+            # Windows win.ini - actual file content sections
+            ("[fonts]", "Windows win.ini"),
+            ("[extensions]", "Windows win.ini"),
+            # Windows boot.ini (legacy, pre-Vista)
+            ("[boot loader]", "Windows boot.ini"),
+            ("[operating systems]", "Windows boot.ini"),
+            # PHP php://filter base64 wrapper responses - base64 substrings
+            # searched directly in the raw response, no decoding needed.
+            # "cm9vdDp4" = base64 of "root:x" (first 8 chars of encoded /etc/passwd)
+            ("cm9vdDp4", "/etc/passwd via php://filter base64"),
+            # "PD9waHAg" = base64 of "<?php " (proves PHP source was leaked)
+            ("PD9waHAg", "PHP source code via php://filter base64"),
         ]
         for indicator, description in indicators:
             if indicator in response.content and indicator not in original_response.content:


### PR DESCRIPTION
## Description

Fixes a bug in the LFI detector's Windows detection and expands response indicators from 2 to 10, improving coverage for both Linux and Windows targets while maintaining zero false-positive tolerance.

**Bug fixed:** The existing Windows indicator `"Windows Registry Editor"` is the signature of a `.reg` file, not `win.ini`. Since the payload file sends `win.ini` traversal payloads (lines 30–34), Windows LFI was **never detectable**. Replaced with `[fonts]` and `[extensions]`, which are actual `win.ini` section headers.

## Changes

- **MODIFIED:** [lfi_detector.py] — Fixed Windows indicator bug, expanded indicator list from 2 to 10 covering `/etc/passwd` variants, `win.ini`, `boot.ini`, and PHP `php://filter` base64 wrapper responses
- **MODIFIED:** [lfi_detector_payloads.txt] — Added 3 PHP `php://filter` wrapper payloads for base64-encoded file disclosure

## New Indicators

| Indicator | Target | Notes |
|-----------|--------|-------|
| `root:x:` | `/etc/passwd` | Existing |
| `daemon:x:`, `bin:x:`, `nobody:x:` | `/etc/passwd` | Common passwd lines for resilience |
| `[fonts]`, `[extensions]` | `win.ini` | **Fixes broken Windows detection** |
| `[boot loader]`, `[operating systems]` | `boot.ini` | Legacy Windows (NT/2000/XP/2003) |
| `cm9vdDp4` | `/etc/passwd` via base64 | PHP `php://filter` wrapper detection |
| `PD9waHAg` | `<?php` via base64 | PHP source leak via wrapper |

## New Payloads

php://filter/convert.base64-encode/resource=/etc/passwd 
php://filter/read=convert.base64-encode/resource=/etc/passwd 
php://filter/convert.base64-encode/resource=../../../etc/passwd


These cause the server to return file content as base64, bypassing WAF filters and preventing PHP files from being executed instead of read. The base64 indicators (`cm9vdDp4`, `PD9waHAg`) are searched directly in the raw response — no decoding heuristics needed.

## False Positive Prevention

All indicators are **concrete file-content signatures** that cannot appear on normal web pages. The existing differential check (`indicator in response AND indicator not in original_response`) is preserved as the primary FP defence. No error-message indicators (e.g., `PHP Notice`, `No such file or directory`) were added.

## No Structural Changes

- Same detection logic, same batching, same parameter minimization
- No new imports, no new classes, no new config options
- Existing tests remain compatible


