### PR TITLE
Implement direct URL scanning

### DIFF
--- a/artemis/direct_url_scanning.py
+++ b/artemis/direct_url_scanning.py
@@ -1,0 +1,87 @@
+import socket
+import urllib.parse
+from typing import Dict, NamedTuple, Optional, Tuple
+
+from artemis.binds import Service
+
+
+class ParsedURL(NamedTuple):
+    service: Service
+    host: str
+    port: int
+    ssl: bool
+
+
+# Maps a URL scheme to the service it implies and whether it uses SSL/TLS. The keys
+# are exactly the schemes accepted as direct scan targets.
+SCHEME_TO_SERVICE: Dict[str, Tuple[Service, bool]] = {
+    "http": (Service.HTTP, False),
+    "https": (Service.HTTP, True),
+    "ftp": (Service.FTP, False),
+    "ftps": (Service.FTP, True),
+    "ssh": (Service.SSH, False),
+    "smtp": (Service.SMTP, False),
+    "smtps": (Service.SMTP, True),
+    "imap": (Service.IMAP, False),
+    "imaps": (Service.IMAP, True),
+    "mysql": (Service.MYSQL, False),
+    "postgresql": (Service.POSTGRESQL, False),
+    "postgres": (Service.POSTGRESQL, False),
+}
+
+
+def parse_url(data: str) -> Optional[ParsedURL]:
+    """
+    Parses a root URL (`scheme://host[:port][/]`) into the service it implies.
+
+    Returns `None` for anything that isn't a supported root URL: an input without
+    a scheme, an unmapped scheme, a missing host, userinfo, or a non-root path,
+    parameters, query or fragment. `urlparse` lowercases the scheme and host and
+    unwraps bracketed IPv6 hosts for us; `hostname`/`port` raise `ValueError`
+    on a malformed host or out-of-range port, which we treat as unsupported.
+    """
+    if "://" not in data:
+        return None
+
+    try:
+        parsed = urllib.parse.urlparse(data)
+    except ValueError:
+        return None
+
+    mapping = SCHEME_TO_SERVICE.get(parsed.scheme)
+    if mapping is None:
+        return None
+
+    # Userinfo (e.g. user:pass@host) points at credentials, not a target.
+    if parsed.username is not None or parsed.password is not None:
+        return None
+
+    # Only a root URL is accepted - service modules crawl from the root themselves,
+    # so a path, parameters, query or fragment would be ambiguous.
+    if parsed.path not in ("", "/") or parsed.params or parsed.query or parsed.fragment:
+        return None
+
+    try:
+        host = parsed.hostname
+        port = parsed.port
+    except ValueError:
+        return None
+
+    if not host:
+        return None
+
+    service, ssl = mapping
+    if port is None:
+        # No explicit port - fall back to the scheme's default from the system
+        # services database, the same way the reporting code resolves it.
+        try:
+            port = socket.getservbyname(parsed.scheme)
+        except OSError:
+            return None
+
+    return ParsedURL(service=service, host=host, port=port, ssl=ssl)
+
+
+def is_scannable_url(data: str) -> bool:
+    """Whether `data` is a root URL that is accepted as a direct scan target."""
+    return parse_url(data) is not None

--- a/artemis/frontend.py
+++ b/artemis/frontend.py
@@ -28,7 +28,7 @@ from karton.core.task import TaskPriority, TaskState
 from redis import Redis
 from starlette.datastructures import Headers
 
-from artemis import auth, csrf
+from artemis import auth, csrf, direct_url_scanning
 from artemis.binds import TaskType
 from artemis.config import Config
 from artemis.db import DB, ColumnOrdering, ReportGenerationTaskStatus, TaskFilter
