### PR TITLE
feat(api): idempotent POST /add via Idempotency-Key header

### DIFF
--- a/artemis/api.py
+++ b/artemis/api.py
@@ -1,6 +1,7 @@
 import asyncio
 import datetime
 import hmac
+import logging
 from typing import Annotated, Any, Dict, List, Optional
 
 import aiohttp
@@ -11,10 +12,12 @@ from karton.core.config import Config as KartonConfig
 from karton.core.task import TaskPriority
 from pydantic import BaseModel
 from redis import Redis
+from redis.exceptions import RedisError
 
 from artemis.blocklist import load_blocklist, should_block_scanning
 from artemis.config import Config
 from artemis.db import DB, ColumnOrdering, TaskFilter
+from artemis.idempotency import IdempotencyStore
 from artemis.karton_utils import get_binds_that_can_be_disabled, get_num_pending_tasks
 from artemis.module_utils import try_to_import_all_modules
 from artemis.modules.base.runtime_configuration_registry import (
@@ -29,9 +32,12 @@ from artemis.task_utils import (
 )
 from artemis.templating import render_analyses_table_row, render_task_table_row
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter()
 db = DB()
 redis = Redis.from_url(Config.Data.REDIS_CONN_STR)
+idempotency_store = IdempotencyStore(redis)
 try_to_import_all_modules()  # so that the module runtime configurations get registered
 
 
@@ -74,12 +80,81 @@ def add(
     requests_per_second_override: Optional[float] = Body(default=None),
     priority: str = Body(default="normal"),
     module_runtime_configurations: Optional[Dict[str, Dict[str, Any]]] = Body(default=None),
+    x_api_token: Annotated[str, Header()] = "",
+    idempotency_key: Annotated[Optional[str], Header()] = None,
 ) -> Dict[str, Any]:
     """Add targets to be scanned.
 
     You can provide per-task module configurations through the module_runtime_configurations parameter.
     These configurations control runtime behavior (like scan aggressiveness) for each module.
+
+    To make this call safe to retry, send an ``Idempotency-Key`` header. The first call with a given
+    key executes and its response is cached for 24h; subsequent calls with the same key and body
+    replay the cached response, concurrent calls get 409 Retry-After, and calls reusing the key
+    with a different body get 409 Conflict.
     """
+    idem_body = {
+        "targets": targets,
+        "tag": tag,
+        "disabled_modules": disabled_modules,
+        "enabled_modules": enabled_modules,
+        "requests_per_second_override": requests_per_second_override,
+        "priority": priority,
+        "module_runtime_configurations": module_runtime_configurations,
+    }
+    if idempotency_key:
+        try:
+            state, cached = idempotency_store.begin(x_api_token, idempotency_key, idem_body)
+        except RedisError as e:
+            logger.warning("idempotency store unavailable, failing open: %s", e)
+            state, cached = "new", None
+        if state == "replay" and cached is not None:
+            return cached
+        if state == "in_flight":
+            raise HTTPException(
+                status_code=409,
+                detail="request with this Idempotency-Key is in progress",
+                headers={"Retry-After": "5"},
+            )
+        if state == "conflict":
+            raise HTTPException(
+                status_code=409,
+                detail="Idempotency-Key reused with a different request body",
+            )
+
+    try:
+        response = _add_impl(
+            targets=targets,
+            tag=tag,
+            disabled_modules=disabled_modules,
+            enabled_modules=enabled_modules,
+            requests_per_second_override=requests_per_second_override,
+            priority=priority,
+            module_runtime_configurations=module_runtime_configurations,
+        )
+    except Exception:
+        if idempotency_key:
+            idempotency_store.abort(x_api_token, idempotency_key)
+        raise
+
+    if idempotency_key and response.get("ok"):
+        try:
+            idempotency_store.finalize(x_api_token, idempotency_key, idem_body, response)
+        except RedisError as e:
+            logger.warning("idempotency finalize failed, response not cached: %s", e)
+
+    return response
+
+
+def _add_impl(
+    targets: List[str],
+    tag: Optional[str],
+    disabled_modules: Optional[List[str]],
+    enabled_modules: Optional[List[str]],
+    requests_per_second_override: Optional[float],
+    priority: str,
+    module_runtime_configurations: Optional[Dict[str, Dict[str, Any]]],
+) -> Dict[str, Any]:
     if disabled_modules and enabled_modules:
         raise HTTPException(
             status_code=400, detail="It's not possible to set both disabled_modules and enabled_modules."

--- a/artemis/idempotency.py
+++ b/artemis/idempotency.py
@@ -1,0 +1,70 @@
+import hashlib
+import json
+import logging
+from typing import Any, Optional, Tuple
+
+from redis import Redis, RedisError
+
+logger = logging.getLogger(__name__)
+
+PENDING_TTL_MS = 60_000
+DONE_TTL_MS = 24 * 60 * 60 * 1000
+
+
+def _body_hash(body: Any) -> str:
+    return hashlib.sha256(json.dumps(body, sort_keys=True, default=str).encode()).hexdigest()
+
+
+def _key(token: str, idem: str) -> str:
+    token_ns = hashlib.sha256(token.encode()).hexdigest()[:16]
+    return f"idem:{token_ns}:{idem}"
+
+
+class IdempotencyStore:
+    """Redis-backed store implementing the Idempotency-Key contract for POST /add.
+
+    States held under each key:
+      {"state": "pending", "body": <hash>}            - claimed, handler running
+      {"state": "done",    "body": <hash>, "response": <json>}
+    """
+
+    def __init__(self, redis: Redis) -> None:
+        self.redis = redis
+
+    def begin(self, token: str, idem: str, body: Any) -> Tuple[str, Optional[dict]]:
+        """Atomically claim the key. Returns one of:
+        ("new", None)                - caller should execute the handler
+        ("replay", cached_response)  - caller should return cached_response verbatim
+        ("in_flight", None)          - another request with the same key+body is running
+        ("conflict", None)           - key reused with a different body
+        """
+        k = _key(token, idem)
+        bh = _body_hash(body)
+        claim = json.dumps({"state": "pending", "body": bh})
+        if self.redis.set(k, claim, nx=True, px=PENDING_TTL_MS):
+            return "new", None
+
+        raw = self.redis.get(k)
+        if not raw:
+            # TTL expired between SET NX and GET; retry the claim once.
+            if self.redis.set(k, claim, nx=True, px=PENDING_TTL_MS):
+                return "new", None
+            raw = self.redis.get(k) or b"{}"
+
+        existing = json.loads(raw)
+        if existing.get("body") != bh:
+            return "conflict", None
+        if existing.get("state") == "pending":
+            return "in_flight", None
+        return "replay", existing.get("response")
+
+    def finalize(self, token: str, idem: str, body: Any, response: dict) -> None:
+        k = _key(token, idem)
+        payload = json.dumps({"state": "done", "body": _body_hash(body), "response": response})
+        self.redis.set(k, payload, px=DONE_TTL_MS)
+
+    def abort(self, token: str, idem: str) -> None:
+        try:
+            self.redis.delete(_key(token, idem))
+        except RedisError as e:
+            logger.warning("idempotency abort failed: %s", e)

--- a/test/unit/test_idempotency.py
+++ b/test/unit/test_idempotency.py
@@ -1,0 +1,96 @@
+import time
+import unittest
+from typing import Any, Dict, Optional
+
+from artemis.idempotency import IdempotencyStore
+
+
+class _FakeRedis:
+    """Minimal in-memory redis replacement covering only the ops IdempotencyStore uses."""
+
+    def __init__(self) -> None:
+        self._store: Dict[str, bytes] = {}
+        self._expiry: Dict[str, float] = {}
+
+    def _gc(self, key: str) -> None:
+        exp = self._expiry.get(key)
+        if exp is not None and exp < time.monotonic():
+            self._store.pop(key, None)
+            self._expiry.pop(key, None)
+
+    def set(self, key: str, value: Any, nx: bool = False, px: Optional[int] = None) -> bool:
+        self._gc(key)
+        if nx and key in self._store:
+            return False
+        self._store[key] = value.encode() if isinstance(value, str) else value
+        if px is not None:
+            self._expiry[key] = time.monotonic() + px / 1000.0
+        else:
+            self._expiry.pop(key, None)
+        return True
+
+    def get(self, key: str) -> Optional[bytes]:
+        self._gc(key)
+        return self._store.get(key)
+
+    def delete(self, key: str) -> int:
+        existed = key in self._store
+        self._store.pop(key, None)
+        self._expiry.pop(key, None)
+        return 1 if existed else 0
+
+
+class IdempotencyStoreTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.redis = _FakeRedis()
+        self.store = IdempotencyStore(self.redis)  # type: ignore[arg-type]
+        self.token = "secret-token"
+        self.body = {"targets": ["example.com"], "priority": "normal"}
+
+    def test_first_call_is_new(self) -> None:
+        state, cached = self.store.begin(self.token, "k1", self.body)
+        self.assertEqual(state, "new")
+        self.assertIsNone(cached)
+
+    def test_same_body_in_flight_returns_in_flight(self) -> None:
+        self.store.begin(self.token, "k1", self.body)
+        state, _ = self.store.begin(self.token, "k1", self.body)
+        self.assertEqual(state, "in_flight")
+
+    def test_replay_after_finalize(self) -> None:
+        self.store.begin(self.token, "k1", self.body)
+        response = {"ok": True, "ids": ["abc"]}
+        self.store.finalize(self.token, "k1", self.body, response)
+        state, cached = self.store.begin(self.token, "k1", self.body)
+        self.assertEqual(state, "replay")
+        self.assertEqual(cached, response)
+
+    def test_conflict_on_different_body(self) -> None:
+        self.store.begin(self.token, "k1", self.body)
+        self.store.finalize(self.token, "k1", self.body, {"ok": True, "ids": []})
+        state, cached = self.store.begin(self.token, "k1", {"targets": ["other.com"]})
+        self.assertEqual(state, "conflict")
+        self.assertIsNone(cached)
+
+    def test_abort_allows_retry(self) -> None:
+        self.store.begin(self.token, "k1", self.body)
+        self.store.abort(self.token, "k1")
+        state, _ = self.store.begin(self.token, "k1", self.body)
+        self.assertEqual(state, "new")
+
+    def test_keys_namespaced_per_token(self) -> None:
+        self.store.begin("token-a", "k1", self.body)
+        self.store.finalize("token-a", "k1", self.body, {"ok": True, "ids": ["a"]})
+        state, _ = self.store.begin("token-b", "k1", self.body)
+        self.assertEqual(state, "new")
+
+    def test_body_field_order_does_not_affect_hash(self) -> None:
+        self.store.begin(self.token, "k1", {"a": 1, "b": 2})
+        self.store.finalize(self.token, "k1", {"a": 1, "b": 2}, {"ok": True})
+        state, cached = self.store.begin(self.token, "k1", {"b": 2, "a": 1})
+        self.assertEqual(state, "replay")
+        self.assertEqual(cached, {"ok": True})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Add Redis-backed idempotency support to `POST /add` using an `Idempotency-Key` header to prevent duplicate task creation on retries.

## Changes
- Introduced `IdempotencyStore` with atomic claim (SET NX PX), finalize, and abort flows
- Added idempotency guard logic in `/add` handler (claim → execute → finalize)
- Cached successful responses for 24h and handled in-flight / conflict scenarios
- Namespaced keys per API token to ensure tenant isolation
- Fail-open behavior when Redis is unavailable

## Behavior
- Same key + same body → cached response replayed
- Same key + concurrent request → 409 (Retry-After)
- Same key + different body → 409 Conflict
- No header → existing behavior unchanged

## Impact
- Prevents duplicate task enqueue and redundant scans
- Reduces external request load and improves reliability under retries
- Enables safe at-least-once retry semantics for clients

## Tests
- Added unit tests for new, replay, in-flight, conflict, abort, and namespace isolation cases :contentReference[oaicite:0]{index=0}