### PR TITLE
Fix double-slash URLs in e2e tests exposed by requests 2.34 redirect handling

### DIFF
--- a/test/e2e/test_exporting.py
+++ b/test/e2e/test_exporting.py
@@ -5,6 +5,7 @@ import time
 import zipfile
 from socket import gethostbyname
 from test.e2e.base import BACKEND_URL, BaseE2ETestCase
+from urllib.parse import urljoin
 
 import requests
 from bs4 import BeautifulSoup
@@ -281,7 +282,9 @@ class ExportingTestCase(BaseE2ETestCase):
         filename = tempfile.mktemp()
 
         with open(filename, "wb") as f:
-            f.write(requests.get(BACKEND_URL + data[0]["zip_url"], headers={"X-Api-Token": "api-token"}).content)
+            f.write(
+                requests.get(urljoin(BACKEND_URL, data[0]["zip_url"]), headers={"X-Api-Token": "api-token"}).content
+            )
 
         with zipfile.ZipFile(filename) as export:
             with export.open("messages/test-smtp-server.artemis.html", "r") as f:
@@ -486,7 +489,9 @@ class ExportingTestCase(BaseE2ETestCase):
             filename = tempfile.mktemp()
 
             with open(filename, "wb") as f:
-                f.write(requests.get(BACKEND_URL + data[0]["zip_url"], headers={"X-Api-Token": "api-token"}).content)
+                f.write(
+                    requests.get(urljoin(BACKEND_URL, data[0]["zip_url"]), headers={"X-Api-Token": "api-token"}).content
+                )
 
             with zipfile.ZipFile(filename) as export:
                 with export.open("advanced/output.json", "r") as f:

--- a/test/e2e/test_modules_list_endpoint.py
+++ b/test/e2e/test_modules_list_endpoint.py
@@ -1,5 +1,6 @@
 from test.e2e.base import BACKEND_URL, BaseE2ETestCase
 from typing import Any, Dict, Optional
+from urllib.parse import urljoin
 
 import requests
 
@@ -9,7 +10,7 @@ VALID_HEADERS: Dict[str, str] = {"X-API-Token": API_TOKEN}
 
 class ModulesListEndpointTestCase(BaseE2ETestCase):
     def test_modules_list_endpoint(self) -> None:
-        response = requests.get(f"{BACKEND_URL}/api/get-modules-that-can-be-disabled", headers=VALID_HEADERS)
+        response = requests.get(urljoin(BACKEND_URL, "/api/get-modules-that-can-be-disabled"), headers=VALID_HEADERS)
         self.assertEqual(response.status_code, 200)
 
         data = response.json()


### PR DESCRIPTION
## What

Fix double-slash URLs in e2e tests (`test_exporting_api`, `test_exporting_api_timeframe`, `test_modules_list_endpoint`) that fail under #2876 (bump `requests` 2.33.1 → 2.34.2).

## Why

The tests build request URLs by string concatenation, producing a double slash. `BACKEND_URL` ends with `/` (`http://web:5000/`), and the appended path has a leading `/` — the `zip_url` field from `api.py` (`/api/export/download-zip/{id}`) in the exporting tests, and a literal `/api/...` in the modules-list test. The result is `//api/...`.

The backend routes `//api/...` differently from `/api/...`: it misses the API router and falls through, returning `303 → /login`. `requests` < 2.34 did not follow that redirect and happened to hit the API anyway; 2.34 correctly follows the redirect, lands on the login HTML, and the subsequent `.json()` / zip parsing fails (`BadZipFile`, `JSONDecodeError`).

So this is **not a regression in 2.34** — the redirect-handling fix in `requests` exposed a pre-existing bug in how the tests construct URLs. The double slash was latent on `main` and passed only because `requests` < 2.34 masked it.

## Fix

Use `urljoin(BACKEND_URL, path)` instead of `BACKEND_URL + path`. `urljoin` composes base + path correctly regardless of slashes on either side, so no `//` is produced.

The API contract is left untouched: `zip_url` keeps its leading `/` (a standard absolute-path API reference — stripping it would make it relative and break correct `urljoin`-based composition for external API consumers). The only in-repo consumer of `zip_url` is the tests; the frontend links to the ZIP via `url_path_for('export_download_zip', ...)`, independently of this field.

## Tests

Verified locally against `requests` 2.34.2 (rebuilt image): all 7 e2e tests green, including the three that previously failed. On 2.33.1 the pre-fix code passed only incidentally (redirect not followed), so the fix was validated on the version that actually needs it.

## Notes / Out of scope

- Bumping `requests` itself stays in #2876; this PR only fixes the URL construction in the tests.
- Path-traversal checked while here: `//api`, `/api/../api`, `%2e%2e`, `..%2f`, `..;/`, `/./api`, multiple slashes — none reach API data without a token (`422` / `303 → /login` / `404`). Checked representatively, not exhaustively (no double-encoding / backslash variants); a full traversal audit of `/api/*` would be a separate task. Local check is bare uvicorn — a production proxy may normalize paths differently.