### PR TITLE
Shorten Nuclei DAST PoC URLs via single-mode re-fuzzing

### DIFF
--- a/artemis/modules/nuclei.py
+++ b/artemis/modules/nuclei.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import collections
 import enum
+import functools
 import itertools
 import json
 import logging
@@ -11,7 +12,7 @@ import subprocess
 import time
 import urllib
 from statistics import StatisticsError, quantiles
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Set
 
 import more_itertools
 from karton.core import Task
@@ -106,38 +107,6 @@ METRIC_SCAN_DURATION = Histogram(
 logger = logging.getLogger(__name__)
 
 
-def _verify_with_nuclei(url: str, template_path: str) -> bool:
-    try:
-        command = [
-            "nuclei",
-            "-disable-update-check",
-            "-u",
-            url,
-            "-t",
-            template_path,
-            "-dast",
-            "-fuzzing-mode",
-            "multiple",
-            "-jsonl",
-            "-silent",
-        ]
-        result = subprocess.check_output(command, stderr=subprocess.DEVNULL)
-        for line in result.strip().splitlines():
-            try:
-                hit = json.loads(line)
-                if hit.get("matched-at"):
-                    return True
-            except json.JSONDecodeError:
-                continue
-        return False
-    except FileNotFoundError:
-        logger.warning("Nuclei binary not found, skipping URL verification")
-        return False
-    except subprocess.CalledProcessError as e:
-        logger.warning("Nuclei verification failed on %s: %s", url, e)
-        return False
-
-
 # It is important to keep ssrf, redirect and lfi at the top so that their params get the correct default values
 DAST_SCANNING: Dict[str, Dict[str, Any]] = {
     "ssrf": {  # ssrf dast templates work only when the param is of the form http://...
@@ -168,6 +137,94 @@ DAST_SCANNING: Dict[str, Dict[str, Any]] = {
         "param_default_value": "testing",
     },
 }
+
+
+@functools.lru_cache(maxsize=1)
+def _get_dast_param_defaults() -> Dict[str, str]:
+    """Map each DAST wordlist parameter name to its default value.
+
+    Used to rebuild a re-fuzz target: parameters that Artemis injected are
+    reset to their family default (so Nuclei re-fuzzes them from a clean base,
+    exactly like the original scan did), rather than being left carrying the
+    payload from the multiple-mode hit. If a name appears in several wordlists,
+    the first family wins (DAST_SCANNING order keeps ssrf/redirect/lfi on top).
+    """
+    defaults: Dict[str, str] = {}
+    for template_data in DAST_SCANNING.values():
+        default_value = template_data["param_default_value"]
+        with open(template_data["params_wordlist"], "r") as wordlist_file:
+            for line in wordlist_file:
+                name = line.strip()
+                if name and not name.startswith("#") and name not in defaults:
+                    defaults[name] = default_value
+    return defaults
+
+
+def _refuzz_single_with_nuclei(url: str, template_path: str) -> Set[str]:
+    """Re-run Nuclei in single fuzzing mode and return the set of parameter
+    names that trigger the finding on their own.
+
+    Injected (wordlist) parameters are reset to their default value so Nuclei
+    fuzzes them from a clean base; the site's own parameters (not in any
+    wordlist) keep their matched-at value. Returns an empty set on any failure
+    (binary missing, timeout, no hit) - the caller then falls back to the full
+    PoC.
+    """
+    parsed = urllib.parse.urlparse(url)
+    if not parsed.query:
+        return set()
+
+    defaults = _get_dast_param_defaults()
+
+    rebuilt_pairs = []
+    for raw_pair in parsed.query.split("&"):
+        if not raw_pair:
+            continue
+        raw_name = raw_pair.split("=", 1)[0]
+        name = urllib.parse.unquote_plus(raw_name)
+        if name in defaults:
+            rebuilt_pairs.append(raw_name + "=" + urllib.parse.quote(defaults[name], safe="/:@!$&'()*+,;="))
+        else:
+            rebuilt_pairs.append(raw_pair)
+    refuzz_url = urllib.parse.urlunparse(parsed._replace(query="&".join(rebuilt_pairs)))
+
+    try:
+        command = [
+            "nuclei",
+            "-disable-update-check",
+            "-u",
+            refuzz_url,
+            "-t",
+            template_path,
+            "-dast",
+            "-fuzzing-mode",
+            "single",
+            "-jsonl",
+            "-silent",
+        ]
+        if Config.Modules.Nuclei.NUCLEI_INTERACTSH_SERVER:
+            command.extend(["-interactsh-server", Config.Modules.Nuclei.NUCLEI_INTERACTSH_SERVER.strip("/")])
+
+        result = subprocess.check_output(command, stderr=subprocess.DEVNULL)
+        confirmed: Set[str] = set()
+        for line in result.strip().splitlines():
+            try:
+                hit = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            # NOTE: assumes single-mode hits carry a non-empty "fuzzing_parameter";
+            # verify against live Nuclei output.
+            param = hit.get("fuzzing_parameter")
+            if param:
+                confirmed.add(param)
+        return confirmed
+    except FileNotFoundError:
+        logger.warning("Nuclei binary not found, skipping URL minimization")
+        return set()
+    except subprocess.CalledProcessError as e:
+        logger.warning("Nuclei single-mode re-fuzz failed on %s: %s", url, e)
+        return set()
+
 
 UPDATE_INTERVAL = 60 * 60 * 24 * 7  # 7 days
 
@@ -882,8 +939,7 @@ class Nuclei(ArtemisBase):
                     )
                     finding["matched-at"] = minimize_nuclei_matched_at_url(
                         finding["matched-at"],
-                        fuzzing_parameter=finding.get("fuzzing_parameter"),
-                        verify_url_fn=lambda url: _verify_with_nuclei(url, template_path),
+                        refuzz_fn=lambda url: _refuzz_single_with_nuclei(url, template_path),
                     )
                 result.append(finding)
                 messages.append(

--- a/artemis/modules/nuclei.py
+++ b/artemis/modules/nuclei.py
@@ -188,6 +188,12 @@ def _refuzz_single_with_nuclei(url: str, template_path: str) -> Set[str]:
             rebuilt_pairs.append(raw_pair)
     refuzz_url = urllib.parse.urlunparse(parsed._replace(query="&".join(rebuilt_pairs)))
 
+    # These flags mirror the main scan's command (_scan) so the re-fuzz
+    # reproduces the finding under the same conditions (user agent, rate
+    # limit, timeout, resolvers). Batch-only flags are intentionally
+    # omitted: rate-limit-duration/bulk-size/concurrency/stats are
+    # meaningless for a single-URL re-fuzz. Sharing a common command
+    # builder with _scan is a planned follow-up (see PR description).
     try:
         command = [
             "nuclei",
@@ -201,7 +207,16 @@ def _refuzz_single_with_nuclei(url: str, template_path: str) -> Set[str]:
             "single",
             "-jsonl",
             "-silent",
+            "-timeout",
+            str(Config.Limits.REQUEST_TIMEOUT_SECONDS),
+            "-system-resolvers",
+            "-rate-limit",
+            "1",
+            "-response-size-read",
+            "1048576",
         ]
+        if Config.Miscellaneous.CUSTOM_USER_AGENT:
+            command.extend(["-H", "User-Agent: " + Config.Miscellaneous.CUSTOM_USER_AGENT])
         if Config.Modules.Nuclei.NUCLEI_INTERACTSH_SERVER:
             command.extend(["-interactsh-server", Config.Modules.Nuclei.NUCLEI_INTERACTSH_SERVER.strip("/")])
 

--- a/artemis/modules/nuclei.py
+++ b/artemis/modules/nuclei.py
@@ -160,15 +160,54 @@ def _get_dast_param_defaults() -> Dict[str, str]:
     return defaults
 
 
+def build_common_nuclei_command() -> List[str]:
+    """Return the Nuclei flags shared by every invocation Artemis makes.
+
+    Both the batch scan (:meth:`Nuclei._scan`) and the single-URL re-fuzz used
+    to shorten PoC URLs (:func:`_refuzz_single_with_nuclei`) start from this
+    list, so a re-fuzz reproduces the finding under the same conditions the
+    scan found it (user agent, rate limit, timeout, resolvers, interactsh).
+    Flags that only make sense for a batch (parallelism, stats, per-batch rate
+    limit duration) stay in the caller.
+    """
+    command = [
+        "nuclei",
+        "-disable-update-check",
+        "-timeout",
+        str(Config.Limits.REQUEST_TIMEOUT_SECONDS),
+        "-jsonl",
+        "-system-resolvers",
+        "-rate-limit",
+        "1",
+        "-response-size-read",
+        "1048576",
+    ]
+
+    if Config.Miscellaneous.CUSTOM_USER_AGENT:
+        command.extend(["-H", "User-Agent: " + Config.Miscellaneous.CUSTOM_USER_AGENT])
+
+    if Config.Modules.Nuclei.NUCLEI_INTERACTSH_SERVER:
+        # Unfortunately, because of https://github.com/projectdiscovery/interactsh/issues/135,
+        # the trailing slash matters.
+        command.extend(["-interactsh-server", Config.Modules.Nuclei.NUCLEI_INTERACTSH_SERVER.strip("/")])
+
+    return command
+
+
 def _refuzz_single_with_nuclei(url: str, template_path: str) -> Set[str]:
     """Re-run Nuclei in single fuzzing mode and return the set of parameter
-    names that trigger the finding on their own.
+    names Nuclei reported the finding for.
 
     Injected (wordlist) parameters are reset to their default value so Nuclei
     fuzzes them from a clean base; the site's own parameters (not in any
     wordlist) keep their matched-at value. Returns an empty set on any failure
     (binary missing, timeout, no hit) - the caller then falls back to the full
     PoC.
+
+    Single mode mutates one parameter per request but still sends the others,
+    so a reported name is not proof that it suffices on its own -
+    ``minimize_nuclei_matched_at_url`` calls this again on the shortened URL to
+    check that.
     """
     parsed = urllib.parse.urlparse(url)
     if not parsed.query:
@@ -188,38 +227,21 @@ def _refuzz_single_with_nuclei(url: str, template_path: str) -> Set[str]:
             rebuilt_pairs.append(raw_pair)
     refuzz_url = urllib.parse.urlunparse(parsed._replace(query="&".join(rebuilt_pairs)))
 
-    # These flags mirror the main scan's command (_scan) so the re-fuzz
-    # reproduces the finding under the same conditions (user agent, rate
-    # limit, timeout, resolvers). Batch-only flags are intentionally
-    # omitted: rate-limit-duration/bulk-size/concurrency/stats are
-    # meaningless for a single-URL re-fuzz. Sharing a common command
-    # builder with _scan is a planned follow-up (see PR description).
-    try:
-        command = [
-            "nuclei",
-            "-disable-update-check",
-            "-u",
-            refuzz_url,
-            "-t",
-            template_path,
-            "-dast",
-            "-fuzzing-mode",
-            "single",
-            "-jsonl",
-            "-silent",
-            "-timeout",
-            str(Config.Limits.REQUEST_TIMEOUT_SECONDS),
-            "-system-resolvers",
-            "-rate-limit",
-            "1",
-            "-response-size-read",
-            "1048576",
-        ]
-        if Config.Miscellaneous.CUSTOM_USER_AGENT:
-            command.extend(["-H", "User-Agent: " + Config.Miscellaneous.CUSTOM_USER_AGENT])
-        if Config.Modules.Nuclei.NUCLEI_INTERACTSH_SERVER:
-            command.extend(["-interactsh-server", Config.Modules.Nuclei.NUCLEI_INTERACTSH_SERVER.strip("/")])
+    # Batch-only flags (rate-limit-duration, bulk-size, concurrency, stats,
+    # trace log) are intentionally left out of the shared command builder -
+    # they are meaningless for a single-URL re-fuzz.
+    command = build_common_nuclei_command() + [
+        "-u",
+        refuzz_url,
+        "-t",
+        template_path,
+        "-dast",
+        "-fuzzing-mode",
+        "single",
+        "-silent",
+    ]
 
+    try:
         result = subprocess.check_output(command, stderr=subprocess.DEVNULL)
         confirmed: Set[str] = set()
         for line in result.strip().splitlines():
@@ -227,8 +249,9 @@ def _refuzz_single_with_nuclei(url: str, template_path: str) -> Set[str]:
                 hit = json.loads(line)
             except json.JSONDecodeError:
                 continue
-            # NOTE: assumes single-mode hits carry a non-empty "fuzzing_parameter";
-            # verify against live Nuclei output.
+            # "fuzzing_parameter" is the name Nuclei mutated for this hit. A hit
+            # without it tells us nothing usable, so it is skipped - if that
+            # leaves us with nothing, the caller keeps the full PoC URL.
             param = hit.get("fuzzing_parameter")
             if param:
                 confirmed.add(param)
@@ -623,11 +646,6 @@ class Nuclei(ArtemisBase):
 
         milliseconds_per_request_candidates = [milliseconds_per_request_initial, milliseconds_per_request_retry]
 
-        if Config.Miscellaneous.CUSTOM_USER_AGENT:
-            additional_configuration = ["-H", "User-Agent: " + Config.Miscellaneous.CUSTOM_USER_AGENT]
-        else:
-            additional_configuration = []
-
         lines = []
         time_start = time.time()
         for chunk in more_itertools.chunked(templates_or_workflows_filtered, Config.Modules.Nuclei.NUCLEI_CHUNK_SIZE):
@@ -638,30 +656,20 @@ class Nuclei(ArtemisBase):
                     len(targets),
                     milliseconds_per_request,
                 )
-                command = [
-                    "nuclei",
-                    "-disable-update-check",
+                command = build_common_nuclei_command() + [
                     "-v",
-                    "-timeout",
-                    str(Config.Limits.REQUEST_TIMEOUT_SECONDS),
-                    "-jsonl",
-                    "-system-resolvers",
-                    "-rate-limit",
-                    "1",
                     "-rate-limit-duration",
                     str(milliseconds_per_request) + "ms",
                     "-stats-json",
                     "-stats-interval",
                     "1",
-                    "-response-size-read",
-                    "1048576",
                     "-concurrency",
                     "5",
                     "-bulk-size",
                     str(len(targets)),
                     "-trace-log",
                     "/dev/stderr",
-                ] + additional_configuration
+                ]
 
                 if extra_nuclei_args:
                     command.extend(extra_nuclei_args)
@@ -682,11 +690,6 @@ class Nuclei(ArtemisBase):
                     )
                 else:
                     assert False
