### PR TITLE
Add HTTP Basic auth support to admin_panel_login_bruter. Move per-attempt brute logs to DEBUG

### DIFF
--- a/artemis/modules/admin_panel_login_bruter.py
+++ b/artemis/modules/admin_panel_login_bruter.py
@@ -1,3 +1,4 @@
+import base64
 import binascii
 import itertools
 import os
@@ -72,13 +73,19 @@ class AdminPanelLoginBruter(ArtemisBase):
         {"type": TaskType.SERVICE.value, "service": Service.HTTP.value},
     ]
 
+    def _is_basic_auth_challenge(self, response: Optional[http_requests.HTTPResponse]) -> bool:
+        if response is None or response.status_code != 401:
+            return False
+        return response.headers.get("WWW-Authenticate", "").lower().startswith("basic")
+
     def check_url(self, url: str) -> bool:
-        """
-        Checks if the given URL is accessible and returns a 200 status code.
-        """
         try:
             response = http_requests.get(url)
-            return response.status_code == 200 if response else False
+            if not response:
+                return False
+            if response.status_code == 200:
+                return True
+            return self._is_basic_auth_challenge(response)
         except requests.RequestException as e:
             self.log.debug(f"Error checking URL {url}: {e}")
             return False
@@ -152,6 +159,38 @@ class AdminPanelLoginBruter(ArtemisBase):
 
         return (is_json_api, None)
 
+    def _try_basic_auth(
+        self, session: requests.Session, login_url: str, username: str, password: str
+    ) -> Tuple[bool, Optional[AdminPanelLoginBruterResult]]:
+        """Try HTTP Basic auth for panels that respond with a 401 Basic challenge."""
+        token = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
+        self.log.debug("Trying HTTP Basic auth on %s", login_url)
+        try:
+            response = self.throttle_request(
+                lambda: http_requests.request(
+                    "get",
+                    login_url,
+                    session=session,
+                    headers={"Authorization": f"Basic {token}"},
+                )
+            )
+        except requests.RequestException as e:
+            self.log.debug("Error during Basic auth on %s: %s", login_url, e)
+            return (False, None)
+
+        if response is not None and response.status_code == 200:
+            self.log.info("successful Basic auth on %s username=%s password=%s", login_url, username, password)
+            return (
+                True,
+                AdminPanelLoginBruterResult(
+                    url=login_url,
+                    username=username,
+                    password=password,
+                    indicators=["http_basic_auth"],
+                ),
+            )
+        return (True, None)
+
     def discover_login_paths(self, base_url: str) -> List[str]:
         """
         Discovers common admin login paths by checking predefined URLs.
@@ -197,13 +236,15 @@ class AdminPanelLoginBruter(ArtemisBase):
         Attempts to brute-force a single login path.
         Returns a tuple: (login_mechanism_found, AdminPanelLoginBruterResult)
         """
-        self.log.info("Trying %s:%s on %s/%s", username, password, base_url, login_path.lstrip("/"))
+        self.log.debug("Trying %s:%s on %s/%s", username, password, base_url, login_path.lstrip("/"))
         login_url = urllib.parse.urljoin(base_url, login_path)
         session = requests.session()
         login_mechanism_found = False
 
         try:
             response = self.throttle_request(lambda: http_requests.request("get", login_url, session=session))
+            if self._is_basic_auth_challenge(response):
+                return self._try_basic_auth(session, login_url, username, password)
             if not response or response.status_code != 200:
                 # GET failed — the path may still be a JSON-only API endpoint;
                 # attempt JSON login before giving up.
@@ -243,14 +284,14 @@ class AdminPanelLoginBruter(ArtemisBase):
                             form_data[input_name] = input_value
 
                 if not found_username or not found_password:
-                    self.log.info("Didn't found username/pwd in form, ignoring...")
+                    self.log.debug("Didn't find username/pwd in form, ignoring...")
                     continue
                 else:
-                    self.log.info("Found username/pwd in form on %s, proceeding", login_url)
+                    self.log.debug("Found username/pwd in form on %s, proceeding", login_url)
                     login_mechanism_found = True
 
                 try:
-                    self.log.info("Post data: %s", form_data)
+                    self.log.debug("Post data: %s", form_data)
                     post_response = self.throttle_request(
                         lambda: http_requests.request(
                             "post",

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -340,6 +340,11 @@ services:
       timeout: 10s
       retries: 12
       start_period: 60s
+  test-nginx-basic-auth:
+    image: nginx:latest
+    volumes:
+      - ./test/data/admin_panel_login_bruter_basic_auth/default.conf:/etc/nginx/conf.d/default.conf
+      - ./test/data/admin_panel_login_bruter_basic_auth/.htpasswd:/etc/nginx/.htpasswd
 
 volumes:
   data-test:

--- a/test/data/admin_panel_login_bruter_basic_auth/.htpasswd
+++ b/test/data/admin_panel_login_bruter_basic_auth/.htpasswd
@@ -1,0 +1,1 @@
+admin:$apr1$Veasb5Ap$eHTrhxXS6KK0u91NnXPPW0

--- a/test/data/admin_panel_login_bruter_basic_auth/default.conf
+++ b/test/data/admin_panel_login_bruter_basic_auth/default.conf
@@ -1,0 +1,14 @@
+server {
+    listen 80;
+
+    location = /admin/ {
+        auth_basic "Restricted";
+        auth_basic_user_file /etc/nginx/.htpasswd;
+        root /usr/share/nginx/html;
+        try_files /index.html =404;
+    }
+
+    location / {
+        return 404;
+    }
+}

--- a/test/modules/test_admin_panel_login_bruter.py
+++ b/test/modules/test_admin_panel_login_bruter.py
@@ -63,3 +63,21 @@ class AdminPanelLoginBruterTest(ArtemisModuleTestCase):
         self.assertEqual(call.kwargs["data"]["results"][0]["username"], "admin")
         self.assertEqual(call.kwargs["data"]["results"][0]["password"], "admin")
         self.assertIn("json_api_token", call.kwargs["data"]["results"][0]["indicators"])
+
+    def test_basic_auth_login(self) -> None:
+        """Test that an endpoint protected by HTTP Basic auth is detected and brute-forced."""
+        task = Task(
+            {"type": TaskType.SERVICE.value, "service": Service.HTTP.value},
+            payload={
+                "host": "test-nginx-basic-auth",
+                "port": 80,
+            },
+        )
+
+        self.run_task(task)
+        (call,) = self.mock_db.save_task_result.call_args_list
+        self.assertEqual(call.kwargs["status"], TaskStatus.INTERESTING)
+        self.assertEqual(call.kwargs["data"]["results"][0]["url"], "http://test-nginx-basic-auth:80/admin/")
+        self.assertEqual(call.kwargs["data"]["results"][0]["username"], "admin")
+        self.assertEqual(call.kwargs["data"]["results"][0]["password"], "admin")
+        self.assertEqual(call.kwargs["data"]["results"][0]["indicators"], ["http_basic_auth"])


### PR DESCRIPTION
***Basic auth support (#2378)***:
hosts behind HTTP Basic were dropped at discovery because check_url only accepted 200, while a Basic challenge is 401. Now we detect the challenge and try credentials via the Authorization header. Integration test against a real nginx fixture, following the module's existing convention. Note: credentials go through headers={"Authorization": ...} rather than auth=, because the http_requests wrapper only forwards headers.
***Logging per-attempt logs (Trying / form match / post data)***:
moved to DEBUG across all login paths. Successes, discovered paths and rechecks stay at INFO. Per @kazet's suggestion.