### PR TITLE
 Add ProxyHeadersMiddleware to fix mixed-content when using SSL termination

### DIFF
--- a/artemis/config.py
+++ b/artemis/config.py
@@ -237,6 +237,13 @@ class Config:
             "A file that determines what should not be scanned or reported",
         ] = get_config("BLOCKLIST_FILE", default=None)
 
+        TRUSTED_PROXY_HOSTS: Annotated[
+            Optional[str],
+            "Comma-separated list of trusted proxy hosts for ProxyHeadersMiddleware (e.g. '127.0.0.1,10.0.0.1'). "
+            "Set to '*' to trust all proxies. If not set, ProxyHeadersMiddleware will not be added. "
+            "Use this when running Artemis behind a reverse proxy with SSL termination.",
+        ] = get_config("TRUSTED_PROXY_HOSTS", default=None)
+
         CUSTOM_USER_AGENT: Annotated[
             str,
             "Custom User-Agent string used by Artemis (if not set, the library defaults will be used, different for requests, Nuclei etc.)",

--- a/artemis/main.py
+++ b/artemis/main.py
@@ -15,6 +15,7 @@ from artemis.config import Config
 from artemis.db import DB
 from artemis.frontend import error_content_not_found
 from artemis.frontend import router as router_front
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 faulthandler.register(signal.SIGUSR1)
 
@@ -35,6 +36,7 @@ app.add_middleware(
     same_site="strict",
     https_only=False,
 )
+app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
 
 db = DB()
 

--- a/artemis/main.py
+++ b/artemis/main.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi_csrf_protect.exceptions import CsrfProtectError
 from starlette.middleware.sessions import SessionMiddleware
+from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 from artemis import csrf
 from artemis.api import router as router_api
@@ -15,7 +16,6 @@ from artemis.config import Config
 from artemis.db import DB
 from artemis.frontend import error_content_not_found
 from artemis.frontend import router as router_front
-from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 faulthandler.register(signal.SIGUSR1)
 
@@ -36,7 +36,8 @@ app.add_middleware(
     same_site="strict",
     https_only=False,
 )
-app.add_middleware(ProxyHeadersMiddleware, trusted_hosts="*")
+if Config.Miscellaneous.TRUSTED_PROXY_HOSTS:
+    app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=Config.Miscellaneous.TRUSTED_PROXY_HOSTS)  # type: ignore[arg-type]
 
 db = DB()
 


### PR DESCRIPTION
When Artemis is deployed behind nginx or apache2 with SSL termination,
static files (CSS, JS, favicon) are served with `http://` URLs instead
of `https://`, causing browsers to block them as mixed content and
breaking the UI.

The proxy correctly sets `X-Forwarded-Proto: https` but Artemis was
not reading it.

## Fix
Add `ProxyHeadersMiddleware` from uvicorn (already a dependency) so
that Artemis respects the `X-Forwarded-Proto` header and generates
correct `https://` URLs for static content.

## Changes
- Add `ProxyHeadersMiddleware` import and middleware in `artemis/main.py`

Closes #2715