### PR TITLE
Abort admin_panel_login_bruter scan when target returns HTTP 429

### DIFF
--- a/artemis/modules/admin_panel_login_bruter.py
+++ b/artemis/modules/admin_panel_login_bruter.py
@@ -4,7 +4,7 @@ import itertools
 import os
 import random
 import urllib.parse
-from typing import IO, List, Optional, Tuple
+from typing import IO, Any, List, Optional, Tuple
 
 import requests
 from bs4 import BeautifulSoup
@@ -17,6 +17,18 @@ from artemis.config import Config
 from artemis.module_base import ArtemisBase
 from artemis.password_utils import get_passwords
 from artemis.task_utils import get_target_url
+
+
+class RateLimitedError(Exception):
+    """Raised when a target responds with HTTP 429. Rate limiting is per-host, so
+    there is no point in trying other credentials or paths — the whole scan of the
+    host is aborted."""
+
+
+def _abort_if_rate_limited(response: Any) -> None:
+    if response is not None and response.status_code == 429:
+        raise RateLimitedError()
+
 
 COMMON_USERNAMES: List[str] = ["admin"]
 
@@ -143,6 +155,8 @@ class AdminPanelLoginBruter(ArtemisBase):
                 if post_response is None:
                     continue
 
+                _abort_if_rate_limited(post_response)
+
                 if post_response.status_code in (200, 400, 401, 403, 422):
                     content_type = post_response.headers.get("Content-Type", "").lower()
                     if "application/json" in content_type:
@@ -205,6 +219,8 @@ class AdminPanelLoginBruter(ArtemisBase):
         except requests.RequestException as e:
             self.log.debug("Error during Basic auth on %s: %s", login_url, e)
             return (False, None)
+
+        _abort_if_rate_limited(response)
 
         if response is not None and response.status_code == 200:
             self.log.info("successful Basic auth on %s username=%s password=%s", login_url, username, password)
@@ -271,6 +287,7 @@ class AdminPanelLoginBruter(ArtemisBase):
 
         try:
             response = self.throttle_request(lambda: http_requests.request("get", login_url, session=session))
+            _abort_if_rate_limited(response)
             if self._is_basic_auth_challenge(response):
                 return self._try_basic_auth(session, login_url, username, password)
             if not response or response.status_code != 200:
@@ -345,6 +362,8 @@ class AdminPanelLoginBruter(ArtemisBase):
                 if post_response is None:
                     continue
 
+                _abort_if_rate_limited(post_response)
+
                 redirect_detected = self.detect_redirect(post_response, form_url)
 
                 indicators = []
@@ -386,6 +405,9 @@ class AdminPanelLoginBruter(ArtemisBase):
                         ),
                     )
 
+        except RateLimitedError:
+            # Rate limiting is per-host; propagate so scan() can abort the whole host.
+            raise
         except Exception as e:
             self.log.warning(f"Error during brute force on {login_url}: {e}")
 
@@ -395,66 +417,73 @@ class AdminPanelLoginBruter(ArtemisBase):
 
         return (login_mechanism_found, None)
 
-    def scan(self, task: Task, base_url: str, login_paths: List[str]) -> List[AdminPanelLoginBruterResult]:
+    def scan(self, task: Task, base_url: str, login_paths: List[str]) -> Tuple[List[AdminPanelLoginBruterResult], bool]:
         """
         Scans the target URL for vulnerable login paths using common credentials.
+        Returns (results, rate_limited); rate_limited is True if the target responded
+        with HTTP 429 and the scan was aborted before completing.
         """
-        results = []
+        results: List[AdminPanelLoginBruterResult] = []
         credential_pairs = set()
