### PR TITLE
Fill missing asset data when deduplicating

### DIFF
--- a/artemis/reporting/base/reporters.py
+++ b/artemis/reporting/base/reporters.py
@@ -2,6 +2,7 @@ import functools
 import os
 from typing import Any, Dict, List, Type
 
+from .asset import Asset
 from .language import Language
 
 
@@ -33,7 +34,7 @@ def get_all_reporters() -> List[Type[Any]]:
     return reporters
 
 
-def assets_from_task_result(task_result: Dict[str, Any]) -> List[Any]:
+def assets_from_task_result(task_result: Dict[str, Any]) -> List[Asset]:
     """
     Converts a task result as saved by an Artemis task to (one or many) found assets.
     """

--- a/artemis/reporting/export/db.py
+++ b/artemis/reporting/export/db.py
@@ -20,6 +20,28 @@ from artemis.reporting.severity import get_severity
 from artemis.reporting.utils import get_top_level_target
 from artemis.task_utils import get_target_host
 
+MERGEABLE_ASSET_FIELDS = ("version", "cpe")
+
+
+def _fill_missing_data(asset: Asset, duplicate: Asset) -> None:
+    """Copies the data `duplicate` has and `asset` lacks.
+
+    Modules detect overlapping sets of facts about the same asset - e.g. both webapp_identifier and
+    wp_scanner report a WordPress CMS on the same URL, but only the former knows a CPE, and either of them
+    may fail to determine the version. Keeping only the description that happened to be loaded first would
+    therefore drop data depending on the order the database returned the rows in.
+
+    A value that is already there is never overwritten: when both descriptions know a fact and disagree
+    (two versions detected by two different methods), choosing between them is a separate problem and
+    both answers are equally true as far as this function is concerned.
+
+    `asset` is modified in place, which the whole mechanism depends on - it works because Asset is a plain,
+    non-frozen dataclass, and because the object modified here is the one already collected for the export.
+    """
+    for field_name in MERGEABLE_ASSET_FIELDS:
+        if getattr(asset, field_name) is None:
+            setattr(asset, field_name, getattr(duplicate, field_name))
+
 
 class DataLoader:
     """
@@ -70,7 +92,7 @@ class DataLoader:
         if not self._silent:
             results = tqdm(results)  # type: ignore
 
-        seen_assets: Set[Tuple[str, str, str, str]] = set()
+        seen_assets: Dict[Tuple[AssetType, Optional[str], str, Optional[str]], Asset] = {}
 
         for result in results:
             result_tag = result["task"].get("payload_persistent", {}).get("tag", None)
@@ -139,9 +161,14 @@ class DataLoader:
             for item in assets_to_add:
                 # We save last domain so that even if an IP occurs multiple times on multiple domains, we'll still
                 # save it for each domain.
-                if (item.asset_type, item.additional_type, item.name, item.last_domain) in seen_assets:
+                key = (item.asset_type, item.additional_type, item.name, item.last_domain)
+                if key in seen_assets:
+                    # The asset is already there, but this description of it may know something the stored
+                    # one doesn't. Mutating in place is what makes it visible - the object we modify is the
+                    # one already appended to self._assets.
+                    _fill_missing_data(seen_assets[key], item)
                     continue
-                seen_assets.add((item.asset_type, item.additional_type, item.name, item.last_domain))
+                seen_assets[key] = item
                 assets_filtered.append(item)
             self._assets.extend(assets_filtered)
 

--- a/artemis/reporting/export/db.py
+++ b/artemis/reporting/export/db.py
@@ -165,7 +165,9 @@ class DataLoader:
                 if key in seen_assets:
                     # The asset is already there, but this description of it may know something the stored
                     # one doesn't. Mutating in place is what makes it visible - the object we modify is the
-                    # one already appended to self._assets.
+                    # one already appended to self._assets. `dataclasses.replace()` would be the tidier-looking
+                    # alternative, but it re-runs `__post_init__`, resolving the asset's domain again on every
+                    # merge, and wouldn't carry `domain_ips` over anyway, as that one is an `init=False` field.
                     _fill_missing_data(seen_assets[key], item)
                     continue
                 seen_assets[key] = item

--- a/test/unit/test_asset_deduplication.py
+++ b/test/unit/test_asset_deduplication.py
@@ -1,0 +1,112 @@
+import unittest
+from typing import Any, Dict, List, Optional
+
+from artemis.binds import Service, TaskType, WebApplication
+from artemis.reporting.base.asset import Asset
+from artemis.reporting.base.asset_type import AssetType
+from artemis.reporting.base.language import Language
+from artemis.reporting.export.db import DataLoader
+
+# An IP is used instead of a domain so that Asset.__post_init__ doesn't perform a DNS lookup.
+HOST = "127.0.0.1"
+URL = "http://127.0.0.1:80/"
+WORDPRESS_CPE = "cpe:2.3:a:wordpress:wordpress:*:*:*:*:*:*:*:*"
+
+
+class _DBWithTaskResults:
+    """Just enough of DB for DataLoader: the task results it should load."""
+
+    def __init__(self, task_results: List[Dict[str, Any]]) -> None:
+        self._task_results = task_results
+
+    def get_task_results_since(self, time_from: Any, tag: Optional[str] = None) -> List[Dict[str, Any]]:
+        return self._task_results
+
+
+def _webapp_identifier_result(version: Optional[str], cpe: Optional[str]) -> Dict[str, Any]:
+    return {
+        "id": "webapp-identifier-result",
+        "analysis_id": "analysis",
+        "status": "OK",
+        "target_string": URL,
+        "created_at": None,
+        "task": {
+            "headers": {"receiver": "webapp_identifier", "type": TaskType.SERVICE, "service": Service.HTTP},
+            "payload": {"host": HOST, "port": 80, "last_domain": HOST},
+            "payload_persistent": {"original_domain": HOST},
+        },
+        "result": {"technologies": [{"name": "WordPress", "version": version, "cpe": cpe}]},
+    }
+
+
+def _wp_scanner_result(version: Optional[str]) -> Dict[str, Any]:
+    return {
+        "id": "wp-scanner-result",
+        "analysis_id": "analysis",
+        "status": "OK",
+        "target_string": URL,
+        "created_at": None,
+        "task": {
+            "headers": {"receiver": "wp_scanner", "type": TaskType.WEBAPP, "webapp": WebApplication.WORDPRESS},
+            "payload": {"url": URL, "last_domain": HOST},
+            "payload_persistent": {"original_domain": HOST},
+        },
+        # wp_scanner saves the key only when it managed to read the version.
+        "result": {"wp_version": version} if version else {},
+    }
+
+
+def _cms_asset(task_results: List[Dict[str, Any]]) -> Asset:
+    assets = DataLoader(
+        db=_DBWithTaskResults(task_results),  # type: ignore[arg-type]
+        blocklist=[],
+        # Language is built with the functional Enum API from languages.txt, so mypy can't see its members
+        # - hence the ignore, the same one every other use of Language.en_US in the codebase carries.
+        language=Language.en_US,  # type: ignore[attr-defined]
+        tag=None,
+        silent=True,
+    ).assets
+    (asset,) = [asset for asset in assets if asset.asset_type == AssetType.CMS]
+    return asset
+
+
+class AssetDeduplicationTest(unittest.TestCase):
+    def test_the_two_descriptions_of_one_cms_are_merged(self) -> None:
+        # Both modules describe the same WordPress on the same URL, so they produce the same deduplication
+        # key, but only webapp_identifier knows a CPE, and here only wp_scanner determined the version.
+        # Whichever of them is loaded first, the exported asset has to carry both.
+        for order in ("wp_scanner first", "webapp_identifier first"):
+            with self.subTest(order=order):
+                task_results = [
+                    _wp_scanner_result(version="5.9.3"),
+                    _webapp_identifier_result(version=None, cpe=WORDPRESS_CPE),
+                ]
+                if order == "webapp_identifier first":
+                    task_results.reverse()
+
+                asset = _cms_asset(task_results)
+
+                self.assertEqual(asset.additional_type, "wordpress")
+                self.assertEqual(asset.version, "5.9.3")
+                self.assertEqual(asset.cpe, WORDPRESS_CPE)
+
+    def test_a_known_value_is_not_overwritten(self) -> None:
+        asset = _cms_asset(
+            [
+                _webapp_identifier_result(version="5.9.3", cpe=WORDPRESS_CPE),
+                _wp_scanner_result(version="5.9.4"),
+            ]
+        )
+
+        self.assertEqual(asset.version, "5.9.3")
+        self.assertEqual(asset.cpe, WORDPRESS_CPE)
+
+    def test_a_single_description_is_left_alone(self) -> None:
+        asset = _cms_asset([_wp_scanner_result(version="5.9.3")])
+
+        self.assertEqual(asset.version, "5.9.3")
+        self.assertIsNone(asset.cpe)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

When two task results describe one asset differently, the export now merges what the discarded description
knows into the kept one instead of dropping it.

## Why

Assets are deduplicated in `DataLoader` by `(asset_type, additional_type, name, last_domain)`, keeping the
first occurrence. Two modules describe the same WordPress installation and produce exactly that key:

- `webapp_identifier` reports it from the Wappalyzer fingerprint — always with a CPE, and with a version only
  when the fingerprint yields one;
- `wp_scanner` reports it after inspecting WordPress itself — never with a CPE, and with a version only when
  it manages to read it (`result["wp_version"]` is set only `if wp_version`).

The two descriptions therefore overlap partially, and neither is a superset of the other. Which one survives
is decided by the order the rows come back in, and the query feeding the export has no `ORDER BY`, so that
order is whatever Postgres happens to return.

Concretely, for a WordPress whose version `wp_scanner` could read but the Wappalyzer fingerprint couldn't,
the export ends up with either

    version="5.9.3", cpe=None            (wp_scanner won)
    version=None,    cpe="cpe:2.3:a:wordpress:wordpress:*:*:*:*:*:*:*:*"   (webapp_identifier won)

but never with both, even though both facts were detected. This is not new — `version` alone could already be
lost this way — but it stopped being a corner case once assets carry a CPE, because that field is asymmetric:
one of the two sides never has it.

## Fix

`seen_assets` becomes a mapping from the deduplication key to the asset that was kept, so the duplicate can
contribute to it rather than being thrown away.

Three decisions worth stating:

**Which fields are merged is an explicit list** (`version`, `cpe`), not "everything outside the key". The
provenance fields — `original_karton_name`, `original_task_result_id`, `top_level_target` — say which task
result the asset came from, and filling them from a different one would misattribute it. `domain_ips` is
derived from `name`, which is part of the key, so both descriptions have it equal anyway. The list also fails
safe: a field added later isn't merged until somebody decides it should be.

**A value that is already there is never overwritten.** When both descriptions know a fact and disagree —
two versions detected by two different modules — choosing between them is a separate problem, and both
answers are equally true from here. This keeps the rule to one sentence: a `None` gets filled, a value never changes.

**The kept asset is mutated in place rather than rebuilt with `dataclasses.replace()`.** `Asset` isn't
frozen, and `replace()` would re-run `__post_init__`, resolving the asset's domain again on every merge,
while not carrying `domain_ips` over anyway, as it's an `init=False` field.

One two-line addition outside the deduplication itself: `assets_from_task_result` was annotated
`-> List[Any]`, which made everything downstream of it untyped — including the deduplication key, whose
annotation claimed `Tuple[str, str, str, str]` while the first element is an `AssetType` and two others are
`Optional[str]`. mypy had no way to notice. The function now returns `List[Asset]`, which is the type
`Reporter.get_assets` already declares, and the key annotation was corrected to match reality. Verified both
ways: with the old return type the wrong key annotation passes unnoticed; with the new return type in place,
that same wrong annotation is rejected — `Invalid index type "tuple[AssetType, str | None, str, str | None]"`.
`--strict` stays green across all 304 files.

## Tests

- `test_the_two_descriptions_of_one_cms_are_merged` — verifies the exported asset carries both the version
  and the CPE, and does so **in both loading orders**, which is the property that was missing: the result no
  longer depends on what the database returned first.
- `test_a_known_value_is_not_overwritten` — verifies the adjacent case: when both descriptions have a version
  and they differ, the first one is kept rather than being silently replaced.
- `test_a_single_description_is_left_alone` — verifies nothing is invented when there is no duplicate.

## Notes / Out of scope

**This changes behaviour for `version`, not only for the newly added `cpe`.** Until now, when one module knew
the version and the other didn't, the export kept whichever description came first — so the version could
already be lost. That case is fixed here too, which means the diff affects a field that predates the CPE work.

**A merged asset no longer comes from a single task result, and its provenance fields don't say so.**
`original_karton_name` and `original_task_result_id` keep pointing at the description that was kept first, so
an asset attributed to `wp_scanner` can now carry a CPE that `wp_scanner` never reported. Somebody debugging
via `original_task_result_id` would find a task result without that CPE and reasonably conclude the export is
lying. Fixing this properly means recording a list of contributing sources rather than a single one, which is
a different change; until then, the provenance fields should be read as "where this asset was first seen",
not "where everything in this row came from".

**The number of exported assets doesn't change.** The deduplication key is untouched, so the same assets are
emitted as before — only the content of the one that is kept can now be richer. Checked rather than assumed:
running the colliding pair through `DataLoader` on both sides of the change yields one asset either way, and
the only difference is that it now carries the CPE instead of `None`.

**Choosing between two conflicting values is deliberately not addressed.** Two versions detected by two
methods can legitimately differ (the HTML generator tag versus what's in the files); deciding which to trust
needs a rule that doesn't exist yet, and inventing one here would be a behaviour change hidden inside a
deduplication fix.

**The missing `ORDER BY` on the query feeding the export is left alone.** Making the order deterministic
would turn a coin flip into a stable outcome, but a stable outcome that drops half of what was detected is
still wrong, so it isn't a substitute for this change. It may be worth a look on its own.

Follow-up to #3011, where this was described as a known limitation