### PR TITLE
Add vendor-default credential pairs to admin_panel_login_bruter

### DIFF
--- a/artemis/modules/admin_panel_login_bruter.py
+++ b/artemis/modules/admin_panel_login_bruter.py
@@ -25,6 +25,18 @@ def read_file(file: IO[str]) -> List[str]:
     return [line.strip() for line in file if not line.startswith("#")]
 
 
+def read_credential_pairs(file: IO[str]) -> List[Tuple[str, str]]:
+    pairs = []
+    for line in read_file(file):
+        if ":" not in line:
+            continue
+        username, password = line.split(":", 1)
+        if not password:  # no empty passwords for now
+            continue
+        pairs.append((username, password))
+    return pairs
+
+
 COMMON_FAILURE_MESSAGES: List[str]
 with open(
     os.path.join(os.path.dirname(__file__), "data", "admin_panel_login_bruter", "common_failure_messages.txt"),
@@ -45,6 +57,13 @@ with open(
     encoding="utf-8",
 ) as f:
     COMMON_LOGIN_PATHS = read_file(f)
+
+COMMON_CREDENTIAL_PAIRS: List[Tuple[str, str]]
+with open(
+    os.path.join(os.path.dirname(__file__), "data", "admin_panel_login_bruter", "common_credential_pairs.txt"),
+    encoding="utf-8",
+) as f:
+    COMMON_CREDENTIAL_PAIRS = read_credential_pairs(f)
 
 # JSON-only API login endpoints that do not respond to GET with 200 (POST-only).
 # These are always tried regardless of discovery, because check_url(GET) would fail.
@@ -366,6 +385,7 @@ class AdminPanelLoginBruter(ArtemisBase):
         for path in login_paths:
             num_rechecked_credentials = 0
             credentials = list(itertools.product(COMMON_USERNAMES, get_passwords(task)))
+            credentials += COMMON_CREDENTIAL_PAIRS
             random.shuffle(credentials)
             for username, password in credentials:
                 login_mechanism_found, result = self.brute_force_login_path(base_url, path, username, password)

--- a/artemis/modules/data/admin_panel_login_bruter/common_credential_pairs.txt
+++ b/artemis/modules/data/admin_panel_login_bruter/common_credential_pairs.txt
@@ -1,0 +1,39 @@
+# Vendor-default credential pairs in "login:password" format, one per line.
+# Lines starting with "#" and lines without ":" are ignored.
+#
+# Tried in addition to the COMMON_USERNAMES x get_passwords() product, so
+# "admin:<password>" pairs already covered by that product are omitted here as
+# redundant. No empty passwords for now.
+#
+# Curated from the DefaultCreds-cheat-sheet project (well-known vendor defaults).
+root:root
+root:admin
+root:toor
+root:password
+root:changeme
+root:calvin
+administrator:admin
+administrator:password
+user:user
+user:password
+guest:guest
+test:test
+manager:manager
+operator:operator
+supervisor:supervisor
+tomcat:tomcat
+ubnt:ubnt
+cisco:cisco
+support:support
+admin:changeme
+admin:default
+admin:pass
+admin:admin123
+admin:letmein
+admin:welcome
+admin:secret
+admin:system
+admin:tomcat
+admin:cisco
+admin:nimda
+admin:pfsense

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -149,6 +149,11 @@ services:
     volumes:
       - ./test/data/php_redirect_login/:/var/www/html
 
+  test-php-root-toor-login:
+    image: php:8.0-apache
+    volumes:
+      - ./test/data/php_root_toor_login/:/var/www/html/
+
   test-php-mock-CVE-2020-28976:
     image: php:8.0-apache
     volumes:

--- a/test/data/php_root_toor_login/dashboard.php
+++ b/test/data/php_root_toor_login/dashboard.php
@@ -1,0 +1,2 @@
+<h1>Welcome</h1>
+<p>Logout</p>

--- a/test/data/php_root_toor_login/index.php
+++ b/test/data/php_root_toor_login/index.php
@@ -1,0 +1,38 @@
+<?php
+session_start();
+
+$login_error = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $username = $_POST['username'] ?? '';
+    $password = $_POST['password'] ?? '';
+
+    if ($username === 'root' && $password === 'toor') {
+        $_SESSION['loggedin'] = true;
+        $_SESSION['username'] = $username;
+        header('Location: dashboard.php');
+        exit();
+    } else {
+        $login_error = 'Invalid credentials.';
+    }
+}
+?>
+
+<!DOCTYPE html>
+<html>
+<body>
+    <div class="login-box">
+        <h2>Login</h2>
+        <?php if ($login_error): ?>
+            <p class="error"><?= htmlspecialchars($login_error) ?></p>
+        <?php endif; ?>
+        <form method="POST" action="/index.php">
+            <label>Username</label><br>
+            <input type="text" name="username" required><br>
+            <label>Password</label><br>
+            <input type="password" name="password" required><br>
+            <button type="submit">Login</button>
+        </form>
+    </div>
+</body>
+</html>

