### PR TITLE
fix docs deploy

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -147,7 +147,7 @@ uro==1.0.2
 uvicorn==0.51.0
 validators==0.35.0
 werkzeug==3.1.8
-whoisdomain==2.20260709.1
+whoisdomain==1.20260326.1
 wrapt==1.17.3
 xlsxwriter==3.2.9
 xmltodict==1.0.4


### PR DESCRIPTION
~~after upgrading whoisdomain (https://github.com/CERT-Polska/Artemis/pull/2972)~~ 
~~- they introduce breaking change that is not mentioned in release notes~~
~~- need new dependency not mentioned in pypi (https://pypi.org/pypi/whoisdomain/json) which is whodap~~
~~- returned date is now timezone aware~~

~~manually added whodap and adjusted code~~

Downgrading the library as some breaking changes looks like bugs/unintended behaviors