### PR TITLE
Fixed casting of the `NUCLEI_INTERACTSH_SERVER` configuration parameter

### DIFF
--- a/artemis/config.py
+++ b/artemis/config.py
@@ -474,7 +474,7 @@ class Config:
             NUCLEI_INTERACTSH_SERVER: Annotated[
                 str,
                 "Which interactsh server to use. if None, uses the default.",
-            ] = get_config("NUCLEI_INTERACTSH_SERVER", default=None, cast=str)
+            ] = get_config("NUCLEI_INTERACTSH_SERVER", default=None)
 
             NUCLEI_CHECK_TEMPLATE_LIST: Annotated[
                 bool,


### PR DESCRIPTION
If unset, `cast=str` was causing it to take value `"None"` (a `str`). Fixes https://github.com/CERT-Polska/Artemis/issues/2866.

I mean I would expect to framework to prevent us from making such a mistake...