### PR TITLE
Drop badkeys --update-bl from docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,8 +26,7 @@ RUN apk add --no-cache --virtual .build-deps gcc git libc-dev make libffi-dev li
     git clone https://github.com/Ostorlab/KEV.git --branch main /known-exploited-vulnerabilities && \
     pip install --no-cache-dir -r requirements.txt -r /humble/requirements.txt $ADDITIONAL_REQUIREMENTS && \
     apk del .build-deps && \
-    nuclei -update-templates && \
-    badkeys --update-bl
+    nuclei -update-templates
 
 WORKDIR /opt
 


### PR DESCRIPTION
The `badkeys --update-bl` call in the Dockerfile downloads a blocklist at build time, and when that download flakes the entire image build fails. The same call already runs inside `SSHBadKeys.__init__`, so the blocklist still gets refreshed when the module starts - but if the download flakes there, only the badkeys module is affected instead of the whole build.