### PR TITLE
Log targets that hit context deadline exceeded in nuclei

### DIFF
--- a/artemis/modules/nuclei.py
+++ b/artemis/modules/nuclei.py
@@ -459,6 +459,7 @@ class Nuclei(ArtemisBase):
         ]
 
         error_counts: Dict[str, int] = collections.defaultdict(int)
+        context_deadline_exceeded_targets: Dict[str, int] = collections.defaultdict(int)
         for line in lines:
             if not line.startswith("{"):
                 continue
@@ -476,6 +477,21 @@ class Nuclei(ArtemisBase):
                     break
             error_counts[category] += 1
 
+            if "context deadline exceeded" in error:
+                # Aggregate per target, not per template path. A single unreachable or slow
+                # target times out for every template path it's hit with, so the actionable
+                # signal - and the value the eventual re-run would pass back to Nuclei via
+                # `-target` - is the target, not the path. `input` carries the requested
+                # host:port (matching `-target`); `address` is the resolved IP and is used only
+                # as a fallback when `input` is absent.
+                page = entry.get("input")
+                if page:
+                    target = urllib.parse.urlparse(page).netloc or page
+                else:
+                    target = entry.get("address")
+                if target:
+                    context_deadline_exceeded_targets[target] += 1
+
         if not error_counts:
             return
 
@@ -483,6 +499,13 @@ class Nuclei(ArtemisBase):
             "Nuclei request error summary: %s",
             dict(error_counts),
         )
