### PR TITLE
[WIP] [DO NOT MERGE] Running Nuclei on non-HTTP ports as well

### DIFF
--- a/artemis/module_base.py
+++ b/artemis/module_base.py
@@ -658,7 +658,7 @@ class ArtemisBase(Karton):
                 should_check_connection = True
             elif task.headers["type"] == TaskType.WEBAPP:
                 should_check_connection = True
-            elif task.headers["type"] == TaskType.NUCLEI_TARGET:
+            elif task.headers["type"] == TaskType.NUCLEI_TARGET and task.get_payload("nuclei-routing-scan-mode", "http") == "http":
                 should_check_connection = True
             elif task.headers["type"] == TaskType.URL:
                 should_check_connection = True

--- a/artemis/modules/nuclei.py
+++ b/artemis/modules/nuclei.py
@@ -26,7 +26,7 @@ from artemis.crawling import (
 )
 from artemis.module_base import ArtemisBase
 from artemis.modules.data.static_extensions import STATIC_EXTENSIONS
-from artemis.modules.nuclei_router import NUCLEI_ROUTER_FLAGS_PAYLOAD_KEY
+from artemis.modules.nuclei_router import NUCLEI_ROUTER_FLAGS_PAYLOAD_KEY, NUCLEI_ROUTER_SCAN_MODE_KEY, NUCLEI_ROUTER_SCAN_MODE_VALUE_HTTP
 from artemis.modules.runtime_configuration.nuclei_configuration import (
     NucleiConfiguration,
     SeverityThreshold,
@@ -34,7 +34,7 @@ from artemis.modules.runtime_configuration.nuclei_configuration import (
 from artemis.reporting.modules.nuclei.poc_url_utils import (
     minimize_nuclei_matched_at_url,
 )
-from artemis.task_utils import get_target_host, get_target_url
+from artemis.task_utils import get_target_endpoint, get_target_host, get_target_url
 from artemis.utils import (
     CalledProcessErrorWithMessage,
     check_output_log_on_error,
@@ -199,6 +199,16 @@ class Nuclei(ArtemisBase):
     batch_tasks = True
     task_max_batch_size = Config.Modules.Nuclei.NUCLEI_MAX_BATCH_SIZE
 
+    def _get_nuclei_scan_mode(self, tasks: list[Task]) -> str:
+        if len(tasks) == 0:
+            return NUCLEI_ROUTER_SCAN_MODE_VALUE_HTTP
+        first_task_flag = tasks[0].payload.get(NUCLEI_ROUTER_SCAN_MODE_KEY, NUCLEI_ROUTER_SCAN_MODE_VALUE_HTTP)
+
+        if any(task.payload.get(NUCLEI_ROUTER_SCAN_MODE_KEY, NUCLEI_ROUTER_SCAN_MODE_VALUE_HTTP) != first_task_flag for task in tasks[1:]):
+            raise Exception("Nuclei picked up tasks from different groups")
+
+        return first_task_flag
+
     def _get_nuclei_router_flags(self, tasks: list[Task]) -> list[str]:
         if len(tasks) == 0:
             return []
@@ -240,10 +250,12 @@ class Nuclei(ArtemisBase):
         return configuration
 
     def get_batch_group_key(self, task: Task) -> str | None:
+        scan_mode = self._get_nuclei_scan_mode([task])
         router_flags = self._get_nuclei_router_flags([task])
         configuration = self.get_runtime_configuration(task)
         return json.dumps(
             {
+                "nuclei_scan_mode": scan_mode,
                 "nuclei_router_flags": router_flags,
                 "configuration_runtime": configuration.serialize(),
             },
@@ -711,11 +723,18 @@ class Nuclei(ArtemisBase):
         return findings
 
     def run_multiple(self, tasks: List[Task]) -> None:
+        scan_mode = self._get_nuclei_scan_mode(tasks)
+        is_http_scan = scan_mode == NUCLEI_ROUTER_SCAN_MODE_VALUE_HTTP
+
         scan_tag_args = ["-itags", ",".join(TAGS_TO_INCLUDE)]
         router_flags = self._get_nuclei_router_flags(tasks)
         scan_tag_args.extend(router_flags)
 
-        self.log.info("Using router flags: %s", router_flags)
+        if not is_http_scan:
+            scan_tag_args.extend(["-ept", "http"])
+
+        self.log.info("Using scan mode: %s", scan_mode)
+        self.log.info("Using scan arguments: %s", scan_tag_args)
 
         templates = []
         configuration = self.get_runtime_configuration(tasks[0])
@@ -734,86 +753,36 @@ class Nuclei(ArtemisBase):
         # Remove duplicates
         templates = list(set(templates))
 
-        self.log.info(f"running {len(templates)} templates and {len(self._workflows)} workflow on {len(tasks)} hosts.")
+        self.log.info(f"Running {len(templates)} templates and {len(self._workflows)} workflow for {len(tasks)} tasks.")
 
         targets: List[str] = []
         for task in tasks:
-            targets.append(get_target_url(task))
+            if is_http_scan:
+                targets.append(get_target_url(task))
+            else:
+                targets.append(get_target_endpoint(task))
+
+        self.log.info(f"Targets:")
+        for target in targets:
+            self.log.info(f"- {target}")
 
         findings = self._scan(templates, ScanUsing.TEMPLATES, targets, extra_nuclei_args=scan_tag_args)
         findings.extend(self._scan(self._workflows, ScanUsing.WORKFLOWS, targets, extra_nuclei_args=scan_tag_args))
 
-        # DAST scanning
-        dast_targets: List[str] = []
-        for task in tasks:
-            param_url = get_target_url(task)
-            for _, template_data in DAST_SCANNING.items():
-                param_url = add_injectable_params_and_common_params_from_wordlist(
-                    param_url, template_data["params_wordlist"], template_data["param_default_value"]
-                )
-            dast_targets.append(param_url)
-
-        # Running all dast templates at once on all dast targets constructed
-        all_dast_templates = []
-        for keyword in DAST_SCANNING.keys():
-            all_dast_templates.extend(self._dast_templates[keyword])
-        all_dast_templates.extend(self._dast_templates["other"])
-
-        findings.extend(
-            self._scan(
-                [NUCLEI_TEMPLATES_LOCATION + item for item in all_dast_templates],
-                ScanUsing.TEMPLATES,
-                dast_targets,
-                use_fake_home=True,
-                extra_nuclei_args=[
-                    "-dast",
-                    "-fuzzing-mode",
-                    "multiple",
-                    "-fuzz-param-frequency",
-                    str(get_max_num_parameters(dast_targets)),
-                ],
-            )
-        )
-
         links_per_task = {}
-        for task in tasks:
-            links = self._get_links(get_target_url(task))
-            # Let's scan both links with stripped query strings and with original one. We may catch a bug on either
-            # of them.
-            links = list(set(links) | set([self._strip_query_string(link) for link in links]))
 
-            random.shuffle(links)
-            links = links[: Config.Modules.Nuclei.NUCLEI_MAX_NUM_LINKS_TO_PROCESS]
+        if is_http_scan:
+            # DAST scanning
+            dast_targets: List[str] = []
+            for task in tasks:
+                param_url = get_target_url(task)
+                for _, template_data in DAST_SCANNING.items():
+                    param_url = add_injectable_params_and_common_params_from_wordlist(
+                        param_url, template_data["params_wordlist"], template_data["param_default_value"]
+                    )
+                dast_targets.append(param_url)
 
-            links_per_task[task.uid] = links
-            self.log.info("Links for %s: %s", get_target_url(task), links_per_task[task.uid])
-
-        # That way, if we have 20 links for a webpage, we won't run 100 concurrent scans for that webpage
-        for link_package in itertools.zip_longest(*list(links_per_task.values())):
-            findings.extend(
-                self._scan(
-                    [
-                        NUCLEI_TEMPLATES_LOCATION + item
-                        for item in Config.Modules.Nuclei.NUCLEI_TEMPLATES_TO_RUN_ON_HOMEPAGE_LINKS
-                        if not item.startswith("dast/")
-                    ],
-                    ScanUsing.TEMPLATES,
-                    [item for item in link_package if item],
-                    extra_nuclei_args=scan_tag_args,
-                )
-            )
-
-            dast_targets.clear()
-
-            for item in link_package:
-                if item:
-                    param_url = item
-                    for _, template_data in DAST_SCANNING.items():
-                        param_url = add_injectable_params_and_common_params_from_wordlist(
-                            param_url, template_data["params_wordlist"], template_data["param_default_value"]
-                        )
-                    dast_targets.append(param_url)
-
+            # Running all dast templates at once on all dast targets constructed
             all_dast_templates = []
             for keyword in DAST_SCANNING.keys():
                 all_dast_templates.extend(self._dast_templates[keyword])
@@ -821,11 +790,7 @@ class Nuclei(ArtemisBase):
 
             findings.extend(
                 self._scan(
-                    [
-                        NUCLEI_TEMPLATES_LOCATION + template
-                        for template in Config.Modules.Nuclei.NUCLEI_TEMPLATES_TO_RUN_ON_HOMEPAGE_LINKS
-                        if template.startswith("dast/")
-                    ],
+                    [NUCLEI_TEMPLATES_LOCATION + item for item in all_dast_templates],
                     ScanUsing.TEMPLATES,
                     dast_targets,
                     use_fake_home=True,
@@ -839,22 +804,92 @@ class Nuclei(ArtemisBase):
                 )
             )
 
+            for task in tasks:
+                links = self._get_links(get_target_url(task))
+                # Let's scan both links with stripped query strings and with original one. We may catch a bug on either
+                # of them.
+                links = list(set(links) | set([self._strip_query_string(link) for link in links]))
+
+                random.shuffle(links)
+                links = links[: Config.Modules.Nuclei.NUCLEI_MAX_NUM_LINKS_TO_PROCESS]
+
+                links_per_task[task.uid] = links
+                self.log.info("Links for %s: %s", get_target_url(task), links_per_task[task.uid])
+
+            # That way, if we have 20 links for a webpage, we won't run 100 concurrent scans for that webpage
+            for link_package in itertools.zip_longest(*list(links_per_task.values())):
+                findings.extend(
+                    self._scan(
+                        [
+                            NUCLEI_TEMPLATES_LOCATION + item
+                            for item in Config.Modules.Nuclei.NUCLEI_TEMPLATES_TO_RUN_ON_HOMEPAGE_LINKS
+                            if not item.startswith("dast/")
+                        ],
+                        ScanUsing.TEMPLATES,
+                        [item for item in link_package if item],
+                        extra_nuclei_args=scan_tag_args,
+                    )
+                )
+
+                dast_targets.clear()
+
+                for item in link_package:
+                    if item:
+                        param_url = item
+                        for _, template_data in DAST_SCANNING.items():
+                            param_url = add_injectable_params_and_common_params_from_wordlist(
+                                param_url, template_data["params_wordlist"], template_data["param_default_value"]
+                            )
+                        dast_targets.append(param_url)
+
+                all_dast_templates = []
+                for keyword in DAST_SCANNING.keys():
+                    all_dast_templates.extend(self._dast_templates[keyword])
+                all_dast_templates.extend(self._dast_templates["other"])
+
+                findings.extend(
+                    self._scan(
+                        [
+                            NUCLEI_TEMPLATES_LOCATION + template
+                            for template in Config.Modules.Nuclei.NUCLEI_TEMPLATES_TO_RUN_ON_HOMEPAGE_LINKS
+                            if template.startswith("dast/")
+                        ],
+                        ScanUsing.TEMPLATES,
+                        dast_targets,
+                        use_fake_home=True,
+                        extra_nuclei_args=[
+                            "-dast",
+                            "-fuzzing-mode",
+                            "multiple",
+                            "-fuzz-param-frequency",
+                            str(get_max_num_parameters(dast_targets)),
+                        ],
+                    )
+                )
+
+        # populate the 'links_per_task' mapping so that we can rely
+        # on the assumption that all the `task.uid` keys are in it
+        # (it helps to catch potential problems below)
+        if not is_http_scan:
+            for task in tasks:
+                links_per_task[task.uid] = []
+
         findings_per_task = collections.defaultdict(list)
         findings_unmatched = []
         for finding in findings:
             found = False
             for task in tasks:
+                matches = [get_target_url(task), get_target_endpoint(task)] + links_per_task[task.uid]
+                hosts_with_port = [
+                    urllib.parse.urlparse(item).netloc for item in matches if ":" in urllib.parse.urlparse(item).netloc
+                ]
                 if "url" in finding:
-                    if finding["url"] in [get_target_url(task)] + links_per_task[task.uid]:
+                    if finding["url"] in matches + hosts_with_port:
                         findings_per_task[task.uid].append(finding)
                         found = True
                         break
                 elif "matched-at" in finding:
-                    urls = [get_target_url(task)] + links_per_task[task.uid]
-                    hosts_with_port = [
-                        urllib.parse.urlparse(item).netloc for item in urls if ":" in urllib.parse.urlparse(item).netloc
-                    ]
-                    if finding["matched-at"] in urls or finding["matched-at"] in hosts_with_port:
+                    if finding["matched-at"] in matches + hosts_with_port:
                         findings_per_task[task.uid].append(finding)
                         found = True
                         break

--- a/artemis/modules/nuclei_router.py
+++ b/artemis/modules/nuclei_router.py
@@ -11,6 +11,9 @@ from artemis.web_technology_identification import run_tech_detection
 
 TECHNOLOGY_DETECTION_TAGS_TO_EXCLUDE = {"wordpress": ["wordpress"]}
 NUCLEI_ROUTER_FLAGS_PAYLOAD_KEY = "nuclei-routing-additional-flags"
+NUCLEI_ROUTER_SCAN_MODE_KEY = "nuclei-routing-scan-mode"
+NUCLEI_ROUTER_SCAN_MODE_VALUE_HTTP = "http"
+NUCLEI_ROUTER_SCAN_MODE_VALUE_OTHER = "other"
 
 
 @load_risk_class.load_risk_class(load_risk_class.LoadRiskClass.HIGH)
@@ -22,7 +25,7 @@ class NucleiRouter(ArtemisBase):
 
     identity = "nuclei-router"
     filters = [
-        {"type": TaskType.SERVICE.value, "service": Service.HTTP.value},
+        {"type": TaskType.SERVICE.value},
     ]
 
     def __init__(self, *args: Any, **kwargs: Any):
@@ -47,7 +50,7 @@ class NucleiRouter(ArtemisBase):
             tags_to_exclude.update(TECHNOLOGY_DETECTION_TAGS_TO_EXCLUDE[tech_name])
         return sorted(tags_to_exclude)
 
-    def get_nuclei_additional_flags_for_task(self, target_url: str) -> list[str]:
+    def get_nuclei_additional_flags_for_http_task(self, target_url: str) -> list[str]:
         flags = []
 
         # Nuclei module implementation currently only supports '-etags'
@@ -58,9 +61,17 @@ class NucleiRouter(ArtemisBase):
         return flags
 
     def run(self, current_task: Task) -> None:
-        target_url = get_target_url(current_task)
 
-        nuclei_additional_flags = self.get_nuclei_additional_flags_for_task(target_url)
+        is_http_service = current_task.headers.get("service") == Service.HTTP
+
+        if is_http_service:
+            target_url = get_target_url(current_task)  # TODO maybe inline it
+            nuclei_additional_flags = self.get_nuclei_additional_flags_for_http_task(target_url)
+            nuclei_scan_mode = NUCLEI_ROUTER_SCAN_MODE_VALUE_HTTP
+        else:
+            nuclei_additional_flags = []
+            nuclei_scan_mode = NUCLEI_ROUTER_SCAN_MODE_VALUE_OTHER
+
         routed_task = Task(
             {
                 "type": TaskType.NUCLEI_TARGET,
@@ -69,6 +80,7 @@ class NucleiRouter(ArtemisBase):
                 "host": get_target_host(current_task),
                 "port": current_task.get_payload("port"),
                 "ssl": current_task.get_payload("ssl"),
+                NUCLEI_ROUTER_SCAN_MODE_KEY: nuclei_scan_mode,
                 NUCLEI_ROUTER_FLAGS_PAYLOAD_KEY: nuclei_additional_flags,
             },
         )
@@ -83,7 +95,10 @@ class NucleiRouter(ArtemisBase):
             status=TaskStatus.OK,
             data={
                 "routed_task_type": TaskType.NUCLEI_TARGET,
-                "url": target_url,
+                "host": get_target_host(current_task),
+                "port": current_task.get_payload("port"),
+                "ssl": current_task.get_payload("ssl"),
+                "nuclei_scan_type": nuclei_scan_mode,
                 "nuclei_additional_flags": nuclei_additional_flags,
             },
         )

--- a/artemis/task_utils.py
+++ b/artemis/task_utils.py
@@ -68,6 +68,17 @@ def get_target_host(task: Task) -> str:
     raise ValueError(f"Unknown target found: {task_type}")
 
 
+def get_target_endpoint(task: Task) -> str:
+    host = get_target_host(task)
+    port = task.get_payload("port")
+
+    # TODO check if it even can be 'None'
+    if port is None:
+        raise ValueError(f"Unknown target found: {task}")
+
+    return f"{host}:{port}"
+
+
 def get_target_url(task: Task) -> str:
     """
     Build or extract a complete URL from a Karton task.


### PR DESCRIPTION
Two modules got changed in order to achieve it:

1. `nuclei-router` now creates `nuclei-target` tasks for non-HTTP services as well. These `nuclei-target` tasks contain a new field in the payload (`"nuclei-routing-scan-mode"`) which can be either `http` or `other`. We default to `http` for existing tasks, for backwards compatibility reason.

2. When `nuclei-routing-scan-mode = http`, Nuclei runs the way it used to. For `nuclei-routing-scan-mode = other`, we add `-ept http` so that we don't run tests targeting the HTTP(S) protocol - as they take a lot of time - plus we skip some features  which only make sense for HTTP (`-dast`, crawling for links, etc.). Also the initial WAF check doesn't happen for non-HTTP Nuclei runs. I have also updated the grouping logic (`get_batch_group_key()`) so that `http` and `other` tasks are processed in separate groups.

The goal was to keep the behaviour for HTTP ports unchanged so that we don't accidentaly break something. There was some change in how the findings are assigned back to the tasks they belong to, but that should be backwards compatible.

This pull request looks super long, but most of it is just changed indentation which gets displayed in a messy way by GitHub unfortunately.

---

<img width="1360" height="1226" alt="image" src="https://github.com/user-attachments/assets/85f15244-f746-4572-8d3c-88c89ba49211" />

(there is plenty of redundant templates matching for Redis and PostgreSQL here, I just haven't ignored them yet)