### PR TITLE
Don't release scan-destination lock from a non-owning ResourceLock object

### DIFF
--- a/artemis/module_base.py
+++ b/artemis/module_base.py
@@ -842,7 +842,6 @@ class ArtemisBase(Karton):
     def check_connection_to_base_url_and_save_error(self, task: Task) -> bool:
         base_url = get_target_url(task)
         scan_destination = self._get_scan_destination(task)
-        lock = ResourceLock(f"lock-{scan_destination}", max_tries=Config.Locking.SCAN_DESTINATION_LOCK_MAX_TRIES)
 
         try:
             response = self.http_get(base_url)
@@ -868,9 +867,8 @@ class ArtemisBase(Karton):
                     data={"waf_detected": True},
                 )
                 self.log.info(
-                    f"Unable to connect to base URL: {base_url}: WAF detected, task skipped, releasing lock for {scan_destination}"
+                    f"Unable to connect to base URL: {base_url}: WAF detected, task skipped (destination={scan_destination})"
                 )
-                lock.release()
                 return False
 
             return True
@@ -881,9 +879,8 @@ class ArtemisBase(Karton):
                 status_reason=f"Unable to connect to base URL {base_url}: {repr(e)}, task skipped",
             )
             self.log.info(
-                f"Unable to connect to base URL: {base_url}: {repr(e)}, task skipped, releasing lock for {scan_destination}"
+                f"Unable to connect to base URL: {base_url}: {repr(e)}, task skipped (destination={scan_destination})"
             )
-            lock.release()
             return False
 
     def http_get(self, *args, **kwargs) -> http_requests.HTTPResponse:  # type: ignore


### PR DESCRIPTION
## Fix: Prevent incorrect release of scan-destination lock

### Summary
Fixes a bug where `check_connection_to_base_url_and_save_error` released a scan-destination lock using a non-owning `ResourceLock` instance. This caused unintended deletion of the actual lock and broke locking guarantees.

### Changes
- Removed creation of redundant `ResourceLock` instance
- Removed invalid `lock.release()` calls in WAF and exception branches
- Updated log messages for clarity

### Impact
- Prevents premature deletion of active locks
- Ensures lock ownership integrity across workers
- Avoids concurrent scans on the same destination
- Maintains correct heartbeat behavior for lock sustain mechanism

Ref: :contentReference[oaicite:0]{index=0}