### PR TITLE
Made all URLs in HTML templates and in redirects relative

### DIFF
--- a/artemis/frontend.py
+++ b/artemis/frontend.py
@@ -84,7 +84,7 @@ if not Config.Miscellaneous.API_TOKEN:
 @router.get("/login", include_in_schema=False)
 def get_login(request: Request) -> Response:
     if request.session.get(auth.SESSION_KEY_AUTHENTICATED):
-        return RedirectResponse(request.url_for("get_root"), status_code=303)
+        return RedirectResponse(request.app.url_path_for("get_root"), status_code=303)
 
     return templates.TemplateResponse(
         "login.jinja2",
@@ -114,7 +114,7 @@ async def post_login(
         )
 
     request.session[auth.SESSION_KEY_AUTHENTICATED] = True
-    return RedirectResponse(request.url_for("get_root"), status_code=303)
+    return RedirectResponse(request.app.url_path_for("get_root"), status_code=303)
 
 
 @router.post("/logout", include_in_schema=False)
@@ -140,7 +140,7 @@ def get_root(request: Request, csrf_protect: CsrfProtect = Depends()) -> Respons
             "request": request,
             "has_analyses": has_analyses,
             "has_finished_analyses": has_finished_analyses,
-            "api_url": str(request.url_for("get_analyses_table")),
+            "api_url": str(request.app.url_path_for("get_analyses_table")),
             "num_active_tasks": sum(num_pending_tasks.values()),
         },
         csrf_protect,