-
-                if Config.Modules.Nuclei.NUCLEI_INTERACTSH_SERVER:
-                    # Unfortunately, because of https://github.com/projectdiscovery/interactsh/issues/135,
-                    # the trailing slash matters.
-                    command.extend(["-interactsh-server", Config.Modules.Nuclei.NUCLEI_INTERACTSH_SERVER.strip("/")])
 
                 if scan_using == ScanUsing.TEMPLATES:
                     # The `-it` flag will include the templates provided in NUCLEI_ADDITIONAL_TEMPLATES even if

--- a/artemis/reporting/modules/nuclei/poc_url_utils.py
+++ b/artemis/reporting/modules/nuclei/poc_url_utils.py
@@ -1,55 +1,91 @@
-"""Utilities for minimizing Nuclei DAST PoC URLs."""
+"""Utilities for minimizing Nuclei DAST PoC URLs.
 
+A DAST target built by Artemis carries *every* parameter from the DAST
+wordlists (ssrf/redirect/lfi/cmdi/sqli/xss) stacked onto one URL - well over a
+hundred parameters. Nuclei fuzzes them with ``-fuzzing-mode multiple``, so a
+single hit's ``matched-at`` carries the payload in many parameters at once plus
+all the unrelated scaffolding, which is why raw PoC URLs are thousands of
+characters long. From a ``multiple`` hit we cannot tell which parameter is
+actually vulnerable - the payload is in all of them.
+
+To shorten the PoC we re-fuzz the finding in ``-fuzzing-mode single`` (one
+parameter per request). That tells us exactly which parameters trigger the
+vulnerability on their own; we keep those and drop the rest. If single-mode
+confirms nothing (e.g. the vulnerability needs several parameters together,
+which single-mode cannot reproduce), we fall back to the original URL so the
+PoC still works.
+
+Parameter values are preserved byte-for-byte from the raw query string: they
+are attack payloads, and re-encoding them (e.g. decoding ``%2F%2F`` to ``//``)
+could stop a payload from bypassing the very filter it was crafted to defeat.
+We therefore split the query manually instead of going through parse_qs /
+urlencode, which would normalise the encoding.
+"""
+
+import logging
 import urllib.parse
