### PR TITLE
Don't crash removed_domain_existing_vhost reporter when original_domain is None

### DIFF
--- a/artemis/reporting/modules/removed_domain_existing_vhost/reporter.py
+++ b/artemis/reporting/modules/removed_domain_existing_vhost/reporter.py
@@ -24,13 +24,15 @@ class RemovedDomainExistingVhostReporter(Reporter):
         if not task_result["status"] == "INTERESTING":
             return []
 
+        # payload_persistent.get("original_domain") can return None for tasks that didn't inherit
+        # it through the classifier chain (older rows, third-party seeding, schema migrations).
+        # Guard the "www." concatenation so a missing key doesn't crash the entire export via the
+        # DataLoader, which re-iterates every persisted row on every export.
+        original_domain = task_result["payload_persistent"].get("original_domain")
         if (
             Config.Modules.RemovedDomainExistingVhost.REMOVED_DOMAIN_EXISTING_VHOST_REPORT_ONLY_SUBDOMAINS
-            and task_result["result"]["domain"]
-            in (
-                task_result["payload_persistent"].get("original_domain"),
-                "www." + task_result["payload_persistent"].get("original_domain"),
-            )
+            and original_domain
+            and task_result["result"]["domain"] in (original_domain, "www." + original_domain)
         ):
             return []
 


### PR DESCRIPTION
## Summary
Fix crash in removed_domain_existing_vhost reporter when original_domain is missing.

## Bug
The reporter used `payload_persistent.get("original_domain")` and directly concatenated it with `"www."`. When the key was missing, this resulted in a TypeError (`"www." + None`), causing the export pipeline to fail.

## Fix
- Extract `original_domain` into a local variable
- Add a guard to ensure it exists before comparison
- Skip `www.` concatenation when `original_domain` is None

## Impact
Prevents report generation failures caused by malformed or legacy task data and avoids persistent export crashes.