### PR TITLE
Add ParamSpider as additional passive parameter source

### DIFF
--- a/artemis/crawling.py
+++ b/artemis/crawling.py
@@ -1,5 +1,8 @@
 import functools
+import subprocess
+import tempfile
 import urllib
+from pathlib import Path
 from typing import List, Tuple
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
@@ -68,7 +71,12 @@ def get_injectable_parameters(url: str) -> List[str]:
     except Exception:
         wayback_params = []
 
-    return list(set(html_params + wayback_params))
+    try:
+        paramspider_params = get_paramspider_parameters(url)
+    except Exception:
+        paramspider_params = []
+
+    return list(set(html_params + wayback_params + paramspider_params))
 
 
 @functools.lru_cache(maxsize=1024)
@@ -105,6 +113,39 @@ def get_wayback_parameters(url: str) -> List[str]:
         return list(_fetch_wayback_parameters(domain))
     except Exception:
         logger.exception("Failed to fetch Wayback CDX data for %s", domain)
+        return []
+
+
+@functools.lru_cache(maxsize=1024)
+def _fetch_paramspider_parameters(domain: str) -> Tuple[str, ...]:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_file = Path(tmpdir) / f"{domain}.txt"
+        subprocess.run(
+            ["paramspider", "-d", domain, "--output", str(output_file)],
+            capture_output=True,
+            timeout=60,
+        )
+        if not output_file.exists():
+            return ()
+
+        params: set[str] = set()
+        for line in output_file.read_text().splitlines():
+            try:
+                parsed = urlparse(line.strip())
+                params.update(parse_qs(parsed.query).keys())
+            except IndexError:
+                continue
+        return tuple(params)
+
+
+def get_paramspider_parameters(url: str) -> List[str]:
+    domain = urlparse(url).hostname
+    if not domain:
+        return []
+    try:
+        return list(_fetch_paramspider_parameters(domain))
+    except Exception:
+        logger.exception("Failed to fetch ParamSpider data for %s", domain)
         return []
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -73,6 +73,7 @@ openapi-spec-validator==0.8.4
 orjson==3.11.8
 packaging==26.1
 paramiko==4.0.0
+paramspider==2.0
 pathable==0.5.0
 pem==23.1.0
 platformdirs==4.9.4

--- a/test/unit/test_paramspider_parameters.py
+++ b/test/unit/test_paramspider_parameters.py
@@ -1,0 +1,79 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from artemis.crawling import _fetch_paramspider_parameters, get_paramspider_parameters
+
+
+class TestGetParamSpiderParameters(unittest.TestCase):
+    def setUp(self) -> None:
+        _fetch_paramspider_parameters.cache_clear()
+
+    def tearDown(self) -> None:
+        _fetch_paramspider_parameters.cache_clear()
+
+    def _mock_paramspider(self, urls: list[str]) -> MagicMock:
+        output_content = "\n".join(urls)
+
+        def fake_run(cmd: list[str], **kwargs: object) -> None:
+            output_file = cmd[cmd.index("--output") + 1]
+            with open(output_file, "w") as f:
+                f.write(output_content)
+
+        return fake_run
+
+    @patch("artemis.crawling.subprocess.run")
+    def test_extracts_parameters(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = self._mock_paramspider(
+            [
+                "http://example.com/search?q=test&lang=en",
+                "http://example.com/page?id=1",
+            ]
+        )
+
+        result = get_paramspider_parameters("http://example.com/")
+        self.assertEqual(sorted(result), ["id", "lang", "q"])
+
+    @patch("artemis.crawling.subprocess.run")
+    def test_deduplicates_parameters(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = self._mock_paramspider(
+            [
+                "http://example.com/page?id=1",
+                "http://example.com/page?id=2",
+            ]
+        )
+
+        result = get_paramspider_parameters("http://example.com/")
+        self.assertEqual(result, ["id"])
+
+    @patch("artemis.crawling.subprocess.run")
+    def test_no_output_file_returns_empty_list(self, mock_run: MagicMock) -> None:
+        mock_run.return_value = None
+
+        result = get_paramspider_parameters("http://example.com/")
+        self.assertEqual(result, [])
+
+    @patch("artemis.crawling.subprocess.run")
+    def test_failure_returns_empty_list(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = Exception("paramspider not found")
+
+        result = get_paramspider_parameters("http://example.com/")
+        self.assertEqual(result, [])
+
+    def test_invalid_url_returns_empty_list(self) -> None:
+        result = get_paramspider_parameters("not-a-url")
+        self.assertEqual(result, [])
+
+    @patch("artemis.crawling.subprocess.run")
+    def test_results_cached_per_domain(self, mock_run: MagicMock) -> None:
+        mock_run.side_effect = self._mock_paramspider(
+            ["http://example.com/page?foo=1"]
+        )
+
+        get_paramspider_parameters("http://example.com/path/a")
+        get_paramspider_parameters("http://example.com/path/b")
+
+        mock_run.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Added ParamSpider as an additional passive source for parameter discovery, alongside the existing HTML form scraping and Wayback CDX. The parameters found are merged in get_injectable_parameters() and fed into the XSS/SQLi modules.

Part of #1200 