--- a/test/modules/test_admin_panel_login_bruter.py
+++ b/test/modules/test_admin_panel_login_bruter.py
@@ -81,3 +81,24 @@ class AdminPanelLoginBruterTest(ArtemisModuleTestCase):
         self.assertEqual(call.kwargs["data"]["results"][0]["username"], "admin")
         self.assertEqual(call.kwargs["data"]["results"][0]["password"], "admin")
         self.assertEqual(call.kwargs["data"]["results"][0]["indicators"], ["http_basic_auth"])
+
+    def test_vendor_default_credential_pair(self) -> None:
+        """A login accepting only root:toor proves the credential-pairs mechanism:
+        'root' is not in COMMON_USERNAMES, so this is unreachable via the cartesian product."""
+        task = Task(
+            {"type": TaskType.SERVICE.value, "service": Service.HTTP.value},
+            payload={
+                "host": "test-php-root-toor-login",
+                "port": 80,
+            },
+        )
+
+        self.run_task(task)
+        (call,) = self.mock_db.save_task_result.call_args_list
+        self.assertEqual(call.kwargs["status"], TaskStatus.INTERESTING)
+        self.assertEqual(call.kwargs["data"]["results"][0]["url"], "http://test-php-root-toor-login:80/index.php")
+        self.assertEqual(call.kwargs["data"]["results"][0]["username"], "root")
+        self.assertEqual(call.kwargs["data"]["results"][0]["password"], "toor")
+        self.assertEqual(
+            call.kwargs["data"]["results"][0]["indicators"], ["redirect", "logout_link", "no_failure_messages"]
+        )


### PR DESCRIPTION
Adds a separate mechanism for vendor-default `login:password` pairs, alongside the existing `COMMON_USERNAMES × get_passwords()` cartesian product.

## Why pairs, not more usernames

Adding non-admin usernames (root, user, guest, …) to `COMMON_USERNAMES` would explode the request count in a mass scanner — each new username is multiplied by all ~12 passwords, mostly producing noise. Real-world defaults are username-specific (e.g. `root:toor`, `cisco:cisco`, `root:calvin`), so trying them as fixed pairs is both cheaper (1 request each instead of `username × all_passwords`) and more accurate. `COMMON_USERNAMES` is intentionally left unchanged.

## What's included

- `data/admin_panel_login_bruter/common_credential_pairs.txt` — a small, stable list of ~30 well-known defaults (`login:password` per line, `#` comments). Curated from the [DefaultCreds-cheat-sheet](https://github.com/ihebski/DefaultCreds-cheat-sheet) (MIT).
- `admin:<password>` combinations already covered by the cartesian product are omitted as redundant.
- No empty passwords for now.
- Pairs go through the same `brute_force_login_path` as the product, so form / JSON / Basic auth, recheck and the FP-guard all apply for free.

## Deliberately inherited behaviours (unchanged here)

- `len(credential_pairs) > 1 → results = []` FP-guard: pairs increase the chance of >1 successful pair on a host, but this is the intended FP heuristic and I'm not touching it.
- `break` on `not login_mechanism_found`: pairs are skipped on paths with no login mechanism — same as the product, correct behaviour.

## Request budget

On a path with a login mechanism, credentials per path grow from ~12 to ~42 (~3.5×). Thanks to the `break` above, this cost only applies to actual login paths.

## Testing

New fixture `test-php-root-toor-login` accepts only `root:toor`. Since `root` is not in `COMMON_USERNAMES`, this credential is unreachable via the cartesian product — a successful detection proves the pairs mechanism works independently. Full `AdminPanelLoginBruterTest` suite passes (5/5).

## Out of scope (future PR)

Technology-targeted pairs via Wappalyzer / `run_tech_detection` (Etap 2b) — separate PR once the caching architecture is decided.

Refs #2378