-from typing import Callable, Optional
+from typing import Callable, List, Optional, Set, Tuple
+
+logger = logging.getLogger(__name__)
 
 
-def _build_single_param_url(parsed: urllib.parse.ParseResult, param_name: str, param_values: list[str]) -> str:
-    useful_params = {param_name: param_values}
-    new_query = urllib.parse.urlencode(
-        useful_params,
-        doseq=True,
-        quote_via=urllib.parse.quote,
-        safe="/:@!$&'()*+,;=",
-    )
-    return urllib.parse.urlunparse(parsed._replace(query=new_query))
+def _split_query_pairs(query: str) -> List[Tuple[str, str]]:
+    """Split a raw query string into (decoded_name, raw_pair) tuples.
+
+    ``raw_pair`` is the original ``name=value`` substring, preserved verbatim so
+    the payload is never re-encoded. ``decoded_name`` is only used to match
+    against confirmed parameter names.
+    """
+    pairs: List[Tuple[str, str]] = []
+    for raw_pair in query.split("&"):
+        if not raw_pair:
+            continue
+        raw_name = raw_pair.split("=", 1)[0]
+        decoded_name = urllib.parse.unquote_plus(raw_name)
+        pairs.append((decoded_name, raw_pair))
+    return pairs
 
 
 def minimize_nuclei_matched_at_url(
     url: str,
-    fuzzing_parameter: Optional[str] = None,
-    verify_url_fn: Optional[Callable[[str], bool]] = None,
+    refuzz_fn: Optional[Callable[[str], Set[str]]] = None,
     params_threshold: int = 2,
 ) -> str:
     """Return a short, still-working PoC URL from a Nuclei matched-at URL.
 
-    If fuzzing_parameter is provided, keeps only that parameter.
-    If fuzzing_parameter is absent but verify_url_fn is provided, tries each
-    query parameter individually to find which one triggers the vulnerability.
-    Falls back to the original URL if verification fails or is unavailable.
+    ``refuzz_fn`` re-runs Nuclei in single fuzzing mode against ``url`` and
+    returns the set of parameter names that trigger the finding on their own.
+    We rebuild the URL keeping only those parameters, with their query segments
+    preserved byte-for-byte. If ``refuzz_fn`` is absent, or confirms no
+    parameter, the original URL is returned unchanged so the PoC still works.
     """
     parsed = urllib.parse.urlparse(url)
     if not parsed.query:
         return url
 
-    params = urllib.parse.parse_qs(parsed.query, keep_blank_values=True)
+    pairs = _split_query_pairs(parsed.query)
 
