### PR TITLE
Reuse a single SSL context and stream bruter responses

### DIFF
--- a/artemis/http_requests.py
+++ b/artemis/http_requests.py
@@ -1,5 +1,6 @@
 import copy
 import dataclasses
+import functools
 import json
 import os
 import ssl
@@ -18,16 +19,24 @@ LOGGER = build_logger(__name__)
 # As our goal in Artemis is to access the sites in order to test their security, let's
 # enable SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION in order to make a connection even if it's
 # not secure.
+#
+# Building the SSL context loads and parses the whole system CA bundle and the result is
+# identical for every request. We therefore build it once at import time instead of on
+# every mount() - in modules that make thousands of requests this otherwise burns a lot
+# of CPU re-parsing the same certificates.
+SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION = 1 << 18
+
+_SSL_CONTEXT = ssl.create_default_context()
+_SSL_CONTEXT.check_hostname = False
+_SSL_CONTEXT.options |= SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION
+# Shared across all sessions and threads - treat as read-only after this point.
+# Never mutate it per-request (e.g. load_verify_locations / set_ciphers), or the
+# change would leak into every other caller.
+
+
 class SSLContextAdapter(requests.adapters.HTTPAdapter):
     def init_poolmanager(self, *args, **kwargs):  # type: ignore
-        context = ssl.create_default_context()
-
-        SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION = 1 << 18
-
-        context.check_hostname = False
-        context.options |= SSL_OP_ALLOW_UNSAFE_LEGACY_RENEGOTIATION
-
-        kwargs["ssl_context"] = context
+        kwargs["ssl_context"] = _SSL_CONTEXT
         return super().init_poolmanager(*args, **kwargs)  # type: ignore
 
 
@@ -58,8 +67,10 @@ class HTTPResponse:
     def text(self) -> str:
         return self.content
 
-    @property
+    @functools.cached_property
     def content(self) -> str:
+        # Computed once per response and cached: callers read .content several times
+        # and re-decoding the content bytes on each access is pure waste.
         if self.encoding and self.encoding != "binary":
             return self.content_bytes.decode(self.encoding, errors="ignore")
         else:
