### PR TITLE
Add more common admin panel login paths to admin_panel_login_bruter

### DIFF
--- a/artemis/modules/data/admin_panel_login_bruter/common_login_paths.txt
+++ b/artemis/modules/data/admin_panel_login_bruter/common_login_paths.txt
@@ -60,3 +60,17 @@
 /api/auth
 # Traefik dashboard
 /dashboard/
+# Apache Tomcat Manager (HTTP Basic auth)
+/manager/html
+/host-manager/html
+# Oracle WebLogic Server admin console
+/console/
+# Adminer (single-file database manager)
+/adminer.php
+/adminer/
+# Cacti
+/cacti/
+# Nagios (HTTP Basic auth)
+/nagios/
+# pgAdmin 4
+/pgadmin4/


### PR DESCRIPTION
Adds a few widely-exposed admin panel paths that `admin_panel_login_bruter` doesn't currently probe:

- `/manager/html`, `/host-manager/html` — Apache Tomcat Manager / Host Manager (HTTP Basic auth)
- `/console/` — Oracle WebLogic Server admin console
- `/adminer.php`, `/adminer/` — Adminer (single-file database manager)
- `/cacti/` — Cacti
- `/nagios/` — Nagios (HTTP Basic auth)
- `/pgadmin4/` — pgAdmin 4