### PR TITLE
Fix stale resource lock release ownership

### DIFF
--- a/artemis/resource_lock.py
+++ b/artemis/resource_lock.py
@@ -31,6 +31,14 @@ LOCKS_TO_SUSTAIN_LOCK = threading.Lock()
 
 REDIS = Redis.from_url(Config.Data.REDIS_CONN_STR)
 
+_RELEASE_SCRIPT = """
+if redis.call("get", KEYS[1]) == ARGV[1] then
+    return redis.call("del", KEYS[1])
+else
+    return 0
+end
+"""
+
 
 def sustain_locks() -> None:
     while True:
@@ -67,6 +75,10 @@ if hasattr(os, "register_at_fork"):
     os.register_at_fork(after_in_child=_reinit_after_fork_in_child)
 
 
+def _release_lock_if_owned(res_name: str, lid: str) -> None:
+    REDIS.eval(_RELEASE_SCRIPT, 1, res_name, lid)  # type: ignore[no-untyped-call]
+
+
 class ResourceLock:
     def __init__(self, res_name: str, max_tries: Optional[int] = None):
         self.res_name = res_name
@@ -76,10 +88,12 @@ class ResourceLock:
     @staticmethod
     def release_all_locks(logger: Logger) -> None:
         with LOCKS_TO_SUSTAIN_LOCK:
-            for lock in list(LOCKS_TO_SUSTAIN.keys()):
-                logger.info(f"Releasing lock: {lock} -> {LOCKS_TO_SUSTAIN[lock]}")
-                REDIS.delete(lock)
+            locks_to_release = list(LOCKS_TO_SUSTAIN.items())
             LOCKS_TO_SUSTAIN.clear()