@@ -216,7 +216,7 @@ async def post_add(
 
     # When every target is a root URL, the classifier emits the SERVICE task directly
     # from the scheme, so port_scanner isn't needed to reach SERVICE/WEBAPP modules.
-    all_targets_are_urls = bool(total_list) and all(Classifier.is_url(task) for task in total_list)
+    all_targets_are_urls = bool(total_list) and all(direct_url_scanning.is_scannable_url(task) for task in total_list)
 
     for dependency, task_types in [
         ("port_scanner", [TaskType.SERVICE.value, TaskType.WEBAPP.value]),

--- a/artemis/frontend.py
+++ b/artemis/frontend.py
@@ -211,13 +211,19 @@ async def post_add(
     for task in total_list:
         if not Classifier.is_supported(task):
             validation_messages.append(
-                f"{task} is not supported - Artemis supports domains, IPs or IPv4 ranges. Domains and IPs may also optionally be followed by port number."
+                f"{task} is not supported - Artemis supports domains, IPs, IPv4 ranges or root URLs such as https://example.com/ or ssh://example.com:22/. Domains and IPs may also optionally be followed by port number. A URL must be a root URL (scheme://host[:port]/) without a path."
             )
+
+    # When every target is a root URL, the classifier emits the SERVICE task directly
+    # from the scheme, so port_scanner isn't needed to reach SERVICE/WEBAPP modules.
+    all_targets_are_urls = bool(total_list) and all(Classifier.is_url(task) for task in total_list)
 
     for dependency, task_types in [
         ("port_scanner", [TaskType.SERVICE.value, TaskType.WEBAPP.value]),
         ("device_identifier", [TaskType.DEVICE.value]),
     ]:
+        if dependency == "port_scanner" and all_targets_are_urls:
+            continue
         if dependency in disabled_modules:
             for bind in get_binds_that_can_be_disabled():
                 if bind.identity not in disabled_modules:

--- a/artemis/frontend.py
+++ b/artemis/frontend.py
@@ -28,7 +28,7 @@ from karton.core.task import TaskPriority, TaskState
 from redis import Redis
 from starlette.datastructures import Headers
 
-from artemis import auth, csrf, direct_url_scanning
+from artemis import auth, csrf
 from artemis.binds import TaskType
 from artemis.config import Config
 from artemis.db import DB, ColumnOrdering, ReportGenerationTaskStatus, TaskFilter
@@ -214,15 +214,15 @@ async def post_add(
                 f"{task} is not supported - Artemis supports domains, IPs, IPv4 ranges or root URLs such as https://example.com/ or ssh://example.com:22/. Domains and IPs may also optionally be followed by port number. A URL must be a root URL (scheme://host[:port]/) without a path."
             )
 
-    # When every target is a root URL, the classifier emits the SERVICE task directly
-    # from the scheme, so port_scanner isn't needed to reach SERVICE/WEBAPP modules.
-    all_targets_are_urls = bool(total_list) and all(direct_url_scanning.is_scannable_url(task) for task in total_list)
+    # The port scanner isn't needed when every target already names its service - a root
+    # URL or a host:port - so the classifier can emit a SERVICE task without it.
+    port_scan_not_needed = bool(total_list) and all(Classifier.is_service_target(task) for task in total_list)
 
     for dependency, task_types in [
         ("port_scanner", [TaskType.SERVICE.value, TaskType.WEBAPP.value]),
         ("device_identifier", [TaskType.DEVICE.value]),
     ]:
-        if dependency == "port_scanner" and all_targets_are_urls:
+        if dependency == "port_scanner" and port_scan_not_needed:
             continue
         if dependency in disabled_modules:
             for bind in get_binds_that_can_be_disabled():

--- a/artemis/modules/classifier.py
+++ b/artemis/modules/classifier.py
@@ -113,6 +113,18 @@ class Classifier(ArtemisBase):
         return Classifier._is_ip_or_domain(data)
 
     @staticmethod
+    def is_service_target(data: str) -> bool:
+        """Whether `data` already names a service (a root URL or a `host:port`), so the classifier
+        can emit a SERVICE task for it without the port scanner."""
+        if not Classifier.is_supported(data):
+            return False
+        if "://" in data:
+            return True
+        if re.match(ASN_REGEX, data) or to_ip_range(data):
+            return False
+        return not Classifier._is_ip_or_domain(Classifier._clean_ipv6_brackets(data))
+
+    @staticmethod
     def _classify(data: str) -> TaskType:
         """
         :raises: ValueError if failed to find domain/IP

--- a/artemis/modules/classifier.py
+++ b/artemis/modules/classifier.py
@@ -2,14 +2,12 @@
 import ipaddress
 import json
 import re
-import socket
 import subprocess
-import urllib.parse
-from typing import Dict, List, NamedTuple, Optional, Tuple
+from typing import List
 
 from karton.core import Task
 
-from artemis import http_requests, load_risk_class
+from artemis import direct_url_scanning, http_requests, load_risk_class
 from artemis.binds import Service, TaskStatus, TaskType
 from artemis.domains import is_domain
 from artemis.ip_utils import to_ip_range
@@ -17,34 +15,6 @@ from artemis.module_base import ArtemisBase
 from artemis.utils import check_output_log_on_error
 
 ASN_REGEX = "[aA][sS][0-9][0-9]*"
-
-
-class ParsedURL(NamedTuple):
-    service: Service
-    host: str
-    port: int
-    ssl: bool
-
-
-# Maps a URL scheme to the service it implies and whether it uses SSL/TLS. This is
-# the single source of truth for which schemes are accepted as direct targets - the
-# supported schemes are exactly the keys of this table. The default port for a scheme
-# is looked up in the system services database (socket.getservbyname), the same way
-# the reporting code derives ports from URL schemes.
-SCHEME_TO_SERVICE: Dict[str, Tuple[Service, bool]] = {
-    "http": (Service.HTTP, False),
-    "https": (Service.HTTP, True),
-    "ftp": (Service.FTP, False),
-    "ftps": (Service.FTP, True),
-    "ssh": (Service.SSH, False),
-    "smtp": (Service.SMTP, False),
-    "smtps": (Service.SMTP, True),
-    "imap": (Service.IMAP, False),
-    "imaps": (Service.IMAP, True),
-    "mysql": (Service.MYSQL, False),
-    "postgresql": (Service.POSTGRESQL, False),
-    "postgres": (Service.POSTGRESQL, False),
-}
 
 
 class RIPEAccessException(Exception):
@@ -114,61 +84,9 @@ class Classifier(ArtemisBase):
         return data
 
     @staticmethod
-    def _parse_url(data: str) -> Optional[ParsedURL]:
-        """
-        Parses a root URL (`scheme://host[:port][/]`) into the service it implies.
-
-        Returns `None` for anything that isn't a supported root URL: an input without
-        a scheme, an unmapped scheme, a missing host, userinfo, or a non-root path,
-        parameters, query or fragment. `urlparse` lowercases the scheme and host and
-        unwraps bracketed IPv6 hosts for us; `hostname`/`port` raise `ValueError`
-        on a malformed host or out-of-range port, which we treat as unsupported.
-        """
-        if "://" not in data:
-            return None
-
-        try:
-            parsed = urllib.parse.urlparse(data)
-        except ValueError:
-            return None
-
-        mapping = SCHEME_TO_SERVICE.get(parsed.scheme)
-        if mapping is None:
-            return None
-
-        # Userinfo (e.g. user:pass@host) points at credentials, not a target.
-        if parsed.username is not None or parsed.password is not None:
-            return None
-
-        # Only a root URL is accepted - service modules crawl from the root themselves,
-        # so a path, parameters, query or fragment would be ambiguous.
-        if parsed.path not in ("", "/") or parsed.params or parsed.query or parsed.fragment:
-            return None
-
-        try:
-            host = parsed.hostname
-            port = parsed.port
-        except ValueError:
-            return None
-
-        if not host:
-            return None
-
-        service, ssl = mapping
-        if port is None:
-            # No explicit port - fall back to the scheme's default from the system
-            # services database, the same way the reporting code resolves it.
-            try:
-                port = socket.getservbyname(parsed.scheme)
-            except OSError:
-                return None
-
-        return ParsedURL(service=service, host=host, port=port, ssl=ssl)
-
-    @staticmethod
     def is_supported(data: str) -> bool:
         if "://" in data:
-            return Classifier._parse_url(data) is not None
+            return direct_url_scanning.is_scannable_url(data)
 
         if re.match(ASN_REGEX, data):
             return True
@@ -193,11 +111,6 @@ class Classifier(ArtemisBase):
 
         data = Classifier._clean_ipv6_brackets(data)
         return Classifier._is_ip_or_domain(data)
-
-    @staticmethod
-    def is_url(data: str) -> bool:
-        """Whether `data` is a root URL the classifier turns directly into a service task."""
-        return Classifier._parse_url(data) is not None
 
     @staticmethod
     def _classify(data: str) -> TaskType:
@@ -258,12 +171,17 @@ class Classifier(ArtemisBase):
             )
             return
 
-        parsed_url = Classifier._parse_url(data)
-        if parsed_url is not None:
+        direct_scanning_url = direct_url_scanning.parse_url(data)
+        if direct_scanning_url is not None:
             # The scheme already told us the service, port and SSL flag, so we emit a
             # SERVICE task straight away instead of fingerprinting the host:port.
             self._create_service_task(
-                current_task, original_target, parsed_url.service, parsed_url.host, parsed_url.port, parsed_url.ssl
+                current_task,
+                original_target,
+                direct_scanning_url.service,
+                direct_scanning_url.host,
+                direct_scanning_url.port,
+                direct_scanning_url.ssl,
             )
             return
 

--- a/artemis/modules/classifier.py
+++ b/artemis/modules/classifier.py
@@ -2,8 +2,10 @@
 import ipaddress
 import json
 import re
+import socket
 import subprocess
-from typing import List
+import urllib.parse
+from typing import Dict, List, NamedTuple, Optional, Tuple
 
 from karton.core import Task
 
@@ -15,6 +17,34 @@ from artemis.module_base import ArtemisBase
 from artemis.utils import check_output_log_on_error
 
 ASN_REGEX = "[aA][sS][0-9][0-9]*"
+
+
+class ParsedURL(NamedTuple):
+    service: Service
+    host: str
+    port: int
+    ssl: bool
+
+
+# Maps a URL scheme to the service it implies and whether it uses SSL/TLS. This is
+# the single source of truth for which schemes are accepted as direct targets - the
+# supported schemes are exactly the keys of this table. The default port for a scheme
+# is looked up in the system services database (socket.getservbyname), the same way
+# the reporting code derives ports from URL schemes.
+SCHEME_TO_SERVICE: Dict[str, Tuple[Service, bool]] = {
+    "http": (Service.HTTP, False),
+    "https": (Service.HTTP, True),
+    "ftp": (Service.FTP, False),
+    "ftps": (Service.FTP, True),
+    "ssh": (Service.SSH, False),
+    "smtp": (Service.SMTP, False),
+    "smtps": (Service.SMTP, True),
+    "imap": (Service.IMAP, False),
+    "imaps": (Service.IMAP, True),
+    "mysql": (Service.MYSQL, False),
+    "postgresql": (Service.POSTGRESQL, False),
+    "postgres": (Service.POSTGRESQL, False),
+}
 
 
 class RIPEAccessException(Exception):
@@ -84,7 +114,62 @@ class Classifier(ArtemisBase):
         return data
 
     @staticmethod
+    def _parse_url(data: str) -> Optional[ParsedURL]:
+        """
+        Parses a root URL (`scheme://host[:port][/]`) into the service it implies.
+
+        Returns `None` for anything that isn't a supported root URL: an input without
+        a scheme, an unmapped scheme, a missing host, userinfo, or a non-root path,
+        parameters, query or fragment. `urlparse` lowercases the scheme and host and
+        unwraps bracketed IPv6 hosts for us; `hostname`/`port` raise `ValueError`
+        on a malformed host or out-of-range port, which we treat as unsupported.
+        """
+        if "://" not in data:
+            return None
+
+        try:
+            parsed = urllib.parse.urlparse(data)
+        except ValueError:
+            return None
+
+        mapping = SCHEME_TO_SERVICE.get(parsed.scheme)
+        if mapping is None:
+            return None
+
+        # Userinfo (e.g. user:pass@host) points at credentials, not a target.
+        if parsed.username is not None or parsed.password is not None:
+            return None
+
+        # Only a root URL is accepted - service modules crawl from the root themselves,
+        # so a path, parameters, query or fragment would be ambiguous.
+        if parsed.path not in ("", "/") or parsed.params or parsed.query or parsed.fragment:
+            return None
+
+        try:
+            host = parsed.hostname
+            port = parsed.port
+        except ValueError:
+            return None
+
+        if not host:
+            return None
+
+        service, ssl = mapping
+        if port is None:
+            # No explicit port - fall back to the scheme's default from the system
+            # services database, the same way the reporting code resolves it.
+            try:
+                port = socket.getservbyname(parsed.scheme)
+            except OSError:
+                return None
+
+        return ParsedURL(service=service, host=host, port=port, ssl=ssl)
+
+    @staticmethod
     def is_supported(data: str) -> bool:
+        if "://" in data:
+            return Classifier._parse_url(data) is not None
+
         if re.match(ASN_REGEX, data):
             return True
 
@@ -110,6 +195,11 @@ class Classifier(ArtemisBase):
         return Classifier._is_ip_or_domain(data)
 
     @staticmethod
+    def is_url(data: str) -> bool:
+        """Whether `data` is a root URL the classifier turns directly into a service task."""
+        return Classifier._parse_url(data) is not None
+
+    @staticmethod
     def _classify(data: str) -> TaskType:
         """
         :raises: ValueError if failed to find domain/IP
@@ -130,6 +220,31 @@ class Classifier(ArtemisBase):
 
         raise ValueError("Failed to find domain/IP in input")
 
+    def _create_service_task(
+        self,
+        current_task: Task,
+        original_target: str,
+        service: Service,
+        host: str,
+        port: int,
+        ssl: bool,
+    ) -> None:
+        host_type = "domain" if is_domain(host) else "ip"
+
+        new_task = Task(
+            {
+                "type": TaskType.SERVICE,
+                "service": service,
+            },
+            payload={"host": host, "port": port, "ssl": ssl, **({"last_domain": host} if is_domain(host) else {})},
+            payload_persistent={
+                f"original_{host_type}": host,
+                "original_target": original_target,
+            },
+        )
+        self.add_task(current_task, new_task)
+        self.db.save_task_result(task=current_task, status=TaskStatus.OK, data={"type": host_type, "data": [host]})
+
     def run(self, current_task: Task) -> None:
         data = current_task.get_payload("data")
 
@@ -140,6 +255,15 @@ class Classifier(ArtemisBase):
         if not Classifier.is_supported(data):
             self.db.save_task_result(
                 task=current_task, status=TaskStatus.ERROR, status_reason="Unsupported data: " + data
+            )
+            return
+
+        parsed_url = Classifier._parse_url(data)
+        if parsed_url is not None:
+            # The scheme already told us the service, port and SSL flag, so we emit a
+            # SERVICE task straight away instead of fingerprinting the host:port.
+            self._create_service_task(
+                current_task, original_target, parsed_url.service, parsed_url.host, parsed_url.port, parsed_url.ssl
             )
             return
 
@@ -204,11 +328,6 @@ class Classifier(ArtemisBase):
             host = Classifier._clean_ipv6_brackets(host)
             port = int(port_str)
 
-            if is_domain(host):
-                host_type = "domain"
-            else:
-                host_type = "ip"
-
             try:
                 output = self.throttle_request(
                     lambda: check_output_log_on_error(
@@ -238,19 +357,7 @@ class Classifier(ArtemisBase):
 
             self.log.info("%s identified to be %s", data, service)
 
-            new_task = Task(
-                {
-                    "type": TaskType.SERVICE,
-                    "service": Service(service.lower()),
-                },
-                payload={"host": host, "port": port, "ssl": ssl, **({"last_domain": host} if is_domain(host) else {})},
-                payload_persistent={
-                    f"original_{host_type}": host,
-                    "original_target": original_target,
-                },
-            )
-            self.add_task(current_task, new_task)
-            self.db.save_task_result(task=current_task, status=TaskStatus.OK, data={"type": host_type, "data": [host]})
+            self._create_service_task(current_task, original_target, Service(service.lower()), host, port, ssl)
         else:
             data = Classifier._clean_ipv6_brackets(data)
 

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -73,6 +73,11 @@ in the form of entries separated with newlines. Artemis works with both IPs and 
 IP ranges, both in the form of `127.0.0.1-127.0.0.10` or `127.0.0.0/30` and `host:port` syntax - in the latter
 case, no port scanning will be performed.
 
+You may also provide a root URL such as `https://example.com/` or `ssh://example.com:22/`. In that case the
+scheme selects the service directly, so no port scanning or fingerprinting is performed - Artemis scans exactly
+the host, port and protocol given. The URL must be a root URL (`scheme://host[:port]/`) without a path, query
+or fragment.
+
 To be later able to filter various types of targets, provide a tag in the `Tag` field. You may
 also choose what modules will be executed, to increase scanning speed if you need only to check for
 a subset of vulnerabilities.

--- a/templates/add.jinja2
+++ b/templates/add.jinja2
@@ -26,6 +26,14 @@
             <label class="form-label">Targets (separated with newlines)</label>
             <textarea class="form-control" name="targets" rows="10" required>{% for task in tasks %}{{ task }}
 {% endfor %}</textarea>
+            <small class="form-text text-muted">
+                You can provide domains, IP addresses, IPv4 ranges, or root URLs of the form
+                <tt>scheme://host[:port]/</tt> - for example <tt>https://example.com/</tt> or <tt>ssh://example.com:22/</tt>,
+                where the scheme selects the service to scan. A URL with a path such as <tt>http://example.com/admin/</tt>
+                is not accepted, because Artemis crawls from the root on its own. Supported URL schemes are
+                <tt>http</tt>, <tt>https</tt>, <tt>ftp</tt>, <tt>ftps</tt>, <tt>ssh</tt>, <tt>smtp</tt>, <tt>smtps</tt>,
+                <tt>imap</tt>, <tt>imaps</tt>, <tt>mysql</tt> and <tt>postgresql</tt>.
+            </small>
         </div>
         <div class="form-group mb-3">
             <label class="form-label">Enter your tag{% if tag_names %} or select existing one{% endif %}</label>

--- a/test/modules/test_classifier.py
+++ b/test/modules/test_classifier.py
@@ -75,6 +75,23 @@ class ClassifierTest(ArtemisModuleTestCase):
         self.assertFalse(direct_url_scanning.is_scannable_url("http:/cert.pl"))
         self.assertFalse(direct_url_scanning.is_scannable_url("http:cert.pl"))
 
+    def test_is_service_target(self) -> None:
+        # Root URLs and host:port targets already name a service, so no port scan is needed
+        self.assertTrue(Classifier.is_service_target("https://example.com/"))
+        self.assertTrue(Classifier.is_service_target("ssh://example.com:22/"))
+        self.assertTrue(Classifier.is_service_target("cert.pl:8080"))
+        self.assertTrue(Classifier.is_service_target("1.2.3.4:56"))
+        self.assertTrue(Classifier.is_service_target("[::1]:22"))
+        # Bare domains and IPs, ranges and ASNs still need the port scanner
+        self.assertFalse(Classifier.is_service_target("cert.pl"))
+        self.assertFalse(Classifier.is_service_target("[::1]"))
+        self.assertFalse(Classifier.is_service_target("1.2.3.4"))
+        self.assertFalse(Classifier.is_service_target("127.0.0.1-127.0.0.5"))
+        self.assertFalse(Classifier.is_service_target("AS123"))
+        # Unsupported inputs (non-root URL, malformed port) are not service targets
+        self.assertFalse(Classifier.is_service_target("http://cert.pl/admin"))
+        self.assertFalse(Classifier.is_service_target("cert.pl:8080port"))
+
     def test_parsing(self) -> None:
         entries = [
             TestData(

--- a/test/modules/test_classifier.py
+++ b/test/modules/test_classifier.py
@@ -1,5 +1,6 @@
 from test.base import ArtemisModuleTestCase
 from typing import Any, Dict, List, NamedTuple
+from unittest.mock import patch
 
 from karton.core import Task
 
@@ -29,9 +30,22 @@ class ClassifierTest(ArtemisModuleTestCase):
         self.assertTasksEqual(results, [])
 
     def test_support(self) -> None:
-        # URLs are not supported
-        self.assertFalse(Classifier.is_supported("http://example.com"))
+        # Root URLs are supported - the scheme selects the service
+        self.assertTrue(Classifier.is_supported("http://example.com"))
+        self.assertTrue(Classifier.is_supported("http://cert.pl"))
+        self.assertTrue(Classifier.is_supported("https://CERT.pl"))
+        self.assertTrue(Classifier.is_supported("https://example.com:8443/"))
+        self.assertTrue(Classifier.is_supported("ssh://127.0.0.1"))
+        self.assertTrue(Classifier.is_supported("ssh://example.com:22/"))
+        self.assertTrue(Classifier.is_supported("http://[::1]:8080/"))
+        # URLs with userinfo, an unmapped scheme, a missing host, a path or a query are rejected
         self.assertFalse(Classifier.is_supported("http://a:b@example.com"))
+        self.assertFalse(Classifier.is_supported("ws://cert.pl"))
+        self.assertFalse(Classifier.is_supported("gopher://cert.pl"))
+        self.assertFalse(Classifier.is_supported("http://"))
+        self.assertFalse(Classifier.is_supported("http://cert.pl/admin"))
+        self.assertFalse(Classifier.is_supported("http://cert.pl/?q=1"))
+        # Non-URL inputs keep their existing behaviour
         self.assertTrue(Classifier.is_supported("cert.pl"))
         self.assertTrue(Classifier.is_supported("[::1]:2"))
         self.assertTrue(Classifier.is_supported("[::1]"))
@@ -40,11 +54,20 @@ class ClassifierTest(ArtemisModuleTestCase):
         self.assertFalse(Classifier.is_supported("cert.pl:8080port"))
         self.assertTrue(Classifier.is_supported("1.2.3.4:56"))
         self.assertTrue(Classifier.is_supported("CERT.pl"))
-        self.assertFalse(Classifier.is_supported("https://CERT.pl"))
-        self.assertFalse(Classifier.is_supported("http://cert.pl"))
-        self.assertFalse(Classifier.is_supported("ws://cert.pl"))
         self.assertFalse(Classifier.is_supported("root@cert.pl"))
-        self.assertFalse(Classifier.is_supported("ssh://127.0.0.1"))
+
+    def test_is_url(self) -> None:
+        # Root URLs that map to a service are recognized as URLs
+        self.assertTrue(Classifier.is_url("http://example.com"))
+        self.assertTrue(Classifier.is_url("https://example.com:8443/"))
+        self.assertTrue(Classifier.is_url("ssh://example.com:22/"))
+        # Domains and IPs (with or without a port) are supported targets but are not URLs
+        self.assertFalse(Classifier.is_url("cert.pl"))
+        self.assertFalse(Classifier.is_url("cert.pl:8080"))
+        self.assertFalse(Classifier.is_url("1.2.3.4:56"))
+        # Non-root URLs and unmapped schemes are not URLs either
+        self.assertFalse(Classifier.is_url("http://cert.pl/admin"))
+        self.assertFalse(Classifier.is_url("ws://cert.pl"))
 
     def test_parsing(self) -> None:
         entries = [
@@ -206,3 +229,88 @@ class ClassifierTest(ArtemisModuleTestCase):
         self.run_task(task)
         (call,) = self.mock_db.save_task_result.call_args_list
         self.assertEqual(call.kwargs["status_reason"], "Unsupported data: invalid_data")
+
+    def test_url_emission(self) -> None:
+        entries = [
+            TestData(
+                "http://example.com:8080/",
+                [
+                    ExpectedTaskData(
+                        headers={"origin": "classifier", "type": "service", "service": "http"},
+                        payload={"host": "example.com", "port": 8080, "ssl": False, "last_domain": "example.com"},
+                        payload_persistent={
+                            "original_domain": "example.com",
+                            "original_target": "http://example.com:8080/",
+                        },
+                    ),
+                ],
+            ),
+            TestData(
+                "https://example.com/",
+                [
+                    ExpectedTaskData(
+                        headers={"origin": "classifier", "type": "service", "service": "http"},
+                        payload={"host": "example.com", "port": 443, "ssl": True, "last_domain": "example.com"},
+                        payload_persistent={
+                            "original_domain": "example.com",
+                            "original_target": "https://example.com/",
+                        },
+                    ),
+                ],
+            ),
+            TestData(
+                "ssh://example.com:22/",
+                [
+                    ExpectedTaskData(
+                        headers={"origin": "classifier", "type": "service", "service": "ssh"},
+                        payload={"host": "example.com", "port": 22, "ssl": False, "last_domain": "example.com"},
+                        payload_persistent={
+                            "original_domain": "example.com",
+                            "original_target": "ssh://example.com:22/",
+                        },
+                    ),
+                ],
+            ),
+            TestData(
+                # An IP host has no domain, so the task carries no last_domain and uses original_ip.
+                "http://1.1.1.1/",
+                [
+                    ExpectedTaskData(
+                        headers={"origin": "classifier", "type": "service", "service": "http"},
+                        payload={"host": "1.1.1.1", "port": 80, "ssl": False},
+                        payload_persistent={
+                            "original_ip": "1.1.1.1",
+                            "original_target": "http://1.1.1.1/",
+                        },
+                    ),
+                ],
+            ),
+        ]
+
+        for entry in entries:
+            self.karton.cache.flush()
+            # The scheme tells us the service, so the URL path must not shell out to fingerprintx.
+            with patch("artemis.modules.classifier.check_output_log_on_error") as mock_fingerprintx:
+                task = Task({"type": TaskType.NEW}, payload={"data": entry.raw})
+                results = self.run_task(task)
+                mock_fingerprintx.assert_not_called()
+
+            expected_tasks = [
+                Task(
+                    headers=item.headers,
+                    payload=item.payload,
+                    payload_persistent=item.payload_persistent,
+                )
+                for item in entry.expected
+            ]
+
+            for i in range(len(results)):
+                del results[i].payload["created_at"]
+            self.assertTasksEqual(results, expected_tasks)
+
+    def test_url_with_path_is_unsupported(self) -> None:
+        task = Task({"type": TaskType.NEW}, payload={"data": "http://cert.pl/admin"})
+
+        self.run_task(task)
+        (call,) = self.mock_db.save_task_result.call_args_list
+        self.assertEqual(call.kwargs["status_reason"], "Unsupported data: http://cert.pl/admin")

--- a/test/modules/test_classifier.py
+++ b/test/modules/test_classifier.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from karton.core import Task
 
+from artemis import direct_url_scanning
 from artemis.binds import TaskType
 from artemis.modules.classifier import Classifier
 
@@ -45,6 +46,9 @@ class ClassifierTest(ArtemisModuleTestCase):
         self.assertFalse(Classifier.is_supported("http://"))
         self.assertFalse(Classifier.is_supported("http://cert.pl/admin"))
         self.assertFalse(Classifier.is_supported("http://cert.pl/?q=1"))
+        # Malformed scheme separators are not URLs and aren't valid host:port either
+        self.assertFalse(Classifier.is_supported("http:/cert.pl"))
+        self.assertFalse(Classifier.is_supported("http:cert.pl"))
         # Non-URL inputs keep their existing behaviour
         self.assertTrue(Classifier.is_supported("cert.pl"))
         self.assertTrue(Classifier.is_supported("[::1]:2"))
@@ -56,18 +60,20 @@ class ClassifierTest(ArtemisModuleTestCase):
         self.assertTrue(Classifier.is_supported("CERT.pl"))
         self.assertFalse(Classifier.is_supported("root@cert.pl"))
 
-    def test_is_url(self) -> None:
-        # Root URLs that map to a service are recognized as URLs
-        self.assertTrue(Classifier.is_url("http://example.com"))
-        self.assertTrue(Classifier.is_url("https://example.com:8443/"))
-        self.assertTrue(Classifier.is_url("ssh://example.com:22/"))
-        # Domains and IPs (with or without a port) are supported targets but are not URLs
-        self.assertFalse(Classifier.is_url("cert.pl"))
-        self.assertFalse(Classifier.is_url("cert.pl:8080"))
-        self.assertFalse(Classifier.is_url("1.2.3.4:56"))
-        # Non-root URLs and unmapped schemes are not URLs either
-        self.assertFalse(Classifier.is_url("http://cert.pl/admin"))
-        self.assertFalse(Classifier.is_url("ws://cert.pl"))
+    def test_is_scannable_url(self) -> None:
+        # Root URLs that map to a service are accepted as direct scan targets
+        self.assertTrue(direct_url_scanning.is_scannable_url("http://example.com"))
+        self.assertTrue(direct_url_scanning.is_scannable_url("https://example.com:8443/"))
+        self.assertTrue(direct_url_scanning.is_scannable_url("ssh://example.com:22/"))
+        # Domains and IPs (with or without a port) are supported targets but not direct scan URLs
+        self.assertFalse(direct_url_scanning.is_scannable_url("cert.pl"))
+        self.assertFalse(direct_url_scanning.is_scannable_url("cert.pl:8080"))
+        self.assertFalse(direct_url_scanning.is_scannable_url("1.2.3.4:56"))
+        # Non-root URLs, unmapped schemes and malformed separators are not accepted
+        self.assertFalse(direct_url_scanning.is_scannable_url("http://cert.pl/admin"))
+        self.assertFalse(direct_url_scanning.is_scannable_url("ws://cert.pl"))
+        self.assertFalse(direct_url_scanning.is_scannable_url("http:/cert.pl"))
+        self.assertFalse(direct_url_scanning.is_scannable_url("http:cert.pl"))
 
     def test_parsing(self) -> None:
         entries = [


### PR DESCRIPTION
This change teaches the classifier to accept a root URL such as `https://example.com/` or `ssh://example.com:22/`. When it sees one, it reads the scheme, host and port and emits a `TaskType.SERVICE` task directly, the same task `port_scanner` would eventually produce - so every service-consuming module (`sql_injection_detector`, `nuclei`, `lfi_detector`, etc) picks it up immediately with no changes on their side. The scheme selects the service and the SSL flag, and the default port is resolved with `socket.getservbyname()`, the same way the reporting code already derives ports from schemes, so no port numbers are hardcoded.

Only root URLs are accepted. A URL carrying a path, query, fragment or userinfo is rejected with a clear validation error rather than being silently stripped, because a root URL identifies a service to scan rather than a specific resource, and the HTTP modules crawl from the root on their own. Because a root URL already yields a SERVICE task without port scanning, the add-targets form no longer forces `port_scanner` to be enabled when every submitted target is a root URL. Mixed submissions that still contain a bare domain or IP continue to require it, since those targets rely on the recon path.