### PR TITLE
Treat href-less anchors as empty href in is_log_file classifier

### DIFF
--- a/artemis/reporting/modules/bruter/classifier.py
+++ b/artemis/reporting/modules/bruter/classifier.py
@@ -46,7 +46,7 @@ def is_log_file(found_url: FoundURL) -> bool:
     if found_url.has_directory_index:
         soup = bs4.BeautifulSoup(found_url.content_prefix)
         for link in soup.find_all("a"):
-            href = link.get("href")
+            href = link.get("href") or ""
             if (
                 "access.log" in href
                 or "error.log" in href


### PR DESCRIPTION
## Summary
Fix crash in `is_log_file` when parsing `<a>` tags without an `href` attribute.

## Bug
`link.get("href")` can return `None`, causing a `TypeError` during substring checks and breaking the entire report generation flow. :contentReference[oaicite:0]{index=0}

## Fix
Default `href` to an empty string before performing checks to prevent runtime errors.

## Impact
Prevents report export failures on directory index pages containing anchor tags without `href`, ensuring stable report generation.