### PR TITLE
deduplicate original host for listed modules

### DIFF
--- a/artemis/config.py
+++ b/artemis/config.py
@@ -331,6 +331,16 @@ class Config:
             bool, "Raise error in case cleanup task did not found unfinished analyses."
         ] = get_config("CLEANUP_RAISE_ERROR_ON_NON_UNFINISHED_ANALYSES", default=False, cast=bool)
 
+        MODULES_WHITELIST_FOR_ORIGINAL_HOST_DEDUPLICATION: Annotated[
+            list[str],
+            "List of modules not depending on original_ip/original_domain. "
+            "The purpose of the list is solely for task deduplication. Can be extended with custom modules.",
+        ] = get_config(
+            "MODULES_WHITELIST_FOR_ORIGINAL_HOST_DEDUPLICATION",
+            default="nuclei-router,nuclei-module,admin_panel_login_bruter,xss_scanner,lfi_detector,sqlmap,sql_injection_detector,dangling_dns_detector",
+            cast=decouple.Csv(str, delimiter=","),
+        )
+
     class Modules:
         class AdminPanelLoginBruter:
             ADMIN_PANEL_LOGIN_BRUTER_NUM_RECHECKS: Annotated[

--- a/artemis/db.py
+++ b/artemis/db.py
@@ -664,6 +664,11 @@ class DB:
             del task_as_dict["payload"]["last_domain"]
         if "created_at" in task_as_dict["payload"]:
             del task_as_dict["payload"]["created_at"]
+        if task.receiver in Config.Miscellaneous.MODULES_WHITELIST_FOR_ORIGINAL_HOST_DEDUPLICATION:
+            if "original_ip" in task_as_dict["payload_persistent"]:
+                del task_as_dict["payload_persistent"]["original_ip"]
+            if "original_domain" in task_as_dict["payload_persistent"]:
+                del task_as_dict["payload_persistent"]["original_domain"]
 
         return self.dict_to_str(
             {


### PR DESCRIPTION
As per title, some modules don't require data regarding original_domain/original_ip, therfore we can deduplicate them.