-        for path in login_paths:
-            num_rechecked_credentials = 0
-            credentials = list(itertools.product(COMMON_USERNAMES, get_passwords(task)))
-            credentials += COMMON_CREDENTIAL_PAIRS
-            random.shuffle(credentials)
-            for username, password in credentials:
-                login_mechanism_found, result = self.brute_force_login_path(base_url, path, username, password)
-                if result:
-                    self.log.info("Checking whether %s:%s indeed works", username, password)
-                    rechecked = True
-                    num_rechecked_credentials += 1
-                    if (
-                        num_rechecked_credentials
-                        > Config.Modules.AdminPanelLoginBruter.ADMIN_PANEL_LOGIN_BRUTER_MAX_RECHECKS_PER_PATH
-                    ):
-                        self.log.info(
-                            "Reached maximum number of rechecks (%d), skipping further rechecks to prevent spending too much time on this path",
-                            Config.Modules.AdminPanelLoginBruter.ADMIN_PANEL_LOGIN_BRUTER_MAX_RECHECKS_PER_PATH,
-                        )
-                        break
-
-                    for _ in range(Config.Modules.AdminPanelLoginBruter.ADMIN_PANEL_LOGIN_BRUTER_NUM_RECHECKS):
-                        _, result_good_password = self.brute_force_login_path(base_url, path, username, password)
-                        # We also try the random password, to make sure we don't "log in" with that password - if we do, that is a false
-                        # positive.
-                        has_login_mechanism_fake_password, result_fake_password = self.brute_force_login_path(
-                            base_url,
-                            path,
-                            "this-username-should-not-exist",
-                            binascii.hexlify(os.urandom(16)).decode("ascii"),
-                        )
-
-                        if not (
-                            result_good_password and has_login_mechanism_fake_password and not result_fake_password
+        rate_limited = False
+        try:
+            for path in login_paths:
+                num_rechecked_credentials = 0
+                credentials = list(itertools.product(COMMON_USERNAMES, get_passwords(task)))
+                credentials += COMMON_CREDENTIAL_PAIRS
+                random.shuffle(credentials)
+                for username, password in credentials:
+                    login_mechanism_found, result = self.brute_force_login_path(base_url, path, username, password)
+                    if result:
+                        self.log.info("Checking whether %s:%s indeed works", username, password)
+                        rechecked = True
+                        num_rechecked_credentials += 1
+                        if (
+                            num_rechecked_credentials
+                            > Config.Modules.AdminPanelLoginBruter.ADMIN_PANEL_LOGIN_BRUTER_MAX_RECHECKS_PER_PATH
                         ):
-                            rechecked = False
+                            self.log.info(
+                                "Reached maximum number of rechecks (%d), skipping further rechecks to prevent spending too much time on this path",
+                                Config.Modules.AdminPanelLoginBruter.ADMIN_PANEL_LOGIN_BRUTER_MAX_RECHECKS_PER_PATH,
+                            )
                             break
 
-                    if rechecked:
-                        results.append(result)
-                        credential_pairs.add((username, password))
-                        self.log.info("rechecked - works!")
-                    else:
-                        self.log.info("rechecked - doesn't work")
+                        for _ in range(Config.Modules.AdminPanelLoginBruter.ADMIN_PANEL_LOGIN_BRUTER_NUM_RECHECKS):
+                            _, result_good_password = self.brute_force_login_path(base_url, path, username, password)
+                            # We also try the random password, to make sure we don't "log in" with that password - if we do, that is a false
+                            # positive.
+                            has_login_mechanism_fake_password, result_fake_password = self.brute_force_login_path(
+                                base_url,
+                                path,
+                                "this-username-should-not-exist",
+                                binascii.hexlify(os.urandom(16)).decode("ascii"),
+                            )
 
-                if not login_mechanism_found:  # not worth trying all other credential pairs
-                    break
+                            if not (
+                                result_good_password and has_login_mechanism_fake_password and not result_fake_password
+                            ):
+                                rechecked = False
+                                break
+
+                        if rechecked:
+                            results.append(result)
+                            credential_pairs.add((username, password))
+                            self.log.info("rechecked - works!")
+                        else:
+                            self.log.info("rechecked - doesn't work")
+
+                    if not login_mechanism_found:  # not worth trying all other credential pairs
+                        break
+        except RateLimitedError:
+            rate_limited = True
+            self.log.info("Aborting scan of %s: target is rate-limiting (HTTP 429)", base_url)
 
         if len(credential_pairs) > 1:
             # More than one successful working credential pair is most probably a FP. We do
             # accept working credentials on different paths though.
             results = []
 
-        return results
+        return results, rate_limited
 
     def run(self, current_task: Task) -> None:
         url = get_target_url(current_task)
@@ -467,13 +496,18 @@ class AdminPanelLoginBruter(ArtemisBase):
 
         random.shuffle(login_paths)
 
-        results = self.scan(current_task, url, login_paths)
+        results, rate_limited = self.scan(current_task, url, login_paths)
 
         if results:
             status = TaskStatus.INTERESTING
             status_reason = "Found weak credentials on admin panel(s): " + ", ".join(
                 [f"{result.username}:{result.password} at {result.url}" for result in results]
             )
+            if rate_limited:
+                status_reason += " (scan aborted early: target rate-limited, HTTP 429)"
+        elif rate_limited:
+            status = TaskStatus.OK
+            status_reason = "Scan aborted: target rate-limited (HTTP 429); results may be incomplete"
         else:
             status = TaskStatus.OK
             status_reason = None

--- a/artemis/modules/admin_panel_login_bruter.py
+++ b/artemis/modules/admin_panel_login_bruter.py
@@ -87,7 +87,7 @@ with open(
     COMMON_CREDENTIAL_PAIRS = read_credential_pairs(f)
 
 # JSON-only API login endpoints that do not respond to GET with 200 (POST-only).
-# These are always tried regardless of discovery, because check_url(GET) would fail.
+# These are always tried regardless of discovery, because _is_login_path(GET) would fail.
 JSON_API_PATHS = [
     "/api/login",  # Grafana
     "/api/auth",  # Portainer and other tools
@@ -118,11 +118,12 @@ class AdminPanelLoginBruter(ArtemisBase):
             return False
         return response.headers.get("WWW-Authenticate", "").lower().startswith("basic")
 
-    def check_url(self, url: str) -> bool:
+    def _is_login_path(self, url: str) -> bool:
         try:
             response = http_requests.get(url)
             if not response:
                 return False
+            _abort_if_rate_limited(response)
             if response.status_code == 200:
                 return True
             return self._is_basic_auth_challenge(response)
@@ -243,7 +244,7 @@ class AdminPanelLoginBruter(ArtemisBase):
         found_paths = []
         for path in COMMON_LOGIN_PATHS:
             full_url = urllib.parse.urljoin(base_url, path)
-            if self.check_url(full_url):
+            if self._is_login_path(full_url):
                 self.log.info("Discovered login path: %s", full_url)
                 found_paths.append(path)
         return found_paths
@@ -487,16 +488,24 @@ class AdminPanelLoginBruter(ArtemisBase):
 
     def run(self, current_task: Task) -> None:
         url = get_target_url(current_task)
-        login_paths = self.discover_login_paths(url)
+        results: List[AdminPanelLoginBruterResult] = []
+        rate_limited = False
+        try:
+            login_paths = self.discover_login_paths(url)
 
-        # Always include known JSON-only API paths that won't pass the GET check.
-        for path in JSON_API_PATHS:
-            if path not in login_paths:
-                login_paths.append(path)
+            # Always include known JSON-only API paths that won't pass the GET check.
+            for path in JSON_API_PATHS:
+                if path not in login_paths:
+                    login_paths.append(path)
 
-        random.shuffle(login_paths)
+            random.shuffle(login_paths)
 
-        results, rate_limited = self.scan(current_task, url, login_paths)
+            results, rate_limited = self.scan(current_task, url, login_paths)
+        except RateLimitedError:
+            # 429 during discovery (before scan() runs). scan() catches 429 raised
+            # during brute forcing itself, so this only fires in the discovery phase.
+            rate_limited = True
+            self.log.info("Aborting scan of %s during discovery: target is rate-limiting (HTTP 429)", url)
 
         if results:
             status = TaskStatus.INTERESTING

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -183,6 +183,11 @@ services:
     volumes:
       - ./test/data/php_rate_limited/:/var/www/html/
 
+  test-php-rate-limited-discovery:
+    image: php:8.0-apache
+    volumes:
+      - ./test/data/php_rate_limited_discovery/:/var/www/html/
+
   test-php-403-bypass:
     image: php:8.0-apache
     volumes:

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -178,6 +178,11 @@ services:
         aliases:
           - test-php-mock-CVE-2020-28976.local
 
+  test-php-rate-limited:
+    image: php:8.0-apache
+    volumes:
+      - ./test/data/php_rate_limited/:/var/www/html/
+
   test-php-403-bypass:
     image: php:8.0-apache
     volumes:

--- a/test/data/php_rate_limited/index.php
+++ b/test/data/php_rate_limited/index.php
@@ -1,0 +1,26 @@
+<?php
+// A target that serves the login page normally (GET 200) but rate-limits every
+// login attempt (POST 429). Used to verify the scan aborts the whole host on 429.
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    http_response_code(429);
+    header('Retry-After: 60');
+    echo 'Too Many Requests';
+    exit();
+}
+?>
+
+<!DOCTYPE html>
+<html>
+<body>
+    <div class="login-box">
+        <h2>Login</h2>
+        <form method="POST" action="/index.php">
+            <label>Username</label><br>
+            <input type="text" name="username" required><br>
+            <label>Password</label><br>
+            <input type="password" name="password" required><br>
+            <button type="submit">Login</button>
+        </form>
+    </div>
+</body>
+</html>

--- a/test/data/php_rate_limited_discovery/index.php
+++ b/test/data/php_rate_limited_discovery/index.php
@@ -1,0 +1,7 @@
+<?php
+// A target that rate-limits every request, including the GET requests made during
+// path discovery. Used to verify the scan aborts cleanly when 429 is hit before
+// the brute-force phase even starts.
+http_response_code(429);
+header('Retry-After: 60');
+echo 'Too Many Requests';

--- a/test/modules/test_admin_panel_login_bruter.py
+++ b/test/modules/test_admin_panel_login_bruter.py
@@ -185,3 +185,22 @@ class AdminPanelLoginBruterTest(ArtemisModuleTestCase):
         self.assertEqual(call.kwargs["status"], TaskStatus.OK)
         self.assertIn("429", call.kwargs["status_reason"])
         self.assertEqual(call.kwargs["data"]["results"], [])
+
+    def test_rate_limited_during_discovery_aborts(self) -> None:
+        """A target that returns HTTP 429 already during path discovery (on the GET
+        requests, before brute forcing starts) aborts cleanly: the RateLimitedError
+        must be caught in run(), giving status OK with a rate-limit reason and no
+        results, rather than crashing the module."""
+        task = Task(
+            {"type": TaskType.SERVICE.value, "service": Service.HTTP.value},
+            payload={
+                "host": "test-php-rate-limited-discovery",
+                "port": 80,
+            },
+        )
+
+        self.run_task(task)
+        (call,) = self.mock_db.save_task_result.call_args_list
+        self.assertEqual(call.kwargs["status"], TaskStatus.OK)
+        self.assertIn("429", call.kwargs["status_reason"])
+        self.assertEqual(call.kwargs["data"]["results"], [])

--- a/test/modules/test_admin_panel_login_bruter.py
+++ b/test/modules/test_admin_panel_login_bruter.py
@@ -167,3 +167,21 @@ class AdminPanelLoginBruterTest(ArtemisModuleTestCase):
         self.assertEqual(
             call.kwargs["data"]["results"][0]["indicators"], ["redirect", "logout_link", "no_failure_messages"]
         )
+
+    def test_rate_limited_aborts_scan(self) -> None:
+        """A target that answers login attempts with HTTP 429 aborts the whole-host
+        scan: the status is OK (not INTERESTING), the reason mentions rate limiting,
+        and no credentials are reported."""
+        task = Task(
+            {"type": TaskType.SERVICE.value, "service": Service.HTTP.value},
+            payload={
+                "host": "test-php-rate-limited",
+                "port": 80,
+            },
+        )
+
+        self.run_task(task)
+        (call,) = self.mock_db.save_task_result.call_args_list
+        self.assertEqual(call.kwargs["status"], TaskStatus.OK)
+        self.assertIn("429", call.kwargs["status_reason"])
+        self.assertEqual(call.kwargs["data"]["results"], [])


### PR DESCRIPTION
## What

Abort the whole-host scan when a target responds with HTTP 429, instead of continuing to send login attempts to a host that is already rate-limiting.

## Why

`admin_panel_login_bruter` tries every credential pair against every discovered path with no reaction to rate limiting. Against real infrastructure, once a target starts returning 429 the module keeps hammering it — which can lock out real accounts, deepen the rate limit, or trip an incident on the scanned host. Root cause: none of the request sites inspected the status for 429, and there was no way for a "stop" signal to propagate out of the nested credential loops. There is no global handling to reuse either — `throttle_request` is a fixed-rate pacer and the `module_base` retry catches Karton task errors, not HTTP status codes — so this is introduced here.

## Fix

`_abort_if_rate_limited(response)` raises a `RateLimitedError` at every site where a 429 can come back — the brute-force requests (JSON-API POST, Basic-auth GET, main GET, form POST) and path discovery (`_is_login_path`, renamed from `check_url`). It propagates through `brute_force_login_path` — with an explicit `except RateLimitedError: raise` guard so the existing broad `except Exception` does not swallow it — up to `scan`, which catches it, stops, and returns `(results, rate_limited)`. Discovery runs before `scan`, so `run` wraps discovery + scan in the same handler and a 429 during discovery aborts cleanly there too. `run` then reports OK with a "rate-limited (HTTP 429)" reason when nothing was found, or INTERESTING with a note that the scan was cut short if credentials were found before the 429.

Key design decisions:
- **Abort the whole host, not just the path.** Rate limiting is per-host, so moving on to other paths would only make it worse.
- **Do not honor Retry-After.** For a mass scanner, sleeping on one host blocks a worker; aborting the host is cheaper and still respects the target's signal.
- **429 only** — an unambiguous status code, no phrase matching.

## Tests

- `test_rate_limited_aborts_scan` — verifies a target that serves the login page (GET 200) but returns 429 on every login attempt (POST) ends as OK, with a rate-limit reason and no reported credentials.
- `test_rate_limited_during_discovery_aborts` — verifies a target that returns 429 already during path discovery aborts cleanly (caught in `run`, no crash), also ending as OK with a rate-limit reason.
- The rest of the module suite (basic-auth, JSON API, redirect, simple, both vendor-pair tests, both email-field tests) stays green, confirming the abort path does not change behavior when no 429 is present.

## Notes / Out of scope

- Follow-up (not here): lockout-phrase detection (e.g. "account locked", "too many attempts") on 401/403. That needs a language-fragile phrase list like `common_failure_messages` plus its own tuning, so it is deliberately deferred; this PR covers only the unambiguous 429 signal.
- No change to the credential set, the HTTP layer, or throttling.