### PR TITLE
Compare cleanup task age against UTC now, not local now

### DIFF
--- a/artemis/cleanup.py
+++ b/artemis/cleanup.py
@@ -45,7 +45,7 @@ def _cleanup_tasks_not_in_queues() -> None:
         task = json.loads(value)
         if (
             datetime.datetime.utcfromtimestamp(task["last_update"])
-            < datetime.datetime.now() - datetime.timedelta(days=DONT_CLEANUP_TASKS_FRESHER_THAN__DAYS)
+            < datetime.datetime.utcnow() - datetime.timedelta(days=DONT_CLEANUP_TASKS_FRESHER_THAN__DAYS)
             or task.get("headers", {}).get("receiver", "") in OLD_MODULES
         ):
             num_tasks_cleaned_up += 1


### PR DESCRIPTION
## Summary
Fix incorrect task cleanup threshold caused by mixing UTC and local time comparisons.

## Problem
_cleanup_tasks_not_in_queues compares a UTC timestamp (`utcfromtimestamp`) with a local time (`datetime.now()`), leading to inconsistent cleanup behavior depending on deployment timezone. This results in either premature deletion or delayed cleanup of tasks.

## Fix
Replaced `datetime.now()` with `datetime.utcnow()` to ensure both sides of the comparison use the same UTC reference.

## Impact
Ensures consistent task retention across all timezones and prevents unintended data loss or Redis key buildup.