### PR TITLE
Bump requests-cache to 1.3.2 (fix cattrs serialization under requests 2.34 inline typing)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -102,7 +102,7 @@ pyyaml==6.0.3
 redis==7.4.0
 referencing==0.37.0
 requests==2.33.1
-requests-cache==1.3.1
+requests-cache==1.3.2
 requests-file==3.0.1
 requests-mock==1.12.1
 retry==0.9.2


### PR DESCRIPTION
## What
Bump requests-cache 1.3.1 → 1.3.2.

## Why
Dependabot #2876 (`requests` 2.33.1 → 2.34.2) fails `unit`, `e2e` and `external-network`. All three fail identically at image build time, in `RUN ... python3 -m artemis.fallback_api_cache`, not in any test:
```
NameError: name 'RequestsCookieJar' is not defined
```
Root cause: `requests` 2.34.0 switched to inline types - `requests.models` now uses `from __future__ import annotations` and imports `RequestsCookieJar` only under `TYPE_CHECKING. CachedResponse` (requests-cache) subclasses `requests.models.Response`, and on cache write requests-cache serializes via cattrs → `attrs.resolve_types` → `typing.get_type_hints`, which evaluates the now-stringized `cookies: RequestsCookieJar | ...` annotation in `requests.models`'s globals, where the name no longer exists at runtime → `NameError`. requests-cache 1.3.2 fixes the model resolution.
This is the actual blocker behind #2876 - `@dependabot recreate` couldn't fix it (it only regenerates the same bump, the compile-requirements bot keeps the lockfile green, but the failure is at runtime/build).

## Notes
- requests-cache 1.3.2 has an identical runtime dependency set to 1.3.1 (verified) - single-line lockfile change.
- Verified locally: with this bump the image builds and the `fallback_api_cache` warmup step passes (no `NameError`).
- After this merges to `main`, `@dependabot` recreate on #2876 should go green on rebase.