### PR TITLE
Change metric calculation

### DIFF
--- a/artemis/autoarchiver/autoarchiver.py
+++ b/artemis/autoarchiver/autoarchiver.py
@@ -14,6 +14,8 @@ from artemis.json_utils import JSONEncoderAdditionalTypes
 db = DB()
 LOGGER = utils.build_logger(__name__)
 
+MIN_TASK_AGE_BEFORE_ARCHIVING = datetime.timedelta(hours=24)
+
 
 def _save_and_delete_items(items: Iterator[dict[str, Any]], path_suffix: str) -> int:
     output_dir = pathlib.Path(Config.Data.Autoarchiver.AUTOARCHIVER_OUTPUT_PATH)
@@ -73,6 +75,7 @@ def archive_tag(tag: str) -> int:
         db.iter_oldest_task_results_with_tag(
             tag=tag,
             max_length=Config.Data.Autoarchiver.AUTOARCHIVER_PACK_SIZE,
+            time_to=datetime.datetime.now() - MIN_TASK_AGE_BEFORE_ARCHIVING,
         ),
         "_tag_" + tag,
     )
@@ -87,6 +90,11 @@ def archive_old_results(interesting: bool) -> None:
         archive_age_timedelta = datetime.timedelta(
             seconds=Config.Data.Autoarchiver.AUTOARCHIVER_MIN_AGE_SECONDS_NOT_INTERESTING
         )
