### PR TITLE
Extract shared crawl helpers from injection detectors

### DIFF
--- a/artemis/crawling.py
+++ b/artemis/crawling.py
@@ -1,6 +1,7 @@
 import functools
 import hashlib
 import json
+import random
 import subprocess
 from typing import List, Tuple
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
@@ -12,6 +13,7 @@ from redis import Redis
 
 from artemis import http_requests, utils
 from artemis.config import Config
+from artemis.modules.data.static_extensions import STATIC_EXTENSIONS
 from artemis.redis_cache import RedisCache
 from artemis.resource_lock import FailedToAcquireLockException, ResourceLock
 
@@ -230,3 +232,21 @@ def crawl_and_filter(url: str) -> List[str]:
                 lock.release()
 
     return list(deduped)
+
+
+def strip_query_string(url: str) -> str:
+    parsed = urlparse(url)
+    return urlunparse(parsed._replace(query="", fragment=""))
+
+
+def prepare_links(url: str) -> List[str]:
+    links = crawl_and_filter(url)
+    links.append(url)
+    links = list(set(links) | set([strip_query_string(link) for link in links]))
+    links = [
+        link.split("#")[0]
+        for link in links
+        if not any(link.split("?")[0].lower().endswith(extension) for extension in STATIC_EXTENSIONS)
+    ]
+    random.shuffle(links)
+    return links[: Config.Miscellaneous.MAX_URLS_TO_SCAN]

--- a/artemis/crawling.py
+++ b/artemis/crawling.py
@@ -239,7 +239,7 @@ def strip_query_string(url: str) -> str:
     return urlunparse(parsed._replace(query="", fragment=""))
 
 
-def prepare_links(url: str) -> List[str]:
+def get_links_to_scan(url: str) -> List[str]:
     links = crawl_and_filter(url)
     links.append(url)
     links = list(set(links) | set([strip_query_string(link) for link in links]))

--- a/artemis/modules/lfi_detector.py
+++ b/artemis/modules/lfi_detector.py
@@ -6,7 +6,7 @@ from karton.core import Task
 from artemis import load_risk_class
 from artemis.binds import Service, TaskStatus, TaskType
 from artemis.config import Config