+
+        if context_deadline_exceeded_targets:
+            self.log.info(
+                "Targets that caused 'context deadline exceeded': %d distinct target(s): %s",
+                len(context_deadline_exceeded_targets),
+                dict(context_deadline_exceeded_targets),
+            )
 
     def _scan(
         self,

--- a/test/unit/test_nuclei_error_summary.py
+++ b/test/unit/test_nuclei_error_summary.py
@@ -1,0 +1,121 @@
+import json
+import unittest
+from typing import Any
+
+from artemis.modules.nuclei import Nuclei
+
+
+class _CapturingLog:
+    """Minimal stand-in for self.log that records info calls."""
+
+    def __init__(self) -> None:
+        self.info_calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    def info(self, fmt: str, *args: Any) -> None:
+        self.info_calls.append((fmt, args))
+
+    def messages(self) -> list[str]:
+        """The format strings of every logged message."""
+        return [fmt for fmt, _ in self.info_calls]
+
+    def args_for(self, prefix: str) -> tuple[Any, ...] | None:
+        """Return the args tuple of the first message starting with prefix, or None."""
+        for fmt, args in self.info_calls:
+            if fmt.startswith(prefix):
+                return args
+        return None
+
+    def payload_for(self, prefix: str) -> Any:
+        """The last arg (the aggregated dict) of the message starting with prefix, or None."""
+        args = self.args_for(prefix)
+        return args[-1] if args else None
+
+
+class _StubNuclei:
+    """Carries just the log attribute the method under test needs."""
+
+    def __init__(self) -> None:
+        self.log = _CapturingLog()
+
+
+def _deadline_error() -> str:
+    return 'cause="context deadline exceeded (Client.Timeout exceeded while awaiting headers)"'
+
+
+def _run(lines: list[str]) -> _CapturingLog:
+    stub = _StubNuclei()
+    # Call unbound so we don't trigger the heavy Nuclei.__init__.
+    Nuclei._log_nuclei_error_summary(stub, lines)  # type: ignore[arg-type]
+    return stub.log
+
+
+class TestLogNucleiErrorSummary(unittest.TestCase):
+    def test_collapses_template_paths_of_one_target(self) -> None:
+        # Three different template paths on the same target must aggregate to one entry -
+        # the target, not the path, is what's actionable and what a re-run passes to -target.
+        lines = [
+            json.dumps({"input": "https://10.255.255.1:443/backend/", "error": _deadline_error()}),
+            json.dumps({"input": "https://10.255.255.1:443/XUI", "error": _deadline_error()}),
+            json.dumps({"input": "https://10.255.255.1:443/opensso/UI/Login", "error": _deadline_error()}),
+            # A plaintext [WRN] line and a truncated JSON line must both be skipped
+            # (continue / json.JSONDecodeError) without breaking aggregation.
+            '[WRN] [openam-panel] Could not execute request: cause="context deadline exceeded"',
+            '{"input": "https://10.255.255.1:443/broken", "error":',
+        ]
+
+        args = _run(lines).args_for("Targets that caused")
+        assert args is not None
+        distinct_count, targets = args
+
+        self.assertEqual(targets, {"10.255.255.1:443": 3})
+        self.assertEqual(distinct_count, 1)
+
+    def test_logs_distinct_target_count(self) -> None:
+        # The explicit distinct-target count is the number that answers "does the slow chunk
+        # time out on a few targets or most of them" - assert it's logged, not eyeballed.
+        lines = [
+            json.dumps({"input": "https://10.255.255.1:443/a", "error": _deadline_error()}),
+            json.dumps({"input": "https://10.255.255.1:443/b", "error": _deadline_error()}),
+            json.dumps({"input": "https://10.255.255.2:443/a", "error": _deadline_error()}),
+            json.dumps({"input": "https://example.com:443/a", "error": _deadline_error()}),
+        ]
+
+        args = _run(lines).args_for("Targets that caused")
+        assert args is not None
+        distinct_count, targets = args
+
+        self.assertEqual(
+            targets,
+            {"10.255.255.1:443": 2, "10.255.255.2:443": 1, "example.com:443": 1},
+        )
+        self.assertEqual(distinct_count, 3)
+
+    def test_falls_back_to_address_when_no_input(self) -> None:
+        # `address` (resolved IP:port) is only used when `input` is absent, e.g. low-level
+        # errors that never reached the request-building stage.
+        lines = [json.dumps({"address": "10.255.255.1:443", "error": _deadline_error()})]
+
+        args = _run(lines).args_for("Targets that caused")
+        assert args is not None
+        distinct_count, targets = args
+
+        self.assertEqual(targets, {"10.255.255.1:443": 1})
+        self.assertEqual(distinct_count, 1)
+
+    def test_no_deadline_errors_does_not_log_targets(self) -> None:
+        lines = [
+            json.dumps({"input": "https://10.255.255.1:443/", "error": 'cause="connect: connection refused"'}),
+            json.dumps({"input": "https://10.255.255.1:443/ok", "error": "none"}),
+        ]
+
+        log = _run(lines)
+
+        # Robust against a reworded message: assert no logged line is about deadline
+        # targets at all, rather than relying on one exact prefix.
+        for message in log.messages():
+            self.assertNotIn("deadline", message.lower())
+            self.assertNotIn("Targets that caused", message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Nuclei's request-error logging now reports **which targets** hit `context deadline exceeded`, aggregated per target with an explicit distinct-target count — not just the aggregate per-category counts it logged before.

## Why

When a scan is dominated by timeouts, the old log only said *how many* `context deadline exceeded` errors happened (`Nuclei request error summary: {context_deadline_exceeded: 214, ...}`) — never *on what*. So the operator's first question — "OK, but which target is timing out?" — was unanswerable from the logs.

Root cause of that blind spot: the data was already there and being thrown away. Nuclei runs with `-trace-log /dev/stderr`, and `_log_nuclei_error_summary` already iterates every trace line and JSON-parses it to bucket errors by category. Each of those lines also carries the `input` (requested URL) and `address` (resolved IP:port) — but the method read only the `error` field and discarded the rest. We were one field-read away from the answer and not taking it.

## Fix

For every trace line whose error contains `context deadline exceeded`, aggregate a per-target counter, then log it with the number of distinct targets:

```
Targets that caused 'context deadline exceeded': 3 distinct target(s): {'10.255.255.1:443': 210, ...}
```
(illustrative example, not a real finding)

Key design decisions:

- **Aggregate per target, not per template path.** A single unreachable/slow target times out for *every* template path it's hit with, so keying on the full `input` URL would produce hundreds of `host/some-path: 1` rows — noise exactly when the log is most needed. The target is the actionable unit, and it's the granularity a re-run would consume via `-target`.
- **Key on `urlparse(input).netloc`, fall back to `address`.** `input` carries the *requested* host:port (what went into `-target`); `address` is the *resolved* IP and would be useless for mapping a hostname target back to its `-target` string. `address` is used only when `input` is absent (low-level errors that never reached request building).
- **Log the distinct-target count explicitly.** That's the number that decides whether a slow chunk timed out on a few targets or most of them — worth stating outright, not leaving to be eyeballed across 40 rows.

No new parsing and no new I/O: this rides entirely on the trace lines the method already reads. The category summary stays as the header line; the deadline detail follows it.

## Tests

`test/unit/test_nuclei_error_summary.py` (pure unit — calls the method unbound with a stub `self`, no Docker/network):

- `test_collapses_template_paths_of_one_target` — three different template paths on one target aggregate to a single `{host:port: 3}` entry, and non-JSON / truncated-JSON lines are skipped without breaking aggregation.
- `test_logs_distinct_target_count` — mixed IPs and a hostname across 3 targets yields the correct per-target dict *and* a distinct count of 3.
- `test_falls_back_to_address_when_no_input` — a line with `address` but no `input` keys on `address`.
- `test_no_deadline_errors_does_not_log_targets` — non-deadline errors emit no target log at all (assertion is reword-robust: no message mentions "deadline").

## Notes / Out of scope

- **Attribution only.** This makes the timing-out targets *visible*; it does not yet feed them into any re-run/backoff logic. That consumer is the intended follow-up, and the per-target (rather than per-path) granularity was chosen specifically so it can be consumed via `-target` when it lands.
- **Untouched on purpose:** the existing retry-with-longer-timeout loop, the `NUCLEI_ERROR_CATEGORIES` list, and the requests-per-second stats logging — this PR only adds a second, more specific line to the same summary step.
- Lives in `test/unit/` (like the other pure nuclei tests, e.g. `test_minimize_nuclei_matched_at_url.py`), not `test/modules/`, since it needs no live services.
