### PR TITLE
Make the wappalyzergo version in go.mod actually authoritative

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,15 @@ updates:
     cooldown:
       default-days: 7
 
+  # Go modules of the Wappalyzer wrapper used for web technology identification. Its wappalyzergo
+  # dependency carries the fingerprint database, so these bumps also refresh technology detection.
+  - package-ecosystem: "gomod"
+    directory: "/artemis/modules/utils/wappalyzer/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
   # Python packages in root
   - package-ecosystem: "pip"
     directory: "/"

--- a/artemis/web_technology_identification.py
+++ b/artemis/web_technology_identification.py
@@ -6,7 +6,12 @@ import tempfile
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
-WAPPALYZER_PATH = "/opt/artemis/modules/utils/wappalyzer/"
+
+class TechDetectionFailedException(Exception):
+    """Raised when technology detection couldn't be performed at all.
+
+    This is not the same as detecting no technologies - see the comment in run_tech_detection.
+    """
 
 
 @dataclass
@@ -49,20 +54,24 @@ def run_tech_detection(urls: List[str], logger: logging.Logger) -> Dict[str, Lis
     """
     Run technology detection on a list of URLs using Wappalyzer.
 
-    Returns a mapping of URL -> list of detected technologies. On subprocess or
-    JSON parse failure, returns an empty list per URL.
+    Returns a mapping of URL -> list of detected technologies. A URL that couldn't be fetched maps to an
+    empty list, same as one that runs nothing we recognize.
+
+    Raises TechDetectionFailedException if the detection itself couldn't be performed - the caller must not
+    confuse that with a target running no technologies.
     """
     wappalyzer_path = os.path.join(os.path.dirname(__file__), "modules", "utils", "wappalyzer")
     main_go_path = os.path.join(wappalyzer_path, "main.go")
     if not os.path.exists(main_go_path):
-        raise FileNotFoundError(f"Wappalyzer main.go not found at {main_go_path}")
+        # Same class of failure as the ones below, so it gets the same exception - a caller catching
+        # TechDetectionFailedException would otherwise miss this one.
+        raise TechDetectionFailedException(f"Wappalyzer main.go not found at {main_go_path}")
 
     try:
-        # Update the Wappalyzer package once
-        subprocess.run(
-            ["go", "-C", WAPPALYZER_PATH, "get", "-u", "./..."], cwd=wappalyzer_path, check=True, capture_output=True
-        )
-
+        # The wappalyzergo version comes from go.mod. We deliberately don't upgrade it here: doing that on
+        # each call meant production, CI and the pinned version were all running different code, so a broken
+        # upstream release would hit production and CI at the same moment, with no PR to revert. Upgrades
+        # arrive as Dependabot pull requests instead - see .github/dependabot.yml.
         with tempfile.NamedTemporaryFile(mode="w") as temp_file:
             for url in urls:
                 temp_file.write(url + "\n")
@@ -83,8 +92,14 @@ def run_tech_detection(urls: List[str], logger: logging.Logger) -> Dict[str, Lis
                 parsed[url] = [_parse_tech(item) for item in items if isinstance(item, dict)]
         return parsed
     except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+        # Returning an empty result here would be indistinguishable from "we checked and found nothing",
+        # which is a lie the callers can't detect. Raising makes ArtemisBase retry the task and, if that
+        # doesn't help, save it with TaskStatus.ERROR instead of recording a false negative.
+        #
+        # A target that didn't respond doesn't end up here - the wrapper logs that and exits with 0 - so this
+        # means the detection itself is broken (no Go toolchain, no module, unreachable proxy, invalid output).
         logger.error(f"Error running technology detection: {e}")
-        return {url: [] for url in urls}
+        raise TechDetectionFailedException(f"Unable to run technology detection for {urls}") from e
 
 
 def to_tag_strings(techs: List[Technology]) -> List[str]:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -31,6 +31,14 @@ RUN apk add --no-cache --virtual .build-deps gcc git libc-dev make libffi-dev li
 
 WORKDIR /opt
 
+# Download the dependencies of the Wappalyzer wrapper (used for web technology identification) at build time.
+# Without this, the first `go run` would fetch them - both the module and the Go toolchain go.mod asks for -
+# from the network at scan time, and a failure to reach it makes technology detection report no technologies.
+# Only the module files are copied at this point so that a change in the Python code doesn't invalidate this
+# layer and re-download everything.
+COPY "artemis/modules/utils/wappalyzer/go.mod" "artemis/modules/utils/wappalyzer/go.sum" "artemis/modules/utils/wappalyzer/"
+RUN cd artemis/modules/utils/wappalyzer && go mod download
+
 COPY "artemis/" "artemis/"
 COPY "alembic.ini" "alembic.ini"
 COPY "migrations/" "migrations/"

--- a/test/unit/test_web_technology_identification.py
+++ b/test/unit/test_web_technology_identification.py
@@ -1,9 +1,15 @@
 import json
 import logging
+import subprocess
 import unittest
+from typing import List
 from unittest.mock import MagicMock, patch
 
-from artemis.web_technology_identification import run_tech_detection, to_tag_strings
+from artemis.web_technology_identification import (
+    TechDetectionFailedException,
+    run_tech_detection,
+    to_tag_strings,
+)
 
 
 class TestWebTechnologyIdentification(unittest.TestCase):
@@ -68,9 +74,61 @@ class TestWebTechnologyIdentification(unittest.TestCase):
     @patch("artemis.web_technology_identification.subprocess.check_output")
     @patch("artemis.web_technology_identification.subprocess.run")
     @patch("artemis.web_technology_identification.os.path.exists", return_value=True)
-    def test_url_absent_from_output_is_still_present(
-        self, _exists: MagicMock, _run: MagicMock, mock_check_output: MagicMock
+    def test_dependencies_are_not_upgraded_at_runtime(
+        self, _exists: MagicMock, mock_run: MagicMock, mock_check_output: MagicMock
     ) -> None:
+        # The wappalyzergo version has to come from go.mod, not from whatever is newest upstream.
+        # A `go get -u` here would mean production, CI and the pin all run different code, so a broken
+        # upstream release would hit production and CI at the same moment, with no PR to revert.
+        mock_check_output.return_value = b"{}"
+
+        run_tech_detection(["http://example.com"], logger=logging.Logger("test_logger"))
+
+        self.assertEqual(mock_run.call_args_list, [])
+
+        # Checking that alone wouldn't be enough: `go get` smuggled through check_output (whose return
+        # value is mocked here anyway) would leave this test green while restoring the old behaviour.
+        # Assert on what is being executed instead of on which function executes it.
+        commands: List[List[str]] = []
+        for call in mock_run.call_args_list + mock_check_output.call_args_list:
+            command = call.args[0] if call.args else call.kwargs.get("args")
+            if command is None:
+                self.fail(f"subprocess called without a command: {call}")
+            commands.append(command)
+
+        # Guards against the loop below becoming vacuous if the subprocess call ever goes away.
+        self.assertIn(["go", "run"], [command[:2] for command in commands])
+
+        for command in commands:
+            self.assertNotIn("get", command, f"the wappalyzergo version must not be upgraded at runtime: {command}")
+
+    @patch("artemis.web_technology_identification.subprocess.check_output")
+    @patch("artemis.web_technology_identification.os.path.exists", return_value=True)
+    def test_broken_detection_raises_instead_of_reporting_no_technologies(
+        self, _exists: MagicMock, mock_check_output: MagicMock
+    ) -> None:
+        # Both ways the detection itself can break: the wrapper failing to run (no Go toolchain, no module,
+        # unreachable module proxy) and it returning something that isn't the expected output. Neither may
+        # be reported as "this target runs no technologies" - the callers have no way to tell the difference.
+        mock_check_output.side_effect = subprocess.CalledProcessError(1, ["go", "run"])
+        with self.assertRaises(TechDetectionFailedException):
+            run_tech_detection(["http://example.com"], logger=logging.Logger("test_logger"))
+
+        mock_check_output.side_effect = None
+        mock_check_output.return_value = b"not json"
+        with self.assertRaises(TechDetectionFailedException):
+            run_tech_detection(["http://example.com"], logger=logging.Logger("test_logger"))
+
+    @patch("artemis.web_technology_identification.os.path.exists", return_value=False)
+    def test_missing_wrapper_raises_the_same_exception(self, _exists: MagicMock) -> None:
+        # A missing main.go is the same class of failure, so a caller catching the domain exception
+        # must not have to also know about FileNotFoundError.
+        with self.assertRaises(TechDetectionFailedException):
+            run_tech_detection(["http://example.com"], logger=logging.Logger("test_logger"))
+
+    @patch("artemis.web_technology_identification.subprocess.check_output")
+    @patch("artemis.web_technology_identification.os.path.exists", return_value=True)
+    def test_url_absent_from_output_is_still_present(self, _exists: MagicMock, mock_check_output: MagicMock) -> None:
         # Wappalyzer returns only one of the two requested URLs; the omitted one must
         # still be present in the result (with an empty list) per the url -> list contract.
         mock_check_output.return_value = json.dumps(


### PR DESCRIPTION
## What

Makes the `wappalyzergo` version pinned in `artemis/modules/utils/wappalyzer/go.mod` govern what actually
runs during a scan, and makes a broken technology detection fail loudly instead of reporting that the target
runs no technologies.

## Why

`run_tech_detection` ran `go get -u ./...` on **every call**, so the pin in `go.mod` controlled nothing.
Everything downstream of that follows:

- **Production, CI and the pin all ran different code.** Whatever was newest upstream is what executed, so a
broken upstream release would hit production and CI at the same moment, with no pull request to revert.
- **CI never tested the pinned version.** That also breaks the mechanism we would want for upgrades: a
Dependabot bump PR would be green regardless of the version it proposes, because the test run upgrades
past it before doing anything.
- **Nothing kept the pin current either.** The `gomod` entry in `.github/dependabot.yml` points at `/docker/`
only, so this module was covered by nothing and sat at `v0.2.76` from 12th of April, close to four months ago. For contrast,
`wappalyzergo` appears in `docker/go.mod` as an indirect dependency at `0.2.87`, because that directory is
covered.
- **Removing the upgrade alone would not have been enough.** Without network the detection did not work at
all, and not only because of the module: the base image ships Go 1.24.13 while `go.mod` asks for `1.25.0`,
so the Go toolchain itself was fetched at scan time. Verified by compiling the wrapper in a container run
with `--network none` — it fails on the toolchain before it even gets to the module.
- **Failures were swallowed.** The exception handler returned an empty list per URL and logged a line, so
"detection is broken" and "this target runs nothing we recognize" were indistinguishable to callers.

## Fix

- Drop the runtime `go get -u ./...`, so the pin is what runs.
- Add a fourth `gomod` entry to `.github/dependabot.yml` for the Wappalyzer module directory (weekly, with
`cooldown`, matching the existing entries; no grouping, as that `go.mod` has a single direct dependency).
- Download the wrapper dependencies at image build time. Only `go.mod` and `go.sum` are copied before that
step, so a change in the Python code doesn't invalidate the layer and re-download everything.
- Raise `TechDetectionFailedException` instead of returning an empty result when the detection itself
breaks. A missing `main.go` raises the same exception rather than `FileNotFoundError`, so a caller needs
to know about one type only.

Two design decisions worth stating explicitly:

**The pin is not bumped here.** It stays at `v0.2.76` even though `0.2.92` is out. Bumping the fingerprint
database changes detection results — technology names, versions, what gets detected at all — and that
deserves its own reviewable pull request rather than riding along with an infrastructure change. The first
Dependabot PR will be exactly that, and it will be the first bump ever tested against the version it
proposes. The cost of waiting is measured: between our pin and today's upstream sources, 31 technologies
were added and 2 existing fingerprints changed, out of 7522.

**Raising, rather than returning `None` or an empty result.** Neither caller of `run_tech_detection` has any
`except`, so the exception propagates to `ArtemisBase`, which retries the task and then saves it with
`TaskStatus.ERROR` and a traceback — the behaviour we want, with no new machinery. Note this is narrow by
construction: a target that didn't respond does **not** take this path, because the wrapper logs the fetch
error and exits with 0. The exception means the detection itself is broken (no toolchain, no module,
unreachable module proxy, unparseable output), which is exactly the case where retrying makes sense.

## Tests

- `test_dependencies_are_not_upgraded_at_runtime` — verifies no executed command contains `get`. It asserts
on the commands from both `subprocess.run` and `subprocess.check_output`, not on which function was
called: a `go get` smuggled through `check_output` would keep a `run`-only assertion green (checked by
mutating the module — the naive assertion stays green, this one fails). It also asserts that `go run` is
among the observed commands, so the check can't quietly become vacuous.
- `test_broken_detection_raises_instead_of_reporting_no_technologies` — verifies both ways the detection can
break (non-zero exit from the wrapper, output that isn't the expected JSON) surface as
`TechDetectionFailedException` rather than as "no technologies".
- `test_missing_wrapper_raises_the_same_exception` — verifies the adjacent case that used to raise a
different type, so catching the domain exception is sufficient.

Verified by hand as well, since the build-time change can't be covered by a unit test:

| Image | `GOPROXY=off`, target reachable |
|---|---|
| this branch | 7 technologies detected, with CPEs |
| current `main` | 0 technologies, one line in the log |


## Notes / Out of scope

**The exception does not close the false negative in `nuclei_router`, and that is deliberate.** There, an
empty result means "WordPress not detected", which `get_tags_to_exclude` turns into `-etags wordpress` —
so a target whose detection came back empty is scanned **without** WordPress templates. That path is not
reached by the exception: it is an unreachable target, which the wrapper reports with exit 0. Closing it
requires distinguishing "we don't know" from "nothing there" per URL and teaching `nuclei_router` about the
new case, which changes scanning behaviour and belongs in its own PR. Upper bound on the cost of not
excluding when unknown: 1672 of 13510 templates carry the `wordpress` tag.

**The Go wrapper is untouched.** The signal needed by the follow-up already exists in its output: a URL that
was fetched appears as a key (possibly with an empty list), a URL that failed to fetch is absent. It is the
Python side that flattens both into `[]`.

**Base Go version and the `go` directive can drift apart silently.** The toolchain download described above
only happens because they disagree; nothing warns about it. Worth keeping in mind when either is changed.

After merge: confirm Dependabot actually picked up the new directory. If no bump PR appears within a week,
the entry is misconfigured and the pin starts ageing again — this time quietly, since `-u` no longer masks
it.