+
+        for lock, lid in locks_to_release:
+            logger.info(f"Releasing lock: {lock} -> {lid}")
+            _release_lock_if_owned(lock, lid)
 
     def acquire(self) -> None:
         """
@@ -102,9 +116,8 @@ class ResourceLock:
 
     def release(self) -> None:
         with LOCKS_TO_SUSTAIN_LOCK:
-            if self.res_name in LOCKS_TO_SUSTAIN:
-                del LOCKS_TO_SUSTAIN[self.res_name]
-        REDIS.delete(self.res_name)
+            LOCKS_TO_SUSTAIN.pop(self.res_name, None)
+        _release_lock_if_owned(self.res_name, self.lid)
 
     def __enter__(self) -> None:
         self.acquire()

--- a/test/unit/test_resource_lock.py
+++ b/test/unit/test_resource_lock.py
@@ -2,10 +2,13 @@ import logging
 import threading
 import unittest
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 from artemis.resource_lock import (
+    _RELEASE_SCRIPT,
     LOCKS_TO_SUSTAIN,
     LOCKS_TO_SUSTAIN_LOCK,
+    REDIS,
     FailedToAcquireLockException,
     ResourceLock,
 )
@@ -27,16 +30,16 @@ class TestReleaseAllLocks(unittest.TestCase):
 
     @patch("artemis.resource_lock.REDIS")
     def test_release_all_locks_deletes_redis_keys(self, mock_redis: MagicMock) -> None:
-        """release_all_locks must call REDIS.delete for every held lock."""
+        """release_all_locks must release only the Redis keys owned by the tracked lock ids."""
         with LOCKS_TO_SUSTAIN_LOCK:
             LOCKS_TO_SUSTAIN["lock-1.2.3.4"] = "uuid-1"
             LOCKS_TO_SUSTAIN["lock-5.6.7.8"] = "uuid-2"
 
         ResourceLock.release_all_locks(self.logger)
 
-        mock_redis.delete.assert_any_call("lock-1.2.3.4")
-        mock_redis.delete.assert_any_call("lock-5.6.7.8")
-        self.assertEqual(mock_redis.delete.call_count, 2)
+        mock_redis.eval.assert_any_call(_RELEASE_SCRIPT, 1, "lock-1.2.3.4", "uuid-1")
+        mock_redis.eval.assert_any_call(_RELEASE_SCRIPT, 1, "lock-5.6.7.8", "uuid-2")
+        self.assertEqual(mock_redis.eval.call_count, 2)
 
     @patch("artemis.resource_lock.REDIS")
     def test_release_all_locks_clears_sustain_dict(self, mock_redis: MagicMock) -> None:
@@ -56,7 +59,7 @@ class TestReleaseAllLocks(unittest.TestCase):
         """Calling release_all_locks with no held locks must not raise."""
         ResourceLock.release_all_locks(self.logger)
 
-        mock_redis.delete.assert_not_called()
+        mock_redis.eval.assert_not_called()
         with LOCKS_TO_SUSTAIN_LOCK:
             self.assertEqual(len(LOCKS_TO_SUSTAIN), 0)
 
@@ -76,7 +79,7 @@ class TestReleaseAllLocks(unittest.TestCase):
         # Simulate the safety-net cleanup
         ResourceLock.release_all_locks(self.logger)
 
-        mock_redis.delete.assert_any_call("lock-leaked-target")
+        mock_redis.eval.assert_any_call(_RELEASE_SCRIPT, 1, "lock-leaked-target", lock.lid)
         with LOCKS_TO_SUSTAIN_LOCK:
             self.assertNotIn("lock-leaked-target", LOCKS_TO_SUSTAIN)
 
@@ -147,7 +150,7 @@ class TestResourceLockBasics(unittest.TestCase):
 
         with LOCKS_TO_SUSTAIN_LOCK:
             self.assertNotIn("lock-test-target", LOCKS_TO_SUSTAIN)
-        mock_redis.delete.assert_called_with("lock-test-target")
+        mock_redis.eval.assert_called_with(_RELEASE_SCRIPT, 1, "lock-test-target", lock.lid)
 
     @patch("artemis.resource_lock.REDIS")
     def test_failed_acquire_raises(self, mock_redis: MagicMock) -> None:
@@ -171,7 +174,38 @@ class TestResourceLockBasics(unittest.TestCase):
 
         with LOCKS_TO_SUSTAIN_LOCK:
             self.assertNotIn("lock-ctx", LOCKS_TO_SUSTAIN)
-        mock_redis.delete.assert_called_with("lock-ctx")
+        _, lid = mock_redis.set.call_args.args[:2]
+        mock_redis.eval.assert_called_with(_RELEASE_SCRIPT, 1, "lock-ctx", lid)
+
+
+class TestResourceLockIntegration(unittest.TestCase):
+    def setUp(self) -> None:
+        with LOCKS_TO_SUSTAIN_LOCK:
+            LOCKS_TO_SUSTAIN.clear()
+        self.res_name = f"lock-integration-{uuid4()}"
+        REDIS.delete(self.res_name)
+
+    def tearDown(self) -> None:
+        with LOCKS_TO_SUSTAIN_LOCK:
+            LOCKS_TO_SUSTAIN.clear()
+        REDIS.delete(self.res_name)
+
+    def test_release_does_not_delete_reacquired_lock(self) -> None:
+        first_lock = ResourceLock(self.res_name, max_tries=1)
+        second_lock = ResourceLock(self.res_name, max_tries=1)
+
+        first_lock.acquire()
+        with LOCKS_TO_SUSTAIN_LOCK:
+            LOCKS_TO_SUSTAIN.pop(self.res_name, None)
+
+        REDIS.delete(self.res_name)
+        second_lock.acquire()
+
+        try:
+            first_lock.release()
+            self.assertEqual(REDIS.get(self.res_name), second_lock.lid.encode())
+        finally:
+            second_lock.release()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
  - protect `ResourceLock.release()` with an atomic Redis compare-and-delete so stale lock holders cannot delete a lock reacquired by another worker
  - harden `release_all_locks()` the same way because it had the same ownership bug
  - add a real-Redis regression test that reproduces the expiry/reacquire race and verifies the new owner keeps the lock

 ## Bug:

The lock lifecycle used unsafe Redis operations:

sustain_locks() blindly executed:
REDIS.set(key, value, ex=60)

release() blindly executed:
REDIS.delete(key)

If a worker missed heartbeats (e.g., due to CPU starvation or I/O delays),
the lock would expire and be correctly acquired by another worker.
However, when the original worker resumed:

It overwrote the new owner's lock (blind SET)
It deleted the lock entirely on release (blind DEL)
This caused multiple workers to concurrently scan the same target,
breaking rate limits and potentially generating DDoS-like traffic.

## Fix:

Replaced unsafe operations with atomic Redis Lua CAS checks:

Sustain:
Only extend TTL if GET(key) == worker_id

Release:
Only delete key if GET(key) == worker_id

This ensures only the current lock owner can modify or release the lock.




