### PR TITLE
`#!/bin/bash` shebangs replaced with `#!/usr/bin/env bash`

### DIFF
--- a/docker/wait-for-dependencies.sh
+++ b/docker/wait-for-dependencies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # We use this file instead of docker-compose depends_on mechanism as depends_on is not taken
 # into account on restarts.

--- a/scripts/compile-requirements
+++ b/scripts/compile-requirements
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd `dirname $0`/..
 

--- a/scripts/export_reports
+++ b/scripts/export_reports
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd $(dirname $0)/..
 

--- a/scripts/find_docker_compose_files
+++ b/scripts/find_docker_compose_files
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cd "$(dirname "$0")/.."

--- a/scripts/run_docker_compose
+++ b/scripts/run_docker_compose
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd $(dirname $0)/..
 

--- a/scripts/start
+++ b/scripts/start
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd $(dirname $0)/..
 

--- a/scripts/start_dev
+++ b/scripts/start_dev
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # depreciated way to start artemis meant to be a backward compatibility way for open source users to start project
 # delete it after some time

--- a/scripts/test
+++ b/scripts/test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 bash ./scripts/test-unit
 

--- a/scripts/test-e2e
+++ b/scripts/test-e2e
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . scripts/check_docker_compose
 

--- a/scripts/test-unit
+++ b/scripts/test-unit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 . scripts/check_docker_compose
 

--- a/scripts/test_long_running
+++ b/scripts/test_long_running
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd `dirname $0`/..
 

--- a/scripts/update_translation_files
+++ b/scripts/update_translation_files
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/utils/slow_pusher/slow_pusher.sh
+++ b/utils/slow_pusher/slow_pusher.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd $(dirname $0)
 


### PR DESCRIPTION
Increases compatibility, for example the former does not work on NixOS.