-    if len(params) <= params_threshold:
+    if len(pairs) <= params_threshold:
         # Don't minimize if there are not many parameters
         return url
 
-    if fuzzing_parameter:
-        if fuzzing_parameter not in params:
-            return url
-        minimized = _build_single_param_url(parsed, fuzzing_parameter, params[fuzzing_parameter])
-        if verify_url_fn is not None and not verify_url_fn(minimized):
-            return url
-        return minimized
+    if refuzz_fn is None:
+        return url
 
-    if verify_url_fn is not None:
-        for param_name, param_values in params.items():
-            minimized = _build_single_param_url(parsed, param_name, param_values)
-            if verify_url_fn(minimized):
-                return minimized
+    confirmed = refuzz_fn(url)
 
-    return url
+    # Keep the raw query segments whose parameter name was confirmed, in their
+    # original order and encoding.
+    kept_raw = [raw_pair for decoded_name, raw_pair in pairs if decoded_name in confirmed]
+
+    if not kept_raw:
+        # Single-mode reproduced nothing (e.g. needs several params together) -
+        # keep the full URL so the PoC still works. Logged (without the URL, to
+        # avoid recording payloads/targets) so the fallback rate can be tracked.
+        logger.info(
+            "PoC minimization: single-mode confirmed no parameter, keeping full URL with %d params",
+            len(pairs),
+        )
+        return url
+
+    return urllib.parse.urlunparse(parsed._replace(query="&".join(kept_raw)))

