### PR TITLE
Split add_protocol_if_needed host:port from the right so IPv6 doesn't crash it

### DIFF
--- a/artemis/reporting/utils.py
+++ b/artemis/reporting/utils.py
@@ -98,8 +98,12 @@ def add_protocol_if_needed(data: str) -> str:
     if "://" in data:
         return data
     elif ":" in data:
-        host, port = data.split(":")
-        port_int = int(port)
+        # rsplit so IPv6 host:port (where host contains colons) splits only on the final colon.
+        host, port = data.rsplit(":", 1)
+        try:
+            port_int = int(port)
+        except ValueError:
+            return data
         try:
             service_name = getservbyport(port_int)
         except OSError:

--- a/test/unit/test_add_protocol_if_needed.py
+++ b/test/unit/test_add_protocol_if_needed.py
@@ -1,0 +1,33 @@
+import unittest
+
+from artemis.reporting.utils import add_protocol_if_needed
+
+
+class TestAddProtocolIfNeeded(unittest.TestCase):
+    def test_ipv4_host_port(self) -> None:
+        self.assertEqual(add_protocol_if_needed("127.0.0.1:3306"), "mysql://127.0.0.1:3306")
+
+    def test_ipv4_host_port_unknown_service(self) -> None:
+        self.assertEqual(add_protocol_if_needed("127.0.0.1:65000"), "unknown://127.0.0.1:65000")
+
+    def test_ipv6_host_port_does_not_crash(self) -> None:
+        # Prior to the fix, split(":") on an IPv6 host:port raised ValueError.
+        self.assertEqual(add_protocol_if_needed("::1:3306"), "mysql://::1:3306")
+        self.assertEqual(
+            add_protocol_if_needed("2001:db8::1:3306"),
+            "mysql://2001:db8::1:3306",
+        )
+
+    def test_url_with_scheme_unchanged(self) -> None:
+        self.assertEqual(add_protocol_if_needed("https://example.com"), "https://example.com")
+        self.assertEqual(add_protocol_if_needed("mysql://127.0.0.1:3306"), "mysql://127.0.0.1:3306")
+
+    def test_non_integer_port_returned_unchanged(self) -> None:
+        self.assertEqual(add_protocol_if_needed("example.com:abc"), "example.com:abc")
+        self.assertEqual(add_protocol_if_needed("host:"), "host:")
+
+    def test_no_port_returned_unchanged(self) -> None:
+        self.assertEqual(add_protocol_if_needed("example.com"), "example.com")
+
+    def test_hostname_with_port(self) -> None:
+        self.assertEqual(add_protocol_if_needed("example.com:80"), "http://example.com:80")


### PR DESCRIPTION
Fix IPv6 host:port parsing crash in add_protocol_if_needed

- Replace split(":") with rsplit(":", 1) to correctly handle IPv6 addresses
- Add validation for non-integer ports to prevent ValueError
- Ensure function safely returns original data when parsing fails

Impact:
Prevents report export failures caused by uncaught exceptions when processing IPv6 host:port inputs :contentReference[oaicite:0]{index=0}