@@ -94,7 +105,11 @@ def request(
             session = requests.Session()
         url_parsed = urllib.parse.urlparse(url)
         if url_parsed.scheme.lower() == "https":
-            session.mount(url, SSLContextAdapter())
+            # Mount once per session (keyed by the "https://" prefix). This previously ran on
+            # every request, rebuilding the adapter - and the SSL context - each time, which
+            # defeated connection reuse for callers that pass a shared session.
+            if not isinstance(session.adapters.get("https://"), SSLContextAdapter):
+                session.mount("https://", SSLContextAdapter())
 
         if url_parsed.username or url_parsed.password:
             LOGGER.debug(

--- a/artemis/modules/bruter.py
+++ b/artemis/modules/bruter.py
@@ -83,41 +83,43 @@ class Bruter(ArtemisBase):
 
         self.log.info(f"bruter scanning {base_url}: {len(FILENAMES_TO_SCAN)} paths to scan")
 
-        results = {}
-        for i, url in enumerate(FILENAMES_TO_SCAN):
-            self.log.info(f"bruter url {i}/{len(FILENAMES_TO_SCAN)}: {url}")
-            try:
-                full_url = base_url + "/" + url
-                results[full_url] = self.http_get(
-                    full_url, allow_redirects=Config.Modules.Bruter.BRUTER_FOLLOW_REDIRECTS
-                )
-            except Exception:
-                self.log.warning("Failed to scan URL %s", full_url)
-
-        self.log.info("bruter finished")
         # For downloading URLs, we don't use an existing tool (such as e.g. dirbuster or gobuster) as we
         # need to have a custom logic to filter custom 404 pages and if we used a separate tool, we would
         # not have access to response contents here.
-
+        #
+        # We filter each response inline instead of collecting them all first: keeping every response in
+        # memory used gigabytes of RAM on the full list, while only the handful of matching URLs is needed.
+        # Iterating a sorted list keeps the output order that sorted(results.items()) produced before.
         found_urls = []
-        for response_url, response in sorted(results.items()):
+        for i, url in enumerate(sorted(FILENAMES_TO_SCAN)):
+            self.log.info(f"bruter url {i}/{len(FILENAMES_TO_SCAN)}: {url}")
+            full_url = base_url + "/" + url
+            try:
+                response = self.http_get(full_url, allow_redirects=Config.Modules.Bruter.BRUTER_FOLLOW_REDIRECTS)
+            except Exception:
+                self.log.warning("Failed to scan URL %s", full_url)
+                continue
+
             if response.status_code != 200:
                 continue
 
+            content = response.content
             filtered_content = (
-                "Error 403" in response.content
-                or response.content.strip() in IGNORED_CONTENTS
-                or SequenceMatcher(None, response.content, dummy_content).quick_ratio() >= 0.8
+                "Error 403" in content
+                or content.strip() in IGNORED_CONTENTS
+                or SequenceMatcher(None, content, dummy_content).quick_ratio() >= 0.8
             )
 
             if not filtered_content:
                 found_urls.append(
                     FoundURL(
-                        url=response_url,
-                        content_prefix=response.content[: Config.Miscellaneous.CONTENT_PREFIX_SIZE],
-                        has_directory_index=is_directory_index(response.content),
+                        url=full_url,
+                        content_prefix=content[: Config.Miscellaneous.CONTENT_PREFIX_SIZE],
+                        has_directory_index=is_directory_index(content),
                     )
                 )
+
+        self.log.info("bruter finished")
 
         if len(found_urls) > len(FILENAMES_TO_SCAN) * Config.Modules.Bruter.BRUTER_FALSE_POSITIVE_THRESHOLD:
             return BruterResult(

--- a/test/modules/test_http_requests.py
+++ b/test/modules/test_http_requests.py
@@ -1,0 +1,46 @@
+import unittest
+
+import requests
+
+from artemis import http_requests
+
+# The nginx-with-sni-tls test service listens on 443, requires the correct SNI
+# (it rejects the handshake otherwise) and serves a self-signed certificate. It is
+# the only test target that lets us exercise the real TLS path through
+# SSLContextAdapter, which the rest of the module suite (HTTP-only targets) does not.
+TLS_URL = "https://test-nginx-with-sni-tls/"
+EXPECTED_BODY = "TLS with correct SNI works\n"
+
+
+class HTTPRequestsTLSTestCase(unittest.TestCase):
+    def test_https_request_succeeds(self) -> None:
+        # A real TLS handshake with the correct SNI must still succeed after the SSL
+        # context started being shared across requests instead of rebuilt each time.
+        response = http_requests.get(TLS_URL, requests_per_second=0)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, EXPECTED_BODY)
+
+    def test_ssl_adapter_is_mounted_once_per_session(self) -> None:
+        # The adapter must be mounted once per session (keyed by the scheme), not on
+        # every request. Three requests on a shared session must all succeed, the
+        # https:// adapter must be our SSLContextAdapter, and the adapter dict must not
+        # accumulate per-URL entries the way the previous session.mount(url, ...) did.
+        session = requests.Session()
+        statuses = [
+            http_requests.request("get", TLS_URL, session=session, requests_per_second=0).status_code for _ in range(3)
+        ]
+        self.assertEqual(statuses, [200, 200, 200])
+        self.assertIsInstance(session.adapters.get("https://"), http_requests.SSLContextAdapter)
+        self.assertEqual(set(session.adapters), {"http://", "https://"})
+
+    def test_content_is_cached(self) -> None:
+        # HTTPResponse.content is a cached_property: decoded once on first access and
+        # reused afterwards (callers such as bruter's filter read it several times).
+        response = http_requests.get(TLS_URL, requests_per_second=0)
+        self.assertNotIn("content", response.__dict__)
+        _ = response.content
+        self.assertIn("content", response.__dict__)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Two related HTTP hot-path fixes:

1. **Reuse a single SSL context.** `SSLContextAdapter.init_poolmanager` called
   `ssl.create_default_context()` on every HTTPS request, re-parsing the whole
   system CA bundle and the adapter was re-mounted on every request even when
   a session was passed for reuse. The context is now built once at import and
   the adapter is mounted once per session (by the `https://` prefix).
   `HTTPResponse.content` is now a `cached_property` so callers that read it
   several times don't re-decode.

2. **Stream bruter responses.** `Bruter.scan` kept every response for the full
   path list in a dict before filtering. It now filters each response inline and
   keeps only matching `FoundURL`s, iterating a sorted list to preserve the
   previous output order.

## Why

In production `docker stats`, `bruter` spikes to the top of the fleet on CPU under
load despite doing the simplest work. Profiling `http_requests.get` with `cProfile` 
attributed **a lot of CPU to `set_default_verify_paths`** — i.e. rebuilding the SSL
context per request.

## Evidence

- Same 300-request loop: **4.12 s → 0.22 s**; `create_default_context` calls
  **300 → 0** (isolated cProfile — attribution of the request-setup path, not a
  promise of the exact production drop).
- New `test/modules/test_http_requests.py` exercises the real TLS path against
  `test-nginx-with-sni-tls` (correct SNI, session reuse, content caching) — the
  first test to cover the SSL path. It passes on this change and fails on the
  previous code (2 assertions), so it guards the behaviour.
- `test_bruter` and the other HTTP module tests pass unchanged.

## Not covered here

Production confirmation (py-spy on the live bruter + before/after `docker stats`)
is a follow-up after deploy.