### PR TITLE
Add CPE information to detected web technologies

### DIFF
--- a/artemis/modules/nuclei_router.py
+++ b/artemis/modules/nuclei_router.py
@@ -78,7 +78,7 @@ class NucleiRouter(ArtemisBase):
         if current_task.headers.get("receiver", None) == "nuclei":
             current_task.headers["receiver"] = "nuclei-router"
             current_task.headers["original_receiver"] = "nuclei"
-        self.db.save_task_result(
+        self.save_task_result(
             task=current_task,
             status=TaskStatus.OK,
             data={

--- a/artemis/modules/nuclei_router.py
+++ b/artemis/modules/nuclei_router.py
@@ -7,7 +7,7 @@ from artemis import load_risk_class
 from artemis.binds import Service, TaskStatus, TaskType
 from artemis.module_base import ArtemisBase
 from artemis.task_utils import get_target_host, get_target_url
-from artemis.web_technology_identification import run_tech_detection
+from artemis.web_technology_identification import run_tech_detection, to_tag_strings
 
 TECHNOLOGY_DETECTION_TAGS_TO_EXCLUDE = {"wordpress": ["wordpress"]}
 NUCLEI_ROUTER_FLAGS_PAYLOAD_KEY = "nuclei-routing-additional-flags"
@@ -32,7 +32,7 @@ class NucleiRouter(ArtemisBase):
     def get_missing_tech(self, target: str) -> set[str]:
         technology_tags = run_tech_detection([target], self.log)
 
-        detected_techs_set = {tech.lower() for tech in technology_tags.get(target, [])}
+        detected_techs_set = {tag.lower() for tag in to_tag_strings(technology_tags.get(target, []))}
         known_detected_techs = set()
         for tech in self.known_techs_to_exclude:
             if any(tech in detected_tech for detected_tech in detected_techs_set):
@@ -78,7 +78,7 @@ class NucleiRouter(ArtemisBase):
         if current_task.headers.get("receiver", None) == "nuclei":
             current_task.headers["receiver"] = "nuclei-router"
             current_task.headers["original_receiver"] = "nuclei"
-        self.save_task_result(
+        self.db.save_task_result(
             task=current_task,
             status=TaskStatus.OK,
             data={

--- a/artemis/modules/utils/wappalyzer/main.go
+++ b/artemis/modules/utils/wappalyzer/main.go
@@ -27,8 +27,14 @@ var client = &http.Client{
 	},
 }
 
-func scan(url string, wappalyzerClient *wappalyzer.Wappalyze) map[string][]string {
-	result := make(map[string][]string)
+type TechInfo struct {
+	Name       string   `json:"name"`
+	CPE        string   `json:"cpe"`
+	Categories []string `json:"categories"`
+}
+
+func scan(url string, wappalyzerClient *wappalyzer.Wappalyze) map[string][]TechInfo {
+	result := make(map[string][]TechInfo)
 
 	resp, err := client.Get(url)
 	if err != nil {
@@ -38,11 +44,15 @@ func scan(url string, wappalyzerClient *wappalyzer.Wappalyze) map[string][]strin
 	defer resp.Body.Close()
 
 	data, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
-	fingerprints := wappalyzerClient.Fingerprint(resp.Header, data)
+	fingerprints := wappalyzerClient.FingerprintWithInfo(resp.Header, data)
 
-	techs := []string{}
-	for tech := range fingerprints {
-		techs = append(techs, tech)
+	techs := []TechInfo{}
+	for name, info := range fingerprints {
+		techs = append(techs, TechInfo{
+			Name:       name,
+			CPE:        info.CPE,
+			Categories: info.Categories,
+		})
 	}
 	result[url] = techs
 	return result
@@ -75,7 +85,7 @@ func main() {
 	}
 
 	wappalyzerClient, _ := wappalyzer.New()
-	finalResults := make(map[string][]string)
+	finalResults := make(map[string][]TechInfo)
 
 	for _, url := range urls {
 		result := scan(url, wappalyzerClient)

--- a/artemis/modules/webapp_identifier.py
+++ b/artemis/modules/webapp_identifier.py
@@ -76,7 +76,7 @@ class WebappIdentifier(ArtemisBase):
         )
         self.add_task(current_task, new_task)
 
-        self.db.save_task_result(
+        self.save_task_result(
             task=current_task,
             status=TaskStatus.OK,
             data={

--- a/artemis/modules/webapp_identifier.py
+++ b/artemis/modules/webapp_identifier.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import re
+from dataclasses import asdict
 from typing import List, Tuple
 
 from karton.core import Task
@@ -8,7 +9,7 @@ from artemis import load_risk_class
 from artemis.binds import Service, TaskStatus, TaskType, WebApplication
 from artemis.module_base import ArtemisBase
 from artemis.task_utils import get_target_url
-from artemis.web_technology_identification import run_tech_detection
+from artemis.web_technology_identification import run_tech_detection, to_tag_strings
 
 WEBAPP_SIGNATURES: List[Tuple[WebApplication, str]] = [
     (WebApplication.WORDPRESS, '<meta name="generator" content="WordPress'),
@@ -57,6 +58,11 @@ class WebappIdentifier(ArtemisBase):
     def _process(self, current_task: Task, url: str) -> None:
         application = self._identify(url)
 
+        tech_results = run_tech_detection([url], self.log)
+        technologies = tech_results.get(url, [])
+        technology_tags = to_tag_strings(technologies)
+        technologies_payload = [asdict(t) for t in technologies]
+
         new_task = Task(
             {
                 "type": TaskType.WEBAPP,
@@ -64,16 +70,20 @@ class WebappIdentifier(ArtemisBase):
             },
             payload={
                 "url": url,
+                "technology_tags": technology_tags,
+                "technologies": technologies_payload,
             },
         )
         self.add_task(current_task, new_task)
 
-        technology_tags = run_tech_detection([url], self.log)
-
-        self.save_task_result(
+        self.db.save_task_result(
             task=current_task,
             status=TaskStatus.OK,
-            data={"webapp": application, "technology_tags": technology_tags.get(url, [])},
+            data={
+                "webapp": application,
+                "technology_tags": technology_tags,
+                "technologies": technologies_payload,
+            },
         )
 
     def run(self, current_task: Task) -> None:

--- a/artemis/reporting/modules/webapp_identifier/reporter.py
+++ b/artemis/reporting/modules/webapp_identifier/reporter.py
@@ -1,8 +1,41 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Tuple
 
 from artemis.reporting.base.asset import Asset
 from artemis.reporting.base.asset_type import AssetType
 from artemis.reporting.base.reporter import Reporter
+
+
+def _iter_technologies(result: Dict[str, Any]) -> List[Tuple[str, Optional[str]]]:
+    """
+    Yield ``(name, version)`` pairs from a ``webapp_identifier`` task result.
+
+    Prefers the structured ``technologies`` list; falls back to the legacy
+    ``technology_tags`` string list so reports for older task results still
+    render.
+    """
+    pairs: List[Tuple[str, Optional[str]]] = []
+
+    structured = result.get("technologies")
+    if isinstance(structured, list) and structured:
+        for tech in structured:
+            if not isinstance(tech, dict):
+                continue
+            name = tech.get("name")
+            if not name:
+                continue
+            version = tech.get("version") or None
+            pairs.append((str(name), str(version) if version else None))
+        return pairs
+
+    for tag in result.get("technology_tags", []):
+        if not isinstance(tag, str):
+            continue
+        if ":" in tag:
+            name, version = tag.split(":", 1)
+            pairs.append((name, version or None))
+        else:
+            pairs.append((tag, None))
+    return pairs
 
 
 class WebappIdentifierReporter(Reporter):
@@ -15,13 +48,7 @@ class WebappIdentifierReporter(Reporter):
             return []
 
         result = []
-        for tag in task_result["result"].get("technology_tags", []):
-            if ":" in tag:
-                technology, version = tag.split(":", 1)
-            else:
-                technology = tag
-                version = None
-
+        for technology, version in _iter_technologies(task_result["result"]):
             if technology == "WordPress":  # we have separate type for that
                 result.append(
                     Asset(

--- a/artemis/web_technology_identification.py
+++ b/artemis/web_technology_identification.py
@@ -3,14 +3,54 @@ import logging
 import os
 import subprocess
 import tempfile
-from typing import Any, List
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
 
 WAPPALYZER_PATH = "/opt/artemis/modules/utils/wappalyzer/"
 
 
-def run_tech_detection(urls: List[str], logger: logging.Logger) -> Any:
+@dataclass
+class Technology:
+    """A single technology detected by Wappalyzer on a URL.
+
+    Wappalyzer reports the technology key as ``"Name:Version"`` when a version
+    was extracted; we split it here so downstream code has structured access.
+    """
+
+    name: str
+    version: Optional[str] = None
+    cpe: Optional[str] = None
+    categories: List[str] = field(default_factory=list)
+
+
+def _parse_tech(raw: Dict[str, Any]) -> Technology:
+    raw_name = str(raw.get("name", ""))
+    if ":" in raw_name:
+        name, _, version = raw_name.partition(":")
+    else:
+        name, version = raw_name, None
+
+    cpe = raw.get("cpe") or None
+    raw_categories = raw.get("categories") or []
+    if isinstance(raw_categories, list):
+        categories = [str(c) for c in raw_categories]
+    else:
+        categories = []
+
+    return Technology(
+        name=name,
+        version=version if version else None,
+        cpe=str(cpe) if cpe else None,
+        categories=categories,
+    )
+
+
+def run_tech_detection(urls: List[str], logger: logging.Logger) -> Dict[str, List[Technology]]:
     """
     Run technology detection on a list of URLs using Wappalyzer.
+
+    Returns a mapping of URL -> list of detected technologies. On subprocess or
+    JSON parse failure, returns an empty list per URL.
     """
     wappalyzer_path = os.path.join(os.path.dirname(__file__), "modules", "utils", "wappalyzer")
     main_go_path = os.path.join(wappalyzer_path, "main.go")
@@ -33,7 +73,25 @@ def run_tech_detection(urls: List[str], logger: logging.Logger) -> Any:
                 ["go", "run", main_go_path, temp_file.name], cwd=wappalyzer_path
             )
 
-        return json.loads(wappalyzer_output)
+        raw = json.loads(wappalyzer_output)
+        # Pre-seed every input URL so the result keeps the documented url -> list
+        # contract even when Wappalyzer omits a URL it found nothing for (or choked
+        # on); we then overlay whatever it did return.
+        parsed: Dict[str, List[Technology]] = {url: [] for url in urls}
+        for url, items in raw.items():
+            if isinstance(items, list):
+                parsed[url] = [_parse_tech(item) for item in items if isinstance(item, dict)]
+        return parsed
     except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
         logger.error(f"Error running technology detection: {e}")
         return {url: [] for url in urls}
+
+
+def to_tag_strings(techs: List[Technology]) -> List[str]:
+    """Convert a list of ``Technology`` objects back to the legacy
+    ``"Name:Version"`` form (just ``"Name"`` when no version is known).
+
+    Used by callers that still operate on flat strings - primarily
+    ``nuclei_router`` for its ``-etags`` substring matching.
+    """
+    return [f"{t.name}:{t.version}" if t.version else t.name for t in techs]

--- a/test/modules/test_webapp_identifier.py
+++ b/test/modules/test_webapp_identifier.py
@@ -29,6 +29,36 @@ class WebappIdentifierTest(ArtemisModuleTestCase):
             )
 
             result = self.run_task(task)
-            (task,) = result
-            self.assertEqual(task.headers["webapp"], entry.application)
-            self.assertEqual(task.payload["url"], f"http://{entry.domain}:80")
+
+            webapp_tasks = [t for t in result if t.headers["type"] == TaskType.WEBAPP]
+
+            self.assertEqual(len(webapp_tasks), 1)
+            webapp_task = webapp_tasks[0]
+            self.assertEqual(webapp_task.headers["webapp"], entry.application)
+            self.assertEqual(webapp_task.payload["url"], f"http://{entry.domain}:80")
+
+            technology_tags = webapp_task.payload["technology_tags"]
+            self.assertIsInstance(technology_tags, list)
+            self.assertGreater(len(technology_tags), 0)
+            for tag in technology_tags:
+                self.assertIsInstance(tag, str)
+
+            # The full structured technology list is carried on the WEBAPP task payload, so
+            # downstream modules can read it from there instead of needing a separate task type.
+            technologies = webapp_task.payload["technologies"]
+            self.assertIsInstance(technologies, list)
+            self.assertGreater(len(technologies), 0)
+            for tech in technologies:
+                self.assertIsInstance(tech, dict)
+                self.assertIn("name", tech)
+                self.assertIn("version", tech)
+                self.assertIn("cpe", tech)
+                self.assertIn("categories", tech)
+                self.assertIsInstance(tech["categories"], list)
+
+            # Be specific: the CMS must show up in the detected technologies (a regression that
+            # stops detecting it should fail here), and at least one technology must carry a CPE
+            # since that is what a technology has to be looked up by downstream.
+            detected_names = {str(tech["name"]).lower() for tech in technologies}
+            self.assertIn(entry.application.value, detected_names)
+            self.assertTrue(any(tech["cpe"] for tech in technologies))

--- a/test/unit/test_web_technology_identification.py
+++ b/test/unit/test_web_technology_identification.py
@@ -1,7 +1,9 @@
+import json
 import logging
 import unittest
+from unittest.mock import MagicMock, patch
 
-from artemis.web_technology_identification import run_tech_detection
+from artemis.web_technology_identification import run_tech_detection, to_tag_strings
 
 
 class TestWebTechnologyIdentification(unittest.TestCase):
@@ -34,7 +36,14 @@ class TestWebTechnologyIdentification(unittest.TestCase):
 
         for target in targets:
             self.assertIn(target, tech_results)
-            self.assertEqual(set(tech_results[target]), set(expected_results[target]))
+            detected_tags = set(to_tag_strings(tech_results[target]))
+            self.assertEqual(detected_tags, set(expected_results[target]))
+
+            # to_tag_strings drops the CPE, so check it separately - it is what a CVE lookup
+            # keys on. Apache is detected on both targets, and its version slot stays a
+            # wildcard because Wappalyzer reports the version apart from the CPE template.
+            (apache,) = [tech for tech in tech_results[target] if tech.name == "Apache HTTP Server"]
+            self.assertEqual(apache.cpe, "cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*")
 
     def test_skipping_ssl_verification(self) -> None:
         targets = ["https://self-signed.badssl.com"]
@@ -53,4 +62,32 @@ class TestWebTechnologyIdentification(unittest.TestCase):
 
         for target in targets:
             self.assertIn(target, tech_results)
-            self.assertEqual(set(tech_results[target]), set(expected_results[target]))
+            detected_tags = set(to_tag_strings(tech_results[target]))
+            self.assertEqual(detected_tags, set(expected_results[target]))
+
+    @patch("artemis.web_technology_identification.subprocess.check_output")
+    @patch("artemis.web_technology_identification.subprocess.run")
+    @patch("artemis.web_technology_identification.os.path.exists", return_value=True)
+    def test_url_absent_from_output_is_still_present(
+        self, _exists: MagicMock, _run: MagicMock, mock_check_output: MagicMock
+    ) -> None:
+        # Wappalyzer returns only one of the two requested URLs; the omitted one must
+        # still be present in the result (with an empty list) per the url -> list contract.
+        mock_check_output.return_value = json.dumps(
+            {
+                "http://has-tech": [
+                    {
+                        "name": "Apache HTTP Server:2.4.53",
+                        "cpe": "cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*",
+                        "categories": ["Web servers"],
+                    }
+                ],
+            }
+        ).encode("utf-8")
+
+        logger = logging.Logger("test_logger")
+        results = run_tech_detection(["http://has-tech", "http://no-tech"], logger=logger)
+
+        self.assertIn("http://no-tech", results)
+        self.assertEqual(results["http://no-tech"], [])
+        self.assertEqual([tech.name for tech in results["http://has-tech"]], ["Apache HTTP Server"])


### PR DESCRIPTION
This is the CPE half of #2842, split out so the technology detection can be reviewed and merged on its own. #2842 keeps the cve_lookup module.

`run_tech_detection` returns structured `Technology` objects (name, version, CPE, categories) instead of tag strings, and `webapp_identifier` carries them on the `WEBAPP` task payload. The CPE Wappalyzer gives back keeps a wildcard in the version slot and reports the version separately, so both are kept as their own fields - `cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*` with `version="2.4.53"`. Nothing here reads the technologies field yet; it's there for downstream consumers, the CVE lookup in #2842  being the first.