### PR TITLE
Modify PostgreSQL warning regex to exclude pg_connect() errors

### DIFF
--- a/artemis/sql_injection_data.py
+++ b/artemis/sql_injection_data.py
@@ -26,7 +26,7 @@ SQL_ERROR_MESSAGES: List[str] = [
     "unsupported nested scalar subselect",
     # PostgreSQL,
     "PostgreSQL.{0,200}?ERROR",
-    "Warning.{0,200}?\\Wpg_",
+    "Warning.{0,200}?\\Wpg_(?!connect)",
     "valid PostgreSQL result",
     "Npgsql\\.",
     "PG::SyntaxError:",

--- a/test/modules/test_sql_injection_detector.py
+++ b/test/modules/test_sql_injection_detector.py
@@ -6,6 +6,7 @@ from karton.core import Task
 
 from artemis import http_requests
 from artemis.binds import Service, TaskStatus, TaskType
+from artemis.http_requests import HTTPResponse
 from artemis.modules.sql_injection_detector import SqlInjectionDetector
 
 
@@ -72,6 +73,30 @@ class PostgresSqlInjectionDetectorTestCase(ArtemisModuleTestCase):
                 url_to_headers_vuln, http_requests.get(url_to_headers_vuln, headers={"User-Agent": "'"})
             )
         )
+
+    def test_contains_error_ignores_pg_connect_warning(self) -> None:
+        response = HTTPResponse(
+            status_code=200,
+            content_bytes=b"Warning: pg_connect(): Unable to connect to PostgreSQL server",
+            encoding="utf-8",
+            is_redirect=False,
+            url="http://example.com",
+            headers={},
+        )
+
+        self.assertIsNone(self.karton.contains_error("http://example.com", response))
+
+    def test_contains_error_detects_pg_query(self) -> None:
+        response = HTTPResponse(
+            status_code=500,
+            content_bytes=b"Warning: pg_query(): Query failed: ERROR: syntax error at or near",
+            encoding="utf-8",
+            is_redirect=False,
+            url="http://example.com",
+            headers={},
+        )
+
+        self.assertIsNotNone(self.karton.contains_error("http://example.com", response))
 
 
 class MysqlSqlInjectionDetectorTestCase(ArtemisModuleTestCase):


### PR DESCRIPTION
##  Problem

The `Warning.{0,200}?\Wpg_` pattern in `SQL_ERROR_MESSAGES` was too broad. It matched `Warning: pg_connect(): Unable to connect to PostreSQL server`, causing database connection error to be reported as SQLi finding.

## Fix
Narrowed the pattern with a negative lookahead:
Warning.{0,200}?\Wpg_(?!connect)

This excludes `pg_connect()` while still matching SQLi signals such as `pg_query()` syntax errors.

## Tests
Added two tests to `PostgreSqlInjectionDetectorTestCase`:
- `test_contains_error_ingores_pg_connect_warning` - verifies a `pg_connect()` warning is no longer flagged as SQLi
- `test_contains_error_detects_pg_query` - verifies that the fix doesn't hide a genuine `pg_query()`

## Note
The lookahead is scoped to `pg_connect()` as described in the issue. However, `pg_pconnect()` could in theory trigger the same false positive - happy to extend it to `(?!p?connect)` if needed.

Fixes #2762