@@ -226,7 +226,7 @@ async def post_add(
 
     await asyncio.to_thread(create_tasks, total_list, tag, disabled_modules, TaskPriority(priority))
     if redirect:
-        return RedirectResponse(request.url_for("get_root"), status_code=303)
+        return RedirectResponse(request.app.url_path_for("get_root"), status_code=303)
     else:
         return Response(
             content="OK",
@@ -314,7 +314,7 @@ def view_export(request: Request, id: int) -> Response:
 @csrf.validate_csrf
 async def post_export_delete(request: Request, id: int, csrf_protect: CsrfProtect = Depends()) -> Response:
     await asyncio.to_thread(db.delete_report_generation_task, id)
-    return RedirectResponse(request.url_for("get_exports"), status_code=303)
+    return RedirectResponse(request.app.url_path_for("get_exports"), status_code=303)
 
 
 def build_export_zip_response(id: int) -> Response:
@@ -358,7 +358,7 @@ async def post_export(
         comment=comment,
         language=Language(language),
     )
-    return RedirectResponse(request.url_for("get_exports"), status_code=303)
+    return RedirectResponse(request.app.url_path_for("get_exports"), status_code=303)
 
 
 @router.post("/remove-finished-analyses", include_in_schema=False)
@@ -374,7 +374,7 @@ async def post_remove_finished_analyses(request: Request, csrf_protect: CsrfProt
                 db.delete_analysis(analysis["id"])
 
     await asyncio.to_thread(_remove_finished_analyses)
-    return RedirectResponse(request.url_for("get_root"), status_code=303)
+    return RedirectResponse(request.app.url_path_for("get_root"), status_code=303)
 
 
 @router.post("/analysis/remove-pending-tasks/{analysis_id}", include_in_schema=False)
@@ -390,7 +390,7 @@ async def post_remove_pending_tasks(
                 backend.delete_task(task)
 
     await asyncio.to_thread(_remove_pending_tasks)
-    return RedirectResponse(request.url_for("get_root"), status_code=303)
+    return RedirectResponse(request.app.url_path_for("get_root"), status_code=303)
 
 
 @router.get("/analysis/get-pending-tasks/{analysis_id}", include_in_schema=False)
@@ -433,7 +433,7 @@ def get_restart_crashed_tasks(request: Request, csrf_protect: CsrfProtect = Depe
 @csrf.validate_csrf
 async def post_restart_crashed_tasks(request: Request, csrf_protect: CsrfProtect = Depends()) -> Response:
     await asyncio.to_thread(restart_crashed_tasks)
-    return RedirectResponse(request.url_for("get_root"), status_code=303)
+    return RedirectResponse(request.app.url_path_for("get_root"), status_code=303)
 
 
 @router.get("/queue", include_in_schema=False)
@@ -494,7 +494,7 @@ def get_analysis(request: Request, root_id: str, task_filter: Optional[TaskFilte
         {
             "request": request,
             "title": f"Analysis of {analysis['target']}",
-            "api_url": str(request.url_for("get_task_results_table"))
+            "api_url": str(request.app.url_path_for("get_task_results_table"))
             + "?"
             + urllib.parse.urlencode(api_url_parameters),
             "task_filter": task_filter,
@@ -513,7 +513,7 @@ def get_results(request: Request, task_filter: Optional[TaskFilter] = None) -> R
         {
             "request": request,
             "title": "Results",
-            "api_url": str(request.url_for("get_task_results_table"))
+            "api_url": str(request.app.url_path_for("get_task_results_table"))
             + "?"
             + urllib.parse.urlencode(api_url_parameters),
             "task_filter": task_filter,

--- a/templates/add.jinja2
+++ b/templates/add.jinja2
@@ -13,7 +13,7 @@
     </script>
 
     <h1>Add targets</h1>
-    <form action="{{ request.url_for('post_add') }}" method="post" class="w-100">
+    <form action="{{ request.app.url_path_for('post_add') }}" method="post" class="w-100">
         {% if validation_message %}
             <div class="alert alert-danger" role="alert">
                 {{ validation_message }}

--- a/templates/components/base.jinja2
+++ b/templates/components/base.jinja2
@@ -4,11 +4,11 @@
         <title>Artemis</title>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" href="{{ request.url_for('static', path='bootstrap.min.css') }}?v=2">
+        <link rel="stylesheet" href="{{ request.app.url_path_for('static', path='bootstrap.min.css') }}?v=2">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css" integrity="sha512-Kc323vGBEqzTmouAECnVceyQqyqdsSiqLQISBL29aUW4U/M7pSPA/gEUZQqv1cwx4OnYxTxve5UMg5GT6L4JJg==" crossorigin="anonymous" />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.21/css/dataTables.bootstrap4.min.css" integrity="sha512-PT0RvABaDhDQugEbpNMwgYBCnGCiTZMh9yOzUsJHDgl/dMhD9yjHAwoumnUk3JydV3QTcIkNDuN40CJxik5+WQ==" crossorigin="anonymous" />
-	<link rel="stylesheet" href="{{ request.url_for('static', path='style.css') }}?v=3" />
-    <link rel="icon" href="{{ request.url_for('static', path='images/favicon.ico') }}" type="image/x-icon">
+	<link rel="stylesheet" href="{{ request.app.url_path_for('static', path='style.css') }}?v=3" />
+    <link rel="icon" href="{{ request.app.url_path_for('static', path='images/favicon.ico') }}" type="image/x-icon">
     </head>
     <body class="w-100 h-100" data-bs-theme="dark">
         {% include "components/navbar.jinja2" %}
@@ -19,7 +19,7 @@
             {% endblock %}
         </main>
         {% endblock %}
-        <script src="{{ request.url_for('static', path='theme.js') }}"></script>
+        <script src="{{ request.app.url_path_for('static', path='theme.js') }}"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.3.3/js/bootstrap.bundle.min.js" integrity="sha512-7Pi/otdlbbCR+LnW+F7PwFcSDJOuUJB3OxtEHbg4vSMvzvJjde4Po1v4BR9Gdc9aXNUNFVUY+SK51wWT8WF0Gg==" crossorigin="anonymous"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.21/js/jquery.dataTables.min.js" integrity="sha512-BkpSL20WETFylMrcirBahHfSnY++H2O1W+UnEEO4yNIl+jI2+zowyoGJpbtk6bx97fBXf++WJHSSK2MV4ghPcg==" crossorigin="anonymous"></script>

--- a/templates/components/generating_reports_hint.jinja2
+++ b/templates/components/generating_reports_hint.jinja2
@@ -1,3 +1,3 @@
 Hint: if, instead of browsing the raw task results, you want to export concise
 <a href="https://artemis-scanner.readthedocs.io/en/latest/generating-reports.html#example-vulnerability-report-generated-by-artemis">
-HTML reports</a> with few false positives and duplicates, <a href="{{ request.url_for('get_export_form') }}">click here</a>.
+HTML reports</a> with few false positives and duplicates, <a href="{{ request.app.url_path_for('get_export_form') }}">click here</a>.

--- a/templates/components/navbar.jinja2
+++ b/templates/components/navbar.jinja2
@@ -1,9 +1,9 @@
 <header>
     <nav class="navbar navbar-expand-lg">
         <div class="container-fluid">
-            <a class="navbar-brand" href="{{ request.url_for('get_root') }}">
-                <img src="{{ request.url_for('static', path='images/logo.png') }}" class="logo light">
-                <img src="{{ request.url_for('static', path='images/logo_dark.png') }}" class="logo dark">
+            <a class="navbar-brand" href="{{ request.app.url_path_for('get_root') }}">
+                <img src="{{ request.app.url_path_for('static', path='images/logo.png') }}" class="logo light">
+                <img src="{{ request.app.url_path_for('static', path='images/logo_dark.png') }}" class="logo dark">
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
@@ -12,25 +12,25 @@
                 {% if request.session.get('authenticated') %}
                 <ul class="navbar-nav">
                     <li class="nav-item">
-                        <a class="nav-link {{ 'active' if request.url.path == request.url_for('get_add_form').path }}" href="{{ request.url_for('get_add_form') }}">Add targets</a>
+                        <a class="nav-link {{ 'active' if request.url.path == request.app.url_path_for('get_add_form') }}" href="{{ request.app.url_path_for('get_add_form') }}">Add targets</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link {{ 'active' if request.url.path == request.url_for('get_root').path }}" href="{{ request.url_for('get_root') }}">View targets</a>
+                        <a class="nav-link {{ 'active' if request.url.path == request.app.url_path_for('get_root') }}" href="{{ request.app.url_path_for('get_root') }}">View targets</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link {{ 'active' if request.url.path == request.url_for('get_results').path }}" href="{{ request.url_for('get_results') }}?task_filter=interesting">View raw task results</a>
+                        <a class="nav-link {{ 'active' if request.url.path == request.app.url_path_for('get_results') }}" href="{{ request.app.url_path_for('get_results') }}?task_filter=interesting">View raw task results</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link {{ 'active' if request.url.path == request.url_for('get_export_form').path }}" href="{{ request.url_for('get_export_form') }}">Export reports</a>
+                        <a class="nav-link {{ 'active' if request.url.path == request.app.url_path_for('get_export_form') }}" href="{{ request.app.url_path_for('get_export_form') }}">Export reports</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link {{ 'active' if request.url.path == request.url_for('get_exports').path }}" href="{{ request.url_for('get_exports') }}">View exported reports</a>
+                        <a class="nav-link {{ 'active' if request.url.path == request.app.url_path_for('get_exports') }}" href="{{ request.app.url_path_for('get_exports') }}">View exported reports</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link {{ 'active' if request.url.path == request.url_for('get_queue').path }}" href="{{ request.url_for('get_queue') }}">Task queue</a>
+                        <a class="nav-link {{ 'active' if request.url.path == request.app.url_path_for('get_queue') }}" href="{{ request.app.url_path_for('get_queue') }}">Task queue</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link {{ 'active' if request.url.path == request.url_for('get_restart_crashed_tasks').path }}" href="{{ request.url_for('get_restart_crashed_tasks') }}">Restart crashed tasks</a>
+                        <a class="nav-link {{ 'active' if request.url.path == request.app.url_path_for('get_restart_crashed_tasks') }}" href="{{ request.app.url_path_for('get_restart_crashed_tasks') }}">Restart crashed tasks</a>
                     </li>
                     <li class="nav-item">
                         <a class="nav-link {{ 'active' if request.path == '/docs' }}" href="/docs">API</a>
@@ -41,7 +41,7 @@
             <div class="navbar-nav ms-auto">
                 {% if request.session.get('authenticated') %}
                 <li class="nav-item align-items-center d-flex me-3">
-                    <form method="post" action="{{ request.url_for('post_logout') }}" class="d-inline">
+                    <form method="post" action="{{ request.app.url_path_for('post_logout') }}" class="d-inline">
                         <button type="submit" class="btn btn-link nav-link p-0">Logout</button>
                     </form>
                 </li>

--- a/templates/export.jinja2
+++ b/templates/export.jinja2
@@ -2,7 +2,7 @@
 
 {% block main %}
     <h1>Export reports</h1>
-    <form action="{{ request.url_for('post_export') }}" method="post" class="w-100">
+    <form action="{{ request.app.url_path_for('post_export') }}" method="post" class="w-100">
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
 
         <div class="form-group mb-3">

--- a/templates/exports.jinja2
+++ b/templates/exports.jinja2
@@ -64,7 +64,7 @@
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                        <form action="{{ request.url_for('post_export_delete', id=report_generation_task.id) }}" method="post" style="display: inline;">
+                        <form action="{{ request.app.url_path_for('post_export_delete', id=report_generation_task.id) }}" method="post" style="display: inline;">
                             <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
                             <button type="submit" class="btn btn-danger">Delete</button>
                         </form>
@@ -79,7 +79,7 @@
             You have not yet exported reports from Artemis.
         </p>
         <p>
-            <a href="{{ request.url_for('get_export_form') }}" class="btn btn-primary">Export reports</a>
+            <a href="{{ request.app.url_path_for('get_export_form') }}" class="btn btn-primary">Export reports</a>
         </p>
 
     {%  else %}
@@ -116,8 +116,8 @@
                         </td>
                         <td>
                             {%  if report_generation_task.status == "done" %}
-                                <a href="{{ request.url_for('export_download_zip', id=report_generation_task.id).path }}">Download ZIP</a> |
-                                <a href="{{ request.url_for('view_export', id=report_generation_task.id).path }}">Browse</a> |
+                                <a href="{{ request.app.url_path_for('export_download_zip', id=report_generation_task.id) }}">Download ZIP</a> |
+                                <a href="{{ request.app.url_path_for('view_export', id=report_generation_task.id) }}">Browse</a> |
                             {%  elif report_generation_task.status == "failed" %}
                                 <a href="#" data-bs-toggle="modal" data-bs-target="#error-{{  report_generation_task.id }}">
                                   Show error
@@ -137,6 +137,6 @@
             </tbody>
         </table>
 
-        <a href="{{ request.url_for('get_export_form').path }}" class="btn btn-primary">Export reports</a>
+        <a href="{{ request.app.url_path_for('get_export_form') }}" class="btn btn-primary">Export reports</a>
     {%  endif %}
 {% endblock %}

--- a/templates/index.jinja2
+++ b/templates/index.jinja2
@@ -19,17 +19,17 @@
             </thead>
         </table>
         <p>
-            <a class="btn btn-primary" href="{{ request.url_for('get_results') }}?task_filter=interesting">Show results for all targets</a>
+            <a class="btn btn-primary" href="{{ request.app.url_path_for('get_results') }}?task_filter=interesting">Show results for all targets</a>
 
             {% if has_finished_analyses %}
                 <a class="btn btn-danger" href="#" data-bs-toggle="modal" data-bs-target="#remove-finished-analyses-modal">Remove finished analyses</a>
             {% endif %}
         </p>
         <p>
-            Hint: Browse to the <a href="{{ request.url_for('get_queue') }}">task queue</a> to see how the tasks are progressing.
+            Hint: Browse to the <a href="{{ request.app.url_path_for('get_queue') }}">task queue</a> to see how the tasks are progressing.
         </p>
     {% else %}
-        No targets have yet been analysed. <a href="{{ request.url_for('get_add_form') }}">Analyze targets.</a>
+        No targets have yet been analysed. <a href="{{ request.app.url_path_for('get_add_form') }}">Analyze targets.</a>
     {% endif %}
 
     <div class="modal" tabindex="-1" role="dialog" id="remove-pending-tasks-modal" aria-hidden="true">
@@ -67,13 +67,13 @@
                     <div class="alert alert-info">
                         This will remove the finished analyses (with the <b>done</b> badge) from the table on the homepage. The
                         corresponding task results will still be in the database and you will still be able to
-                        <a href="{{ request.url_for('get_export_form') }}">export them</a> or view them on the
-                        <a href="{{ request.url_for('get_results') }}?task_filter=interesting">all task results</a> list.
+                        <a href="{{ request.app.url_path_for('get_export_form') }}">export them</a> or view them on the
+                        <a href="{{ request.app.url_path_for('get_results') }}?task_filter=interesting">all task results</a> list.
                     </div>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                    <form method="POST" action="{{ request.url_for('post_remove_finished_analyses') }}" style="display: inline;">
+                    <form method="POST" action="{{ request.app.url_path_for('post_remove_finished_analyses') }}" style="display: inline;">
                         <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
                         <button type="submit" class="btn btn-danger">Remove</button>
                     </form>

--- a/templates/login.jinja2
+++ b/templates/login.jinja2
@@ -8,7 +8,7 @@
         </div>
     {% endif %}
 
-    <form action="{{ request.url_for('post_login') }}" method="post" class="w-100" style="max-width: 400px;">
+    <form action="{{ request.app.url_path_for('post_login') }}" method="post" class="w-100" style="max-width: 400px;">
         <div class="form-group mb-3">
             <label class="form-label">Username</label>
             <input class="form-control" type="text" name="username" autocomplete="username" required autofocus>

--- a/templates/queue.jinja2
+++ b/templates/queue.jinja2
@@ -1,4 +1,4 @@
 {% extends "components/base.jinja2" %}
 {% block main_raw %}
-    <iframe id="dashboard-frame" class="w-100 h-100" style="border: none; margin-top: -90px" src="{{ request.url_for('karton_dashboard', path='') }}"></iframe>
+    <iframe id="dashboard-frame" class="w-100 h-100" style="border: none; margin-top: -90px" src="{{ request.app.url_path_for('karton_dashboard', path='') }}"></iframe>
 {% endblock %}

--- a/templates/restart_crashed_tasks.jinja2
+++ b/templates/restart_crashed_tasks.jinja2
@@ -3,7 +3,7 @@
 {% block main %}
     <h1>Restart all crashed tasks</h1>
 
-    <form method="POST" action="{{ request.url_for('post_restart_crashed_tasks') }}">
+    <form method="POST" action="{{ request.app.url_path_for('post_restart_crashed_tasks') }}">
         <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
 
         <input type="submit" class="btn btn-primary" value="restart" />

--- a/templates/table_row/analysis/actions.jinja2
+++ b/templates/table_row/analysis/actions.jinja2
@@ -1,6 +1,6 @@
-<a href="{{ request.url_for('get_analysis', root_id=entry.id) }}?task_filter=interesting">Show results</a> |
+<a href="{{ request.app.url_path_for('get_analysis', root_id=entry.id) }}?task_filter=interesting">Show results</a> |
 {% if enabled_modules %}
     <a href="#" data-bs-toggle="tooltip" title="{{ enabled_modules }}">Show enabled modules</a> |
 {% endif %}
-<a href="{{ request.url_for('get_pending_tasks', analysis_id=entry.id) }}">Show pending tasks</a> |
+<a href="{{ request.app.url_path_for('get_pending_tasks', analysis_id=entry.id) }}">Show pending tasks</a> |
 <a class="text-danger remove-pending-tasks-link" href="#" data-analysis-id="{{ entry.id }}" data-analysis-target="{{ entry.target }}" data-bs-toggle="modal" data-bs-target="#remove-pending-tasks-modal">Remove pending tasks</a>

--- a/templates/table_row/task/task_link.jinja2
+++ b/templates/table_row/task/task_link.jinja2
@@ -1,1 +1,1 @@
-<a href="{{ request.url_for('get_task', task_id=task_result.id) }}">{{ task_result.target_string }}</a>
+<a href="{{ request.app.url_path_for('get_task', task_id=task_result.id) }}">{{ task_result.target_string }}</a>

--- a/templates/task.jinja2
+++ b/templates/task.jinja2
@@ -31,23 +31,23 @@
     {% if task.parent_uid %}
         <dt class="col-3">Parent UID</dt>
         <dd class="col-9">
-            <a href="{{ request.url_for('get_task', task_id=task.parent_uid) }}">{{task.task.parent_uid}}</a>
+            <a href="{{ request.app.url_path_for('get_task', task_id=task.parent_uid) }}">{{task.task.parent_uid}}</a>
         </dd>
     {% endif %}
 
     <dt class="col-3">Analysis</dt>
     <dd class="col-9">
-      <a href="{{ request.url_for('get_analysis', root_id=task.analysis_id) }}">{{task.analysis_id}}</a>
+      <a href="{{ request.app.url_path_for('get_analysis', root_id=task.analysis_id) }}">{{task.analysis_id}}</a>
     </dd>
 
     <dt class="col-3">Origin</dt>
     <dd class="col-9">
-      <a href="{{ request.url_for('karton_dashboard', path='queue/' + task.task['headers']['origin']) }}">{{task.task['headers']['origin']}}</a>
+      <a href="{{ request.app.url_path_for('karton_dashboard', path='queue/' + task.task['headers']['origin']) }}">{{task.task['headers']['origin']}}</a>
     </dd>
 
     <dt class="col-3">Receiver</dt>
     <dd class="col-9">
-      <a href="{{ request.url_for('karton_dashboard', path='queue/' + task.task['headers']['receiver']) }}">{{task.task['headers']['receiver']}}</a>
+      <a href="{{ request.app.url_path_for('karton_dashboard', path='queue/' + task.task['headers']['receiver']) }}">{{task.task['headers']['receiver']}}</a>
     </dd>
 
     <dt class="col-3">Headers</dt>

--- a/templates/view_export.jinja2
+++ b/templates/view_export.jinja2
@@ -15,7 +15,7 @@
     </dl>
 
     {% if task.status == "done" %}
-        <a class="btn btn-primary mt-4 mb-4" href="{{ request.url_for('export_download_zip', id=task.id) }}">Download ZIP</a>
+        <a class="btn btn-primary mt-4 mb-4" href="{{ request.app.url_path_for('export_download_zip', id=task.id) }}">Download ZIP</a>
 
         <ul class="nav nav-tabs" role="tablist">
           <li class="nav-item" role="presentation">


### PR DESCRIPTION
`request.url_for(...)` generates absolute URLs, based on the `Host` header and the incoming connection scheme (http/https). But absolute URLs easily cause problems when reverse proxies are involved, like the one described in issue #2715 for example.

This commit changes all URL generation to produce relative URLs only. So what used to be `<link rel="stylesheet"
href="http://127.0.0.1:5000/static/bootstrap.min.css?v=2">` in the page header becomes `<link rel="stylesheet" href="/static/bootstrap.min.css?v=2">` instead. Way less problematic.

Additionally, some URLs were already relative, generated using the `request.url_for(...).path` pattern. I have standardized all of them to use `request.app.url_path_for()` instead.