+
+    archive_age_timedelta = max(
+        archive_age_timedelta,
+        MIN_TASK_AGE_BEFORE_ARCHIVING,
+    )
 
     time_to = datetime.datetime.now() - archive_age_timedelta
     count = db.count_oldest_task_results_before(

--- a/artemis/db.py
+++ b/artemis/db.py
@@ -1,12 +1,12 @@
 import copy
 import dataclasses
-import datetime
 import enum
 import functools
 import hashlib
 import json
 import os
 import shutil
+from datetime import date, datetime, timedelta, timezone
 from typing import Any, Callable, Dict, Generator, List, Optional, Type
 
 from karton.core import Task
@@ -569,7 +569,7 @@ class DB:
             return int(result.rowcount)
 
     def get_task_results_since(
-        self, time_from: datetime.datetime, tag: Optional[str] = None, batch_size: int = 100
+        self, time_from: datetime, tag: Optional[str] = None, batch_size: int = 100
     ) -> Generator[Dict[str, Any], None, None]:
         query = select(TaskResult).filter(TaskResult.created_at >= time_from)  # type: ignore
         if tag:
@@ -577,16 +577,16 @@ class DB:
         return self._iter_results(query, batch_size)
 
     def iter_oldest_task_results_with_tag(
-        self, tag: str, max_length: int, batch_size: int = 100
+        self, tag: str, max_length: int, batch_size: int = 100, time_to: datetime | None = None
     ) -> Generator[Dict[str, Any], None, None]:
-        query = (
-            select(TaskResult).filter(TaskResult.tag == tag).order_by(TaskResult.created_at).limit(max_length)  # type: ignore
-        )
+        query = select(TaskResult).filter(TaskResult.tag == tag).order_by(TaskResult.created_at).limit(max_length)  # type: ignore
+        if time_to is not None:
+            query = query.filter(TaskResult.created_at <= time_to)
         for item in self._iter_results(query, batch_size):
             yield self._strip_internal_db_info(dict(item))
 
     def iter_oldest_task_results_before(
-        self, time_to: datetime.datetime, max_length: int, interesting: bool, batch_size: int = 100
+        self, time_to: datetime, max_length: int, interesting: bool, batch_size: int = 100
     ) -> Generator[Dict[str, Any], None, None]:
         query = select(TaskResult).filter(TaskResult.created_at <= time_to).order_by(TaskResult.created_at)  # type: ignore
 
@@ -600,7 +600,7 @@ class DB:
         for item in self._iter_results(query, batch_size):
             yield self._strip_internal_db_info(dict(item))
 
-    def count_oldest_task_results_before(self, time_to: datetime.datetime, max_length: int, interesting: bool) -> int:
+    def count_oldest_task_results_before(self, time_to: datetime, max_length: int, interesting: bool) -> int:
         with self.session() as session:
             query = select(TaskResult).filter(TaskResult.created_at <= time_to)  # type: ignore
             if interesting:
@@ -611,6 +611,19 @@ class DB:
             subquery = query.subquery()
             result = session.execute(select(func.count()).select_from(subquery)).scalar()
             return result or 0
+
+    def count_interesting_tasks_by_receiver(self, day: date) -> dict[str, int]:
+        start = datetime.combine(day, datetime.min.time()).replace(tzinfo=timezone.utc)
+        end = start + timedelta(days=1)
+        with self.session() as session:
+            rows = session.execute(
+                select(TaskResult.receiver, func.count(TaskResult.id).label("count"))  # type: ignore[arg-type]
+                .where(TaskResult.status == TaskStatus.INTERESTING.value)
+                .where(TaskResult.created_at >= start)
+                .where(TaskResult.created_at < end)
+                .group_by(TaskResult.receiver)
+            ).all()
+        return {row.receiver: row.count for row in rows}
 
     @staticmethod
     def dict_to_str(d: Dict[str, Any]) -> str:
@@ -663,7 +676,7 @@ class DB:
         skip_hooks: bool = False,
         skip_suspicious_reports: bool = False,
         custom_template_arguments: Dict[str, Any] = {},
-        include_only_results_since: Optional[datetime.datetime] = None,
+        include_only_results_since: datetime | None = None,
     ) -> None:
         with self.session() as session:
             task = ReportGenerationTask(
@@ -773,7 +786,7 @@ class DB:
         with self.session() as session:
             return session.query(Tag).all()
 
-    def list_tag_archive_requests(self, min_age: datetime.datetime) -> List[Dict[str, Any]]:
+    def list_tag_archive_requests(self, min_age: datetime) -> List[Dict[str, Any]]:
         with self.session() as session:
             return [
                 self._strip_internal_db_info(item.__dict__)

--- a/artemis/db.py
+++ b/artemis/db.py
@@ -613,7 +613,7 @@ class DB:
             return result or 0
 
     def count_interesting_tasks_by_receiver(self, day: date) -> dict[str, int]:
-        start = datetime.combine(day, datetime.min.time()).replace(tzinfo=timezone.utc)
+        start = datetime.combine(day, datetime.min.time(), tzinfo=timezone.utc)
         end = start + timedelta(days=1)
         with self.session() as session:
             rows = session.execute(

--- a/artemis/metrics.py
+++ b/artemis/metrics.py
@@ -1,5 +1,5 @@
 import time
-from datetime import date, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Generator
 
 from karton.core.backend import KartonBackend, KartonMetrics
@@ -48,7 +48,7 @@ class ArtemisMetricsCollector(Collector):
         )
         queue_lengths: dict[str, int] = {}
         for key in self.backend.redis.scan_iter("karton.queue.*"):
-            karton_name = key.decode().split(":")[-1]
+            karton_name = key.split(":")[-1]
             queue_lengths[karton_name] = queue_lengths.get(karton_name, 0) + self.backend.redis.llen(key)
 
         yield GaugeMetricFamily(
@@ -80,9 +80,15 @@ class ArtemisMetricsCollector(Collector):
         )
 
         interesting = GaugeMetricFamily(
-            "tasks_interesting",
+            "tasks_interesting_status",
             "Karton tasks with interesting findings",
-            labels=["date", "receiver"],
+            labels=["date", "karton"],
+        )
+        today_str = datetime.now(timezone.utc).date().isoformat()
+        interesting_today = GaugeMetricFamily(
+            "tasks_interesting_today",
+            "Karton tasks with interesting findings for the current day",
+            labels=["karton"],
         )
         for key in artemis_redis.scan_iter(f"{ARTEMIS_INTERESTING_TASKS_KEY_PREFIX}*"):
             key_str = key.decode() if isinstance(key, bytes) else key
@@ -90,11 +96,14 @@ class ArtemisMetricsCollector(Collector):
             for field, count in artemis_redis.hgetall(key).items():
                 receiver = field.decode() if isinstance(field, bytes) else field
                 interesting.add_metric([day, receiver], int(count))
+                if day == today_str:
+                    interesting_today.add_metric([receiver], int(count))
         yield interesting
+        yield interesting_today
 
 
 def sync_interesting_findings() -> None:
-    today = date.today()
+    today = datetime.now(timezone.utc).date()
     for day in (today, today - timedelta(days=1)):
         counts = db.count_interesting_tasks_by_receiver(day)
         key = ARTEMIS_INTERESTING_TASKS_KEY_PREFIX + day.isoformat()

--- a/artemis/metrics.py
+++ b/artemis/metrics.py
@@ -1,4 +1,5 @@
 import time
+from datetime import date, timedelta
 from typing import Generator
 
 from karton.core.backend import KartonBackend, KartonMetrics
@@ -10,12 +11,22 @@ from prometheus_client import (
     REGISTRY,
     start_http_server,
 )
-from prometheus_client.core import CounterMetricFamily, GaugeMetricFamily
+from prometheus_client.core import GaugeMetricFamily
 from prometheus_client.registry import Collector
 from redis import Redis
 
 from artemis.config import Config
-from artemis.task_utils import ARTEMIS_INTERESTING_TASKS_NUMBER_KEY
+from artemis.db import DB
+from artemis.task_utils import (
+    ARTEMIS_INTERESTING_TASKS_KEY_PREFIX,
+    INTERESTING_TASKS_REDIS_TTL_SECONDS,
+)
+from artemis.utils import build_logger
+
+db = DB()
+artemis_redis = Redis.from_url(Config.Data.REDIS_CONN_STR)
+LOGGER = build_logger(__name__)
+SYNC_POSTGRES_REDIS_INTERVAL_SECONDS = 3600
 
 
 class ArtemisMetricsCollector(Collector):
@@ -23,9 +34,8 @@ class ArtemisMetricsCollector(Collector):
         # We check the backend redis queue length directly to avoid the long runtimes of
         # KartonState.get_all_tasks()
         self.backend = KartonBackend(config=KartonConfig())
-        self.artemis_redis = Redis.from_url(Config.Data.REDIS_CONN_STR)
 
-    def collect(self) -> Generator[GaugeMetricFamily | CounterMetricFamily, None, None]:
+    def collect(self) -> Generator[GaugeMetricFamily, None, None]:
         yield GaugeMetricFamily(
             "tasks_consumed",
             "Karton tasks consumed",
@@ -37,8 +47,8 @@ class ArtemisMetricsCollector(Collector):
             value=sum(map(int, self.backend.redis.hvals(KartonMetrics.TASK_CRASHED.value))),
         )
         queue_lengths: dict[str, int] = {}
-        for key in self.backend.redis.keys("karton.queue.*"):
-            karton_name = key.split(":")[-1]
+        for key in self.backend.redis.scan_iter("karton.queue.*"):
+            karton_name = key.decode().split(":")[-1]
             queue_lengths[karton_name] = queue_lengths.get(karton_name, 0) + self.backend.redis.llen(key)
 
         yield GaugeMetricFamily(
@@ -69,27 +79,32 @@ class ArtemisMetricsCollector(Collector):
             value=num_tasks_high_level_kartons,
         )
 
-        interesting = {
-            (k.decode() if isinstance(k, bytes) else k): int(v)
-            for k, v in self.artemis_redis.hgetall(ARTEMIS_INTERESTING_TASKS_NUMBER_KEY).items()
-        }
-
-        yield CounterMetricFamily(
+        interesting = GaugeMetricFamily(
             "tasks_interesting",
             "Karton tasks with interesting findings",
-            value=sum(interesting.values()),
+            labels=["date", "receiver"],
         )
+        for key in artemis_redis.scan_iter(f"{ARTEMIS_INTERESTING_TASKS_KEY_PREFIX}*"):
+            key_str = key.decode() if isinstance(key, bytes) else key
+            day = key_str[len(ARTEMIS_INTERESTING_TASKS_KEY_PREFIX) :]
+            for field, count in artemis_redis.hgetall(key).items():
+                receiver = field.decode() if isinstance(field, bytes) else field
+                interesting.add_metric([day, receiver], int(count))
+        yield interesting
 
-        interesting_per_karton = CounterMetricFamily(
-            "tasks_interesting_per_karton",
-            "Karton tasks with interesting findings per karton",
-            labels=["karton"],
-        )
 
-        for karton_name, count in interesting.items():
-            interesting_per_karton.add_metric([karton_name], count)
-
-        yield interesting_per_karton
+def sync_interesting_findings() -> None:
+    today = date.today()
+    for day in (today, today - timedelta(days=1)):
+        counts = db.count_interesting_tasks_by_receiver(day)
+        key = ARTEMIS_INTERESTING_TASKS_KEY_PREFIX + day.isoformat()
+        pipe = artemis_redis.pipeline()
+        pipe.delete(key)
+        if counts:
+            pipe.hset(key, mapping=counts)  # type: ignore[arg-type]
+        pipe.expire(key, INTERESTING_TASKS_REDIS_TTL_SECONDS)
+        pipe.execute()
+    LOGGER.info("Synced interesting task counts for today and yesterday")
 
 
 if __name__ == "__main__":
@@ -99,5 +114,12 @@ if __name__ == "__main__":
     REGISTRY.unregister(PLATFORM_COLLECTOR)
     REGISTRY.unregister(PROCESS_COLLECTOR)
 
+    last_sync_at = 0.0
     while True:
         time.sleep(1)
+        if time.time() - last_sync_at > SYNC_POSTGRES_REDIS_INTERVAL_SECONDS:
+            try:
+                sync_interesting_findings()
+                last_sync_at = time.time()
+            except Exception:
+                LOGGER.exception("Error during sync of interesting task counts")

--- a/artemis/task_utils.py
+++ b/artemis/task_utils.py
@@ -130,7 +130,7 @@ def get_analysis_num_in_progress_tasks(redis: Redis, root_uid: str) -> int:  # t
 
 
 def increment_interesting_tasks_number(redis: Redis, receiver: str) -> None:  # type: ignore[type-arg]
-    key = ARTEMIS_INTERESTING_TASKS_KEY_PREFIX + datetime.today().replace(tzinfo=timezone.utc).isoformat()
+    key = ARTEMIS_INTERESTING_TASKS_KEY_PREFIX + datetime.now(timezone.utc).date().isoformat()
     redis.hincrby(key, receiver, 1)
     redis.expire(key, INTERESTING_TASKS_REDIS_TTL_SECONDS)
 

--- a/artemis/task_utils.py
+++ b/artemis/task_utils.py
@@ -1,4 +1,5 @@
 import urllib
+from datetime import datetime, timezone
 from typing import List
 
 from karton.core import Task
@@ -108,7 +109,8 @@ def get_target_url(task: Task) -> str:
 
 ANALYSIS_NUM_FINISHED_TASKS_KEY_PREFIX = b"analysis-num-finished-tasks-"
 ANALYSIS_NUM_IN_PROGRESS_TASKS_KEY_PREFIX = b"analysis-num-in-progress-tasks-"
-ARTEMIS_INTERESTING_TASKS_NUMBER_KEY = "artemis-tasks-interesting"
+ARTEMIS_INTERESTING_TASKS_KEY_PREFIX = "artemis-tasks-interesting:"
+INTERESTING_TASKS_REDIS_TTL_SECONDS = 7 * 24 * 60 * 60
 
 
 def increase_analysis_num_finished_tasks(redis: Redis, root_uid: str, by: int = 1) -> None:  # type: ignore[type-arg]
@@ -128,7 +130,9 @@ def get_analysis_num_in_progress_tasks(redis: Redis, root_uid: str) -> int:  # t
 
 
 def increment_interesting_tasks_number(redis: Redis, receiver: str) -> None:  # type: ignore[type-arg]
-    redis.hincrby(ARTEMIS_INTERESTING_TASKS_NUMBER_KEY, receiver, 1)
+    key = ARTEMIS_INTERESTING_TASKS_KEY_PREFIX + datetime.today().replace(tzinfo=timezone.utc).isoformat()
+    redis.hincrby(key, receiver, 1)
+    redis.expire(key, INTERESTING_TASKS_REDIS_TTL_SECONDS)
 
 
 def get_task_target(task: Task) -> str:


### PR DESCRIPTION
The previous approach with the counter keeps running into anomalies with 'increase()' function on metric; as it's hard to pinpoint exact problem, this change the approach for easier to visualize tables for daily findings.

As the TTL on redis keys is provided - the label days will be stopped from being fired, therefore finally cleared in metric collector.