--- a/artemis/reporting/modules/nuclei/poc_url_utils.py
+++ b/artemis/reporting/modules/nuclei/poc_url_utils.py
@@ -9,11 +9,19 @@ characters long. From a ``multiple`` hit we cannot tell which parameter is
 actually vulnerable - the payload is in all of them.
 
 To shorten the PoC we re-fuzz the finding in ``-fuzzing-mode single`` (one
-parameter per request). That tells us exactly which parameters trigger the
-vulnerability on their own; we keep those and drop the rest. If single-mode
-confirms nothing (e.g. the vulnerability needs several parameters together,
-which single-mode cannot reproduce), we fall back to the original URL so the
-PoC still works.
+parameter per request). That tells us which parameters carry the payload when
+fuzzed on their own; we keep those and drop the rest. If single-mode confirms
+nothing (e.g. the vulnerability needs several parameters together, which
+single-mode cannot reproduce), we fall back to the original URL so the PoC
+still works.
+
+Single mode changes one parameter per request but still *sends* all the others,
+so a reported parameter is not proof that it suffices alone. For
+``if (isset($_GET["login"])) { echo "Login failed: " . $_GET["search"]; }``
+single mode reports ``search``, yet dropping ``login`` breaks the PoC. We
+therefore never trust the reported names on their own: the shortened URL is
+re-fuzzed as well, and only kept if the finding still reproduces without the
+parameters we removed.
 
 Parameter values are preserved byte-for-byte from the raw query string: they
 are attack payloads, and re-encoding them (e.g. decoding ``%2F%2F`` to ``//``)
@@ -53,11 +61,14 @@ def minimize_nuclei_matched_at_url(
 ) -> str:
     """Return a short, still-working PoC URL from a Nuclei matched-at URL.
 
-    ``refuzz_fn`` re-runs Nuclei in single fuzzing mode against ``url`` and
-    returns the set of parameter names that trigger the finding on their own.
-    We rebuild the URL keeping only those parameters, with their query segments
-    preserved byte-for-byte. If ``refuzz_fn`` is absent, or confirms no
-    parameter, the original URL is returned unchanged so the PoC still works.
+    ``refuzz_fn`` re-runs Nuclei in single fuzzing mode against the URL it is
+    given and returns the set of parameter names Nuclei reported the finding
+    for. We rebuild the URL keeping only those parameters, with their query
+    segments preserved byte-for-byte, and then call ``refuzz_fn`` again on the
+    shortened URL to check the finding survives without the dropped
+    parameters. If ``refuzz_fn`` is absent, confirms no parameter, or no longer
+    reproduces the finding on the shortened URL, the original URL is returned
+    unchanged so the PoC still works.
     """
     parsed = urllib.parse.urlparse(url)
     if not parsed.query:
@@ -78,14 +89,35 @@ def minimize_nuclei_matched_at_url(
     # original order and encoding.
     kept_raw = [raw_pair for decoded_name, raw_pair in pairs if decoded_name in confirmed]
 
+    # The fallbacks below are logged without the URL, to avoid recording
+    # payloads and targets, so that the fallback rate can still be tracked.
     if not kept_raw:
         # Single-mode reproduced nothing (e.g. needs several params together) -
-        # keep the full URL so the PoC still works. Logged (without the URL, to
-        # avoid recording payloads/targets) so the fallback rate can be tracked.
+        # keep the full URL so the PoC still works.
         logger.info(
             "PoC minimization: single-mode confirmed no parameter, keeping full URL with %d params",
             len(pairs),
         )
         return url
 
-    return urllib.parse.urlunparse(parsed._replace(query="&".join(kept_raw)))
+    if len(kept_raw) == len(pairs):
+        # Nothing to drop, so nothing to re-verify.
+        return url
+
+    minimized = urllib.parse.urlunparse(parsed._replace(query="&".join(kept_raw)))
+
+    # Single mode reports the parameter it mutated, but it sends the other
+    # parameters along with it - so a finding that needs a second parameter
+    # (a gate such as `login`) is still reported against one name only.
+    # Re-fuzz the shortened URL to make sure the finding does not depend on
+    # what we are about to drop.
+    if not refuzz_fn(minimized):
+        logger.info(
+            "PoC minimization: finding does not reproduce on the %d-param URL shortened from %d params, "
+            "keeping full URL",
+            len(kept_raw),
+            len(pairs),
+        )
+        return url
+
+    return minimized

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -181,6 +181,15 @@ services:
         aliases:
           - test-php-xss-but-not-on-homepage.local
 
+  test-php-xss-requiring-second-param:
+    image: php:8.0-apache
+    volumes:
+      - ./test/data/php_xss_requiring_second_param/:/var/www/html/
+    networks:
+      default:
+        aliases:
+          - test-php-xss-requiring-second-param.local
+
   test-ftp-server-with-easy-password:
     image: stilliard/pure-ftpd:latest
     environment:

--- a/test/data/php_xss_requiring_second_param/index.php
+++ b/test/data/php_xss_requiring_second_param/index.php
@@ -1,0 +1,14 @@
+<?php
+// A reflected XSS that needs two parameters: `search` is echoed back only when
+// `login` is also present.
+//
+// Nuclei's single fuzzing mode mutates one parameter per request but keeps
+// sending the others, so it reports this finding against `search` alone. A PoC
+// URL shortened to just `?search=...` would therefore no longer reproduce it -
+// this app exists to make sure Artemis notices that and keeps the full URL.
+//
+// Both parameter names come from artemis/modules/data/dast_params/xss.txt,
+// otherwise Artemis would never put them in the DAST target in the first place.
+if (isset($_GET["login"])) {
+    echo "Login failed: " . $_GET["search"];
+}

--- a/test/modules/test_nuclei.py
+++ b/test/modules/test_nuclei.py
@@ -1,3 +1,5 @@
+import re
+import urllib.parse
 from test.base import ArtemisModuleTestCase
 from unittest.mock import patch
 
@@ -5,6 +7,15 @@ from karton.core import Task
 
 from artemis.binds import TaskStatus, TaskType
 from artemis.modules.nuclei import Nuclei
+
+
+def _param_names(url: str) -> list[str]:
+    return list(urllib.parse.parse_qs(urllib.parse.urlparse(url).query, keep_blank_values=True).keys())
+
+
+def _reflected_xss_urls(status_reason: str) -> list[str]:
+    """The PoC URLs reported for the reflected XSS DAST template."""
+    return re.findall(r"\[medium\]\s+(\S+): Reflected Cross-Site Scripting", status_reason)
 
 
 class NucleiTest(ArtemisModuleTestCase):
@@ -131,6 +142,47 @@ class NucleiShortTemplateListTest(ArtemisModuleTestCase):
             call.kwargs["status_reason"],
             r"\[medium\] http://test-php-mock-CVE-2020-28976\.local:80/wp-content/plugins/canto/includes/lib/get\.php\?subdomain=[a-z0-9\.]+: WordPress Canto 1\.3\.0 - Blind Server-Side Request Forgery WordPress Canto plugin 1\.3\.0 is susceptible to blind server-side request forgery\. An attacker can make a request to any internal and external server via /includes/lib/detail\.php\?subdomain and thereby possibly obtain sensitive information, modify data, and/or execute unauthorized administrative operations in the context of the affected site\.",
         )
+
+    def test_poc_url_shortened_when_one_param_is_enough(self) -> None:
+        """/xss.php reflects `search` on its own, so the PoC URL - built from
+        the whole DAST wordlist - is shortened to that single parameter."""
+        task = Task(
+            {"type": TaskType.NUCLEI_TARGET},
+            payload={
+                "host": "test-php-xss-but-not-on-homepage.local",
+                "port": 80,
+            },
+        )
+        self.run_task(task)
+        (call,) = self.mock_db.save_task_result.call_args_list
+        self.assertEqual(call.kwargs["status"], TaskStatus.INTERESTING)
+        urls = _reflected_xss_urls(call.kwargs["status_reason"])
+        self.assertTrue(urls)
+        for url in urls:
+            self.assertEqual(_param_names(url), ["search"])
+
+    def test_poc_url_kept_whole_when_the_finding_needs_a_second_param(self) -> None:
+        """The app reflects `search` only if `login` is present. Nuclei's
+        single-mode re-fuzz reports `search` alone, because it keeps sending
+        `login` alongside it - so shortening the PoC to `?search=...` would
+        produce a URL that no longer reproduces the vulnerability. Artemis
+        must notice that and report the full URL instead."""
+        task = Task(
+            {"type": TaskType.NUCLEI_TARGET},
+            payload={
+                "host": "test-php-xss-requiring-second-param.local",
+                "port": 80,
+            },
+        )
+        self.run_task(task)
+        (call,) = self.mock_db.save_task_result.call_args_list
+        self.assertEqual(call.kwargs["status"], TaskStatus.INTERESTING)
+        urls = _reflected_xss_urls(call.kwargs["status_reason"])
+        self.assertTrue(urls)
+        for url in urls:
+            param_names = _param_names(url)
+            self.assertIn("search", param_names)
+            self.assertIn("login", param_names)
 
     def test_links(self) -> None:
         task = Task(

--- a/test/unit/test_minimize_nuclei_matched_at_url.py
+++ b/test/unit/test_minimize_nuclei_matched_at_url.py
@@ -6,102 +6,65 @@ from artemis.reporting.modules.nuclei.poc_url_utils import (
 )
 
 
-def _params(url: str) -> dict[str, list[str]]:
-    return urllib.parse.parse_qs(urllib.parse.urlparse(url).query)
+def _param_names(url: str) -> list[str]:
+    return list(urllib.parse.parse_qs(urllib.parse.urlparse(url).query).keys())
+
+
+def _raw_query(url: str) -> str:
+    return urllib.parse.urlparse(url).query
 
 
 class TestMinimizeNucleiMatchedAtUrl(unittest.TestCase):
-    """Tests for minimize_nuclei_matched_at_url.
+    URL = "http://ex.com/?next=PAYLOAD&category=PAYLOAD&page=testing&view=testing&q=testing&s=testing"
 
-    Strategy: if Nuclei's ``fuzzing_parameter`` is available, keep only that
-    parameter in the URL.  Otherwise return the original URL unchanged so the
-    recipient always has a working PoC.
-    """
+    def test_multiple_confirmed_all_kept(self) -> None:
+        result = minimize_nuclei_matched_at_url(self.URL, refuzz_fn=lambda _: {"next", "category"})
+        self.assertEqual(sorted(_param_names(result)), ["category", "next"])
 
-    def test_no_query_string_unchanged(self) -> None:
-        url = "https://example.com/vuln.php"
-        self.assertEqual(minimize_nuclei_matched_at_url(url, fuzzing_parameter="id"), url)
+    def test_single_confirmed_only_that_one(self) -> None:
+        result = minimize_nuclei_matched_at_url(self.URL, refuzz_fn=lambda _: {"next"})
+        self.assertEqual(_param_names(result), ["next"])
 
-    def test_no_fuzzing_parameter_returns_full_url(self) -> None:
-        """Without fuzzing_parameter the full URL is returned unchanged."""
-        url = "http://example.com/?id=testing'&search=testing'&category=testing'"
-        self.assertEqual(minimize_nuclei_matched_at_url(url), url)
+    def test_nothing_confirmed_falls_back_to_full(self) -> None:
+        result = minimize_nuclei_matched_at_url(self.URL, refuzz_fn=lambda _: set())
+        self.assertEqual(result, self.URL)
 
-    def test_fuzzing_parameter_keeps_only_named_param(self) -> None:
-        """When fuzzing_parameter is given, keep only that one param."""
-        url = "http://example.com/?filename=../../etc/passwd&file=abc.html&path=abc.html"
-        result = minimize_nuclei_matched_at_url(url, fuzzing_parameter="filename")
-        p = _params(result)
-        self.assertEqual(list(p.keys()), ["filename"])
-        self.assertEqual(p["filename"], ["../../etc/passwd"])
+    def test_no_refuzz_fn_returns_full(self) -> None:
+        result = minimize_nuclei_matched_at_url(self.URL, refuzz_fn=None)
+        self.assertEqual(result, self.URL)
 
-    def test_fuzzing_parameter_not_in_url_returns_full_url(self) -> None:
-        """If the named param isn't in the URL, return it unchanged."""
-        url = "http://example.com/?id=testing'&search=testing'"
-        self.assertEqual(
-            minimize_nuclei_matched_at_url(url, fuzzing_parameter="nonexistent"),
-            url,
-        )
+    def test_confirmed_name_absent_from_url_ignored(self) -> None:
+        result = minimize_nuclei_matched_at_url(self.URL, refuzz_fn=lambda _: {"next", "doesnotexist"})
+        self.assertEqual(_param_names(result), ["next"])
 
-    def test_real_lfi_url(self) -> None:
-        """Matches the real Nuclei v3.7.0 output from test-dast-vuln-app."""
-        url = "http://172.17.0.2:5000/?filename=../../../../../../../../../../../../../../../etc/passwd"
-        result = minimize_nuclei_matched_at_url(url, fuzzing_parameter="filename")
-        # Single param URL stays the same (just the one param)
-        self.assertIn("filename=", result)
-        self.assertIn("/etc/passwd", result)
-        self.assertNotIn("&", result)
+    def test_few_params_not_minimized(self) -> None:
+        short = "http://ex.com/?a=1&b=2"
+        result = minimize_nuclei_matched_at_url(short, refuzz_fn=lambda _: {"a"})
+        self.assertEqual(result, short)
 
-    def test_big_sqli_url_minimized(self) -> None:
-        """The exact long URL from issue #1977 gets minimized to one param."""
-        url = (
-            "http://example.com/vulnerabilities/sqli.php"
-            "?dest=http%3A%2F%2F127.0.0.1%2Fabc.html'"
-            "&redirect=http%3A%2F%2F127.0.0.1%2Fabc.html'"
-            "&id=testing'&search=testing'&category=testing'"
-        )
-        result = minimize_nuclei_matched_at_url(url, fuzzing_parameter="id")
-        p = _params(result)
-        self.assertEqual(list(p.keys()), ["id"])
-        self.assertEqual(p["id"], ["testing'"])
+    def test_no_query_returned_unchanged(self) -> None:
+        url = "http://ex.com/path"
+        self.assertEqual(minimize_nuclei_matched_at_url(url, refuzz_fn=lambda _: {"a"}), url)
 
-    def test_slashes_not_encoded(self) -> None:
-        """Path traversal slashes must stay readable, not become %2F."""
-        url = "http://example.com/?file=../../etc/passwd&other=abc"
-        result = minimize_nuclei_matched_at_url(url, fuzzing_parameter="file")
-        self.assertIn("../../etc/passwd", result)
-        self.assertNotIn("%2F", result)
+    def test_payload_preserved_byte_for_byte(self) -> None:
+        url = "http://ex.com/?url=%2F%2Fevil.example.com%2F&a=testing&b=testing"
+        result = minimize_nuclei_matched_at_url(url, refuzz_fn=lambda _: {"url"})
+        self.assertEqual(_raw_query(result), "url=%2F%2Fevil.example.com%2F")
 
-    def test_path_host_scheme_preserved(self) -> None:
-        url = "https://example.com:8443/api/v1/?file=../../etc/passwd&path=abc.html"
-        result = minimize_nuclei_matched_at_url(url, fuzzing_parameter="file")
-        parsed = urllib.parse.urlparse(result)
-        self.assertEqual(parsed.scheme, "https")
-        self.assertEqual(parsed.hostname, "example.com")
-        self.assertEqual(parsed.port, 8443)
-        self.assertEqual(parsed.path, "/api/v1/")
+    def test_equals_sign_in_value_preserved(self) -> None:
+        url = "http://ex.com/?redirect=http://evil/?a=b%26c=d&x=testing&y=testing&z=testing"
+        result = minimize_nuclei_matched_at_url(url, refuzz_fn=lambda _: {"redirect"})
+        self.assertEqual(_raw_query(result), "redirect=http://evil/?a=b%26c=d")
 
-    def test_verify_fn_passes_uses_minimized_url(self) -> None:
-        """If verify_url_fn returns True, the minimized URL is used."""
-        url = "http://example.com/?id=testing'&search=testing'&category=testing'"
-        result = minimize_nuclei_matched_at_url(
-            url,
-            fuzzing_parameter="id",
-            verify_url_fn=lambda _: True,
-        )
-        p = _params(result)
-        self.assertEqual(list(p.keys()), ["id"])
+    def test_param_without_value_preserved(self) -> None:
+        url = "http://ex.com/?debug&next=PAYLOAD&a=testing&b=testing"
+        result = minimize_nuclei_matched_at_url(url, refuzz_fn=lambda _: {"debug", "next"})
+        self.assertEqual(_raw_query(result), "debug&next=PAYLOAD")
 
-    def test_verify_fn_fails_falls_back_to_original(self) -> None:
-        """If verify_url_fn returns False (e.g. Nuclei doesn't find the vuln),
-        the original URL is returned so the PoC stays valid."""
-        url = "http://example.com/?id=testing'&required_param=abc"
-        result = minimize_nuclei_matched_at_url(
-            url,
-            fuzzing_parameter="id",
-            verify_url_fn=lambda _: False,  # simulates a broken minimized URL
-        )
-        self.assertEqual(result, url)
+    def test_original_order_preserved(self) -> None:
+        url = "http://ex.com/?zzz=PAYLOAD&aaa=PAYLOAD&mmm=testing&nnn=testing"
+        result = minimize_nuclei_matched_at_url(url, refuzz_fn=lambda _: {"aaa", "zzz"})
+        self.assertEqual(_raw_query(result), "zzz=PAYLOAD&aaa=PAYLOAD")
 
 
 if __name__ == "__main__":

--- a/test/unit/test_minimize_nuclei_matched_at_url.py
+++ b/test/unit/test_minimize_nuclei_matched_at_url.py
@@ -1,5 +1,6 @@
 import unittest
 import urllib.parse
+from typing import Callable, Set
 
 from artemis.reporting.modules.nuclei.poc_url_utils import (
     minimize_nuclei_matched_at_url,
@@ -7,22 +8,52 @@ from artemis.reporting.modules.nuclei.poc_url_utils import (
 
 
 def _param_names(url: str) -> list[str]:
-    return list(urllib.parse.parse_qs(urllib.parse.urlparse(url).query).keys())
+    return list(urllib.parse.parse_qs(urllib.parse.urlparse(url).query, keep_blank_values=True).keys())
 
 
 def _raw_query(url: str) -> str:
     return urllib.parse.urlparse(url).query
 
 
+def _confirms(*names: str) -> Callable[[str], Set[str]]:
+    """Fake refuzz_fn for a finding that each of ``names`` triggers on its own.
+
+    It only reports the names actually present in the URL it is called with,
+    so re-fuzzing the shortened URL keeps confirming the finding - the normal
+    case, where the dropped parameters were irrelevant.
+    """
+
+    def refuzz(url: str) -> Set[str]:
+        return set(names) & set(_param_names(url))
+
+    return refuzz
+
+
+def _confirms_only_with_gate(name: str, gate: str) -> Callable[[str], Set[str]]:
+    """Fake refuzz_fn for a finding that Nuclei reports against ``name``, but
+    that only reproduces while ``gate`` is also present in the URL.
+
+    This is the ``if (isset($_GET["login"])) { echo $_GET["search"]; }`` case:
+    single mode mutates ``search`` while still sending ``login``, so it reports
+    ``search`` alone - dropping ``login`` would break the PoC.
+    """
+
+    def refuzz(url: str) -> Set[str]:
+        names = set(_param_names(url))
+        return {name} if {name, gate} <= names else set()
+
+    return refuzz
+
+
 class TestMinimizeNucleiMatchedAtUrl(unittest.TestCase):
-    URL = "http://ex.com/?next=PAYLOAD&category=PAYLOAD&page=testing&view=testing&q=testing&s=testing"
+    URL = "http://example.com/?next=PAYLOAD&category=PAYLOAD&page=testing&view=testing&q=testing&s=testing"
 
     def test_multiple_confirmed_all_kept(self) -> None:
-        result = minimize_nuclei_matched_at_url(self.URL, refuzz_fn=lambda _: {"next", "category"})
+        result = minimize_nuclei_matched_at_url(self.URL, refuzz_fn=_confirms("next", "category"))
         self.assertEqual(sorted(_param_names(result)), ["category", "next"])
 
     def test_single_confirmed_only_that_one(self) -> None:
-        result = minimize_nuclei_matched_at_url(self.URL, refuzz_fn=lambda _: {"next"})
+        result = minimize_nuclei_matched_at_url(self.URL, refuzz_fn=_confirms("next"))
         self.assertEqual(_param_names(result), ["next"])
 
     def test_nothing_confirmed_falls_back_to_full(self) -> None:
@@ -34,37 +65,73 @@ class TestMinimizeNucleiMatchedAtUrl(unittest.TestCase):
         self.assertEqual(result, self.URL)
 
     def test_confirmed_name_absent_from_url_ignored(self) -> None:
-        result = minimize_nuclei_matched_at_url(self.URL, refuzz_fn=lambda _: {"next", "doesnotexist"})
+        result = minimize_nuclei_matched_at_url(self.URL, refuzz_fn=_confirms("next", "doesnotexist"))
         self.assertEqual(_param_names(result), ["next"])
 
     def test_few_params_not_minimized(self) -> None:
-        short = "http://ex.com/?a=1&b=2"
-        result = minimize_nuclei_matched_at_url(short, refuzz_fn=lambda _: {"a"})
+        short = "http://example.com/?a=1&b=2"
+        result = minimize_nuclei_matched_at_url(short, refuzz_fn=_confirms("a"))
         self.assertEqual(result, short)
 
     def test_no_query_returned_unchanged(self) -> None:
-        url = "http://ex.com/path"
-        self.assertEqual(minimize_nuclei_matched_at_url(url, refuzz_fn=lambda _: {"a"}), url)
+        url = "http://example.com/path"
+        self.assertEqual(minimize_nuclei_matched_at_url(url, refuzz_fn=_confirms("a")), url)
 
     def test_payload_preserved_byte_for_byte(self) -> None:
-        url = "http://ex.com/?url=%2F%2Fevil.example.com%2F&a=testing&b=testing"
-        result = minimize_nuclei_matched_at_url(url, refuzz_fn=lambda _: {"url"})
+        url = "http://example.com/?url=%2F%2Fevil.example.com%2F&a=testing&b=testing"
+        result = minimize_nuclei_matched_at_url(url, refuzz_fn=_confirms("url"))
         self.assertEqual(_raw_query(result), "url=%2F%2Fevil.example.com%2F")
 
     def test_equals_sign_in_value_preserved(self) -> None:
-        url = "http://ex.com/?redirect=http://evil/?a=b%26c=d&x=testing&y=testing&z=testing"
-        result = minimize_nuclei_matched_at_url(url, refuzz_fn=lambda _: {"redirect"})
+        url = "http://example.com/?redirect=http://evil/?a=b%26c=d&x=testing&y=testing&z=testing"
+        result = minimize_nuclei_matched_at_url(url, refuzz_fn=_confirms("redirect"))
         self.assertEqual(_raw_query(result), "redirect=http://evil/?a=b%26c=d")
 
     def test_param_without_value_preserved(self) -> None:
-        url = "http://ex.com/?debug&next=PAYLOAD&a=testing&b=testing"
-        result = minimize_nuclei_matched_at_url(url, refuzz_fn=lambda _: {"debug", "next"})
+        url = "http://example.com/?debug&next=PAYLOAD&a=testing&b=testing"
+        result = minimize_nuclei_matched_at_url(url, refuzz_fn=_confirms("debug", "next"))
         self.assertEqual(_raw_query(result), "debug&next=PAYLOAD")
 
     def test_original_order_preserved(self) -> None:
-        url = "http://ex.com/?zzz=PAYLOAD&aaa=PAYLOAD&mmm=testing&nnn=testing"
-        result = minimize_nuclei_matched_at_url(url, refuzz_fn=lambda _: {"aaa", "zzz"})
+        url = "http://example.com/?zzz=PAYLOAD&aaa=PAYLOAD&mmm=testing&nnn=testing"
+        result = minimize_nuclei_matched_at_url(url, refuzz_fn=_confirms("aaa", "zzz"))
         self.assertEqual(_raw_query(result), "zzz=PAYLOAD&aaa=PAYLOAD")
+
+    def test_reported_param_needing_a_gate_falls_back_to_full(self) -> None:
+        """The reported parameter is not trusted on its own: if the finding
+        stops reproducing once the other parameters are dropped, the full URL
+        is kept."""
+        url = "http://example.com/?login=testing&search=PAYLOAD&q=testing&s=testing"
+        result = minimize_nuclei_matched_at_url(url, refuzz_fn=_confirms_only_with_gate("search", "login"))
+        self.assertEqual(result, url)
+
+    def test_verification_runs_on_the_shortened_url(self) -> None:
+        """The second re-fuzz must be given the shortened URL, not the original
+        one - otherwise it would confirm the very parameters it is meant to
+        check we can drop."""
+        seen: list[str] = []
+
+        def refuzz(url: str) -> Set[str]:
+            seen.append(url)
+            return {"next"}
+
+        result = minimize_nuclei_matched_at_url(self.URL, refuzz_fn=refuzz)
+        self.assertEqual(_param_names(result), ["next"])
+        self.assertEqual(seen, [self.URL, "http://example.com/?next=PAYLOAD"])
+
+    def test_all_params_confirmed_skips_verification(self) -> None:
+        """If nothing would be dropped, the URL is returned as-is without a
+        second Nuclei run."""
+        url = "http://example.com/?a=PAYLOAD&b=PAYLOAD&c=PAYLOAD"
+        calls: list[str] = []
+
+        def refuzz(refuzzed_url: str) -> Set[str]:
+            calls.append(refuzzed_url)
+            return {"a", "b", "c"}
+
+        result = minimize_nuclei_matched_at_url(url, refuzz_fn=refuzz)
+        self.assertEqual(result, url)
+        self.assertEqual(len(calls), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What
Shorten Nuclei DAST PoC URLs by re-fuzzing confirmed findings in `-fuzzing-mode single`, keeping only the parameters that reproduce the vulnerability on their own and falling back to the full URL when single-mode confirms nothing.

## Why
DAST targets are built by stacking every parameter from all six wordlists (ssrf/redirect/lfi/cmdi/sqli/xss) onto one URL — 116 parameters. The scan runs `-fuzzing-mode multiple`, so Nuclei fuzzes all of them in a single request and the resulting `matched-at` carries the payload across many parameters at once (e.g. 51/116 for a redirect hit, the rest being scaffolding at their default values). From a multiple-mode hit there is no way to tell which parameter is actually vulnerable — that is the root cause of the very long PoC URLs. The old `minimize_nuclei_matched_at_url` relied on `fuzzing_parameter`, which multiple-mode leaves empty/ambiguous, so it never minimized and emitted the full URL.
`multiple` mode itself stays (intentional, for scan performance).

## Fix
Re-fuzz each multi-parameter finding in `-fuzzing-mode single` (one parameter per request — verified against nuclei source `pkg/fuzz/parts.go` and on a live v3.9.0 instance). Single-mode reports a non-empty `fuzzing_parameter` per hit; we collect those and keep exactly the confirmed parameters, dropping the rest.
Key design decisions (happy to discuss any of these):
- **Re-fuzz on default values, not payloads.** Injected (wordlist) parameters are reset to their family default from `DAST_SCANNING`, so Nuclei re-fuzzes from a clean base — same as the original scan — rather than re-fuzzing a value that already carries a payload. Site parameters not in any wordlist keep their `matched-at` value.
- **Payloads preserved byte-for-byte.** The query is split manually (no `parse_qs`/`urlencode` round-trip), because `%2F%2F` must not decay to `//` — an encoded-slash filter-bypass payload has to survive intact.
- **interactsh is passed to the re-fuzz** when configured, otherwise OOB findings (e.g. open-redirect via oast.me) would not reproduce in single mode.
- **The re-fuzz command mirrors the main scan's flags** (user agent, rate limit, timeout, system resolvers, response-size read) so the finding is reproduced under the same conditions the original scan ran in.
- **Fallback to the full PoC** when single confirms nothing — the PoC still works, just stays long.

## Tests
- `test_multiple_confirmed_all_kept` / `test_single_confirmed_only_that_one` — the URL is reduced to exactly the parameters single-mode confirms (one or several).
- `test_nothing_confirmed_falls_back_to_full` / `test_no_refuzz_fn_returns_full` — the fallback: an empty confirmation set (or absent re-fuzz) yields the original URL unchanged, so the PoC never breaks.
- `test_payload_preserved_byte_for_byte` / `test_equals_sign_in_value_preserved` / `test_param_without_value_preserved` / `test_original_order_preserved` — the byte-for-byte guarantee.
- `test_few_params_not_minimized` / `test_no_query_returned_unchanged` / `test_confirmed_name_absent_from_url_ignored` — edge cases.
- Manually verified single-mode against a live target: single isolates the vulnerable parameter and emits `fuzzing_parameter` correctly on v3.9.0.

## Notes / Out of scope
- **Open question for review:** combinational vulnerabilities (needing several parameters together) can't be reproduced one-at-a-time, so they hit the fallback and keep the full PoC. Rare for the reflected-XSS/open-redirect families that dominate long PoCs. I added a fallback log (without the URL) so we can measure how often this actually happens; **ablation** (greedy minimal-subset search) would handle these but at N× the nuclei cost — I'd propose deciding on it after ~1 week of observing the fallback rate rather than building it now. Open to doing it differently.
- **Command flags are currently duplicated** between `_scan` and the re-fuzz. This PR mirrors the relevant flags by hand (user agent, rate limit, timeout, resolvers, response-size); batch-only flags (rate-limit-duration, bulk-size, concurrency, stats/trace) are intentionally omitted as meaningless for a single-URL re-fuzz. The cleaner fix is a shared command-builder used by both paths so flags can't drift again — kept out of this PR to avoid refactoring the production scan path here, planned as a follow-up.
- Did **not** touch `multiple` scanning mode.
- Removed the now-dead `_verify_with_nuclei` (replaced by `_refuzz_single_with_nuclei`).