-from artemis.crawling import get_injectable_parameters, prepare_links
+from artemis.crawling import get_injectable_parameters, get_links_to_scan
 from artemis.http_requests import HTTPResponse
 from artemis.module_base import ArtemisBase
 from artemis.modules.data.lfi_detector.lfi_detector_data import (
@@ -177,7 +177,7 @@ class LFIDetector(ArtemisBase):
         """Run the LFI detection module."""
         if self.check_connection_to_base_url_and_save_error(current_task):
             url = get_target_url(current_task)
-            links = prepare_links(url)
+            links = get_links_to_scan(url)
 
             messages = self.scan(urls=links, task=current_task)
 

--- a/artemis/modules/lfi_detector.py
+++ b/artemis/modules/lfi_detector.py
@@ -1,17 +1,12 @@
-import random
 from enum import Enum
 from typing import Any, Dict, List, Optional
-from urllib.parse import urlparse, urlunparse
 
 from karton.core import Task
 
 from artemis import load_risk_class
 from artemis.binds import Service, TaskStatus, TaskType
 from artemis.config import Config
-from artemis.crawling import (
-    crawl_and_filter,
-    get_injectable_parameters,
-)
+from artemis.crawling import get_injectable_parameters, prepare_links
 from artemis.http_requests import HTTPResponse
 from artemis.module_base import ArtemisBase
 from artemis.modules.data.lfi_detector.lfi_detector_data import (
@@ -19,7 +14,6 @@ from artemis.modules.data.lfi_detector.lfi_detector_data import (
     RCE_PAYLOADS,
 )
 from artemis.modules.data.parameters import URL_PARAMS
-from artemis.modules.data.static_extensions import STATIC_EXTENSIONS
 from artemis.task_utils import get_target_url
 
 
@@ -45,10 +39,6 @@ class LFIDetector(ArtemisBase):
     filters = [
         {"type": TaskType.SERVICE.value, "service": Service.HTTP.value},
     ]
-
-    def _strip_query_string(self, url: str) -> str:
-        url_parsed = urlparse(url)
-        return urlunparse(url_parsed._replace(query="", fragment=""))
 
     def create_url_with_batch_payload(self, url: str, param_batch: List[str], payload: str) -> str:
         assignments = {key: payload for key in param_batch}
@@ -187,20 +177,9 @@ class LFIDetector(ArtemisBase):
         """Run the LFI detection module."""
         if self.check_connection_to_base_url_and_save_error(current_task):
             url = get_target_url(current_task)
+            links = prepare_links(url)
 
-            links = crawl_and_filter(url)
-            links.append(url)
-            links = list(set(links) | set([self._strip_query_string(link) for link in links]))
-
-            links = [
-                link.split("#")[0]
-                for link in links
-                if not any(link.split("?")[0].lower().endswith(extension) for extension in STATIC_EXTENSIONS)
-            ]
-
-            random.shuffle(links)
-
-            messages = self.scan(urls=links[: Config.Miscellaneous.MAX_URLS_TO_SCAN], task=current_task)
+            messages = self.scan(urls=links, task=current_task)
 
             if messages:
                 status = TaskStatus.INTERESTING

--- a/artemis/modules/orm_injection_detector.py
+++ b/artemis/modules/orm_injection_detector.py
@@ -12,7 +12,7 @@ from artemis.binds import Service, TaskStatus, TaskType
 from artemis.config import Config
 from artemis.crawling import (
     get_injectable_parameters,
-    prepare_links,
+    get_links_to_scan,
     strip_query_string,
 )
 from artemis.http_requests import HTTPResponse
@@ -301,7 +301,7 @@ class OrmInjectionDetector(ArtemisBase):
 
     def run(self, current_task: Task) -> None:
         url = get_target_url(current_task)
-        links = prepare_links(url)
+        links = get_links_to_scan(url)
 
         message = self.scan(urls=links)
 

--- a/artemis/modules/orm_injection_detector.py
+++ b/artemis/modules/orm_injection_detector.py
@@ -1,6 +1,4 @@
 import json
-import random
-import urllib
 import uuid
 from difflib import SequenceMatcher
 from enum import Enum
@@ -13,13 +11,13 @@ from artemis import load_risk_class
 from artemis.binds import Service, TaskStatus, TaskType
 from artemis.config import Config
 from artemis.crawling import (
-    crawl_and_filter,
     get_injectable_parameters,
+    prepare_links,
+    strip_query_string,
 )
 from artemis.http_requests import HTTPResponse
 from artemis.module_base import ArtemisBase
 from artemis.modules.data.parameters import URL_PARAMS
-from artemis.modules.data.static_extensions import STATIC_EXTENSIONS
 from artemis.orm_injection_data import (
     ORM_LOOKUP_SUFFIXES,
     SENSITIVE_FIELD_PROBES,
@@ -50,11 +48,6 @@ class OrmInjectionDetector(ArtemisBase):
     filters = [
         {"type": TaskType.SERVICE.value, "service": Service.HTTP.value},
     ]
-
-    @staticmethod
-    def _strip_query_string(url: str) -> str:
-        url_parsed = urllib.parse.urlparse(url)
-        return urllib.parse.urlunparse(url_parsed._replace(query="", fragment=""))
 
     @staticmethod
     def _get_response_text(response: Optional[HTTPResponse]) -> str:
@@ -106,7 +99,7 @@ class OrmInjectionDetector(ArtemisBase):
         # Preserve sibling query params, replacing only the param under test
         parsed = urlparse(original_url)
         siblings = {k: v[0] for k, v in parse_qs(parsed.query).items() if k != param_name}
-        base = self._strip_query_string(original_url)
+        base = strip_query_string(original_url)
 
         url_likely = self._build_url_with_params(base, {**siblings, param_with_suffix: likely_value})
         url_unlikely = self._build_url_with_params(
@@ -262,7 +255,7 @@ class OrmInjectionDetector(ArtemisBase):
         for current_url in urls:
             parsed = urlparse(current_url)
             query_params = parse_qs(parsed.query)
-            base_url = self._strip_query_string(current_url)
+            base_url = strip_query_string(current_url)
 
             injectable = get_injectable_parameters(current_url)
             all_param_names = list(dict.fromkeys(list(query_params.keys()) + injectable + list(URL_PARAMS)))
@@ -308,20 +301,9 @@ class OrmInjectionDetector(ArtemisBase):
 
     def run(self, current_task: Task) -> None:
         url = get_target_url(current_task)
+        links = prepare_links(url)
 
-        links = crawl_and_filter(url)
-        links.append(url)
-        links = list(set(links) | set([self._strip_query_string(link) for link in links]))
-
-        links = [
-            link.split("#")[0]
-            for link in links
-            if not any(link.split("?")[0].lower().endswith(extension) for extension in STATIC_EXTENSIONS)
-        ]
-
-        random.shuffle(links)
-
-        message = self.scan(urls=links[: Config.Miscellaneous.MAX_URLS_TO_SCAN])
+        message = self.scan(urls=links)
 
         if message:
             status = TaskStatus.INTERESTING

--- a/artemis/modules/sql_injection_detector.py
+++ b/artemis/modules/sql_injection_detector.py
@@ -1,7 +1,5 @@
 import datetime
-import random
 import re
-import urllib
 from enum import Enum
 from timeit import default_timer as timer
 from typing import Any, Dict, List, Literal, Optional
@@ -14,14 +12,10 @@ from karton.core import Task
 from artemis import load_risk_class
 from artemis.binds import Service, TaskStatus, TaskType
 from artemis.config import Config
-from artemis.crawling import (
-    crawl_and_filter,
-    get_injectable_parameters,
-)
+from artemis.crawling import get_injectable_parameters, prepare_links
 from artemis.http_requests import HTTPResponse
 from artemis.module_base import ArtemisBase
 from artemis.modules.data.parameters import URL_PARAMS
-from artemis.modules.data.static_extensions import STATIC_EXTENSIONS
 from artemis.sql_injection_data import HEADERS, SQL_ERROR_MESSAGES
 from artemis.task_utils import get_target_url
 
@@ -44,11 +38,6 @@ class SqlInjectionDetector(ArtemisBase):
     filters = [
         {"type": TaskType.SERVICE.value, "service": Service.HTTP.value},
     ]
-
-    @staticmethod
-    def _strip_query_string(url: str) -> str:
-        url_parsed = urllib.parse.urlparse(url)
-        return urllib.parse.urlunparse(url_parsed._replace(query="", fragment=""))
 
     def create_url_with_batch_payload(self, url: str, param_batch: tuple[Any, ...], payload: str) -> str:
         assignments = {key: payload for key in param_batch}
@@ -534,20 +523,9 @@ class SqlInjectionDetector(ArtemisBase):
 
     def run(self, current_task: Task) -> None:
         url = get_target_url(current_task)
+        links = prepare_links(url)
 
-        links = crawl_and_filter(url)
-        links.append(url)
-        links = list(set(links) | set([self._strip_query_string(link) for link in links]))
-
-        links = [
-            link.split("#")[0]
-            for link in links
-            if not any(link.split("?")[0].lower().endswith(extension) for extension in STATIC_EXTENSIONS)
-        ]
-
-        random.shuffle(links)
-
-        message = self.scan(urls=links[: Config.Miscellaneous.MAX_URLS_TO_SCAN], task=current_task)
+        message = self.scan(urls=links, task=current_task)
 
         if message:
             status = TaskStatus.INTERESTING

--- a/artemis/modules/sql_injection_detector.py
+++ b/artemis/modules/sql_injection_detector.py
@@ -12,7 +12,7 @@ from karton.core import Task
 from artemis import load_risk_class
 from artemis.binds import Service, TaskStatus, TaskType
 from artemis.config import Config
-from artemis.crawling import get_injectable_parameters, prepare_links
+from artemis.crawling import get_injectable_parameters, get_links_to_scan
 from artemis.http_requests import HTTPResponse
 from artemis.module_base import ArtemisBase
 from artemis.modules.data.parameters import URL_PARAMS
@@ -523,7 +523,7 @@ class SqlInjectionDetector(ArtemisBase):
 
     def run(self, current_task: Task) -> None:
         url = get_target_url(current_task)
-        links = prepare_links(url)
+        links = get_links_to_scan(url)
 
         message = self.scan(urls=links, task=current_task)
 


### PR DESCRIPTION
The SQL, ORM, and LFI detectors each had their own copy of the same crawl prelude at the top of `run()`, along with a private `_strip_query_string` helper that was identical across all three. Any change to how the list of links to scan gets built had to be made in every module separately, and the copies had already started drifting apart.

This moves both shared pieces into `crawling.py`, next to `crawl_and_filter` where the rest of the crawling logic already lives. `strip_query_string` drops the query and fragment from a URL, and `prepare_links` runs the whole prelude - it crawls the target, adds the seed URL back in, unions in the query-stripped variants, filters out links pointing at static assets, shuffles, and caps the result at `MAX_URLS_TO_SCAN`. Each detector now calls `prepare_links(url)` in place of that block.

Nothing changes behaviorally - the relocated code is identical to what the detectors ran before, so their existing tests cover it without modification. The command injection detector (#2947) and the NoSQLi detector I'm working on next will adopt the same helpers in their own PRs rather than copying the prelude again.