### PR TITLE
Add nosql injection detector

### DIFF
--- a/artemis/config.py
+++ b/artemis/config.py
@@ -1276,6 +1276,21 @@ class Config:
                 "Seconds to sleep using the sleep command in time-based OS command injection detection.",
             ] = get_config("COMMAND_INJECTION_TIME_THRESHOLD", default=5, cast=int)
 
+        class NoSqlInjectionDetector:
+            NOSQL_INJECTION_STOP_ON_FIRST_MATCH: Annotated[
+                bool,
+                "Whether to stop scanning after the first NoSQL injection finding.",
+            ] = get_config("NOSQL_INJECTION_STOP_ON_FIRST_MATCH", default=True, cast=bool)
+            NOSQL_INJECTION_MINIMAL_PARAMS_MAX_LEN: Annotated[
+                int,
+                "Maximum number of parameters kept after NoSQL injection parameter minimization.",
+            ] = get_config("NOSQL_INJECTION_MINIMAL_PARAMS_MAX_LEN", default=5, cast=int)
+            NOSQL_INJECTION_NUM_CONFIRMATIONS: Annotated[
+                int,
+                "How many times an operator must reproduce a database error absent from the baseline "
+                "before it is reported as a finding. Guards against a one-off error on a flaky service.",
+            ] = get_config("NOSQL_INJECTION_NUM_CONFIRMATIONS", default=10, cast=int)
+
         class LFIDetector:
             LFI_STOP_ON_FIRST_MATCH: Annotated[
                 bool,

--- a/artemis/crawling.py
+++ b/artemis/crawling.py
@@ -13,6 +13,7 @@ from redis import Redis
 
 from artemis import http_requests, utils
 from artemis.config import Config
+from artemis.modules.data.parameters import URL_PARAMS
 from artemis.modules.data.static_extensions import STATIC_EXTENSIONS
 from artemis.redis_cache import RedisCache
 from artemis.resource_lock import FailedToAcquireLockException, ResourceLock
@@ -250,3 +251,10 @@ def get_links_to_scan(url: str) -> List[str]:
     ]
     random.shuffle(links)
     return links[: Config.Miscellaneous.MAX_URLS_TO_SCAN]
+
+
+def collect_parameters(url: str) -> List[str]:
+    # Union of the parameters already present in the URL, the ones discovered on the page, and the
+    # common names from the wordlist, deduplicated while keeping first-seen order.
+    query_params = list(parse_qs(urlparse(url).query).keys())
+    return list(dict.fromkeys(query_params + get_injectable_parameters(url) + list(URL_PARAMS)))

--- a/artemis/injection_helpers.py
+++ b/artemis/injection_helpers.py
@@ -6,9 +6,8 @@ from artemis.http_requests import HTTPResponse
 
 
 def responses_differ(response_a: HTTPResponse | None, response_b: HTTPResponse | None, threshold: float = 0.9) -> bool:
-    # True when two responses are meaningfully different. A missing response, or a 5xx on either side,
-    # counts as "not different" - a server error is noise (e.g. the server crashing on an unexpected
-    # parameter), not evidence - so the text similarity is only compared when both sides are usable.
+    # A missing response or a 5xx counts as "not different": a server error is noise (e.g. the server
+    # crashing on an unexpected parameter), not evidence.
     if response_a is None or response_b is None:
         return False
     if response_a.status_code >= 500 or response_b.status_code >= 500:
@@ -17,13 +16,11 @@ def responses_differ(response_a: HTTPResponse | None, response_b: HTTPResponse |
 
 
 def create_status_reason(message: list[dict[str, Any]]) -> str:
-    # Stable, deduplicated "<url>: <statement>" summary of the findings.
     return ", ".join(sorted({f"{item.get('url')}: {item.get('statement')}" for item in message}))
 
 
 def deduplicate_findings(message: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    # Drop exact-duplicate findings while keeping first-seen order. Serializing with sorted keys
-    # gives a stable identity for dicts whose keys were built in a different order.
+    # Serializing with sorted keys gives a stable identity for dicts built in a different key order.
     seen: set[str] = set()
     deduplicated: list[dict[str, Any]] = []
     for item in message:
@@ -35,6 +32,5 @@ def deduplicate_findings(message: list[dict[str, Any]]) -> list[dict[str, Any]]:
 
 
 def build_result_data(message: list[dict[str, Any]], statements: dict[str, str], **extra: Any) -> dict[str, Any]:
-    # The result envelope every injection detector saves: the deduplicated findings, the map of
-    # statement codes the reporter reads, and any detector-specific extra keys (e.g. untestable_urls).
+    # The envelope every injection detector saves; `extra` carries detector-specific keys.
     return {"result": deduplicate_findings(message), **extra, "statements": statements}

--- a/artemis/modules/base/injection_helpers.py
+++ b/artemis/modules/base/injection_helpers.py
@@ -1,0 +1,40 @@
+import json
+from difflib import SequenceMatcher
+from typing import Any
+
+from artemis.http_requests import HTTPResponse
+
+
+def responses_differ(response_a: HTTPResponse | None, response_b: HTTPResponse | None, threshold: float = 0.9) -> bool:
+    # True when two responses are meaningfully different. A missing response, or a 5xx on either side,
+    # counts as "not different" - a server error is noise (e.g. the server crashing on an unexpected
+    # parameter), not evidence - so the text similarity is only compared when both sides are usable.
+    if response_a is None or response_b is None:
+        return False
+    if response_a.status_code >= 500 or response_b.status_code >= 500:
+        return False
+    return SequenceMatcher(None, response_a.content, response_b.content).quick_ratio() < threshold
+
+
+def create_status_reason(message: list[dict[str, Any]]) -> str:
+    # Stable, deduplicated "<url>: <statement>" summary of the findings.
+    return ", ".join(sorted({f"{item.get('url')}: {item.get('statement')}" for item in message}))
+
+
+def deduplicate_findings(message: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    # Drop exact-duplicate findings while keeping first-seen order. Serializing with sorted keys
+    # gives a stable identity for dicts whose keys were built in a different order.
+    seen: set[str] = set()
+    deduplicated: list[dict[str, Any]] = []
+    for item in message:
+        item_json = json.dumps(item, sort_keys=True)
+        if item_json not in seen:
+            seen.add(item_json)
+            deduplicated.append(item)
+    return deduplicated
+
+
+def build_result_data(message: list[dict[str, Any]], statements: dict[str, str], **extra: Any) -> dict[str, Any]:
+    # The result envelope every injection detector saves: the deduplicated findings, the map of
+    # statement codes the reporter reads, and any detector-specific extra keys (e.g. untestable_urls).
+    return {"result": deduplicate_findings(message), **extra, "statements": statements}

--- a/artemis/modules/nosql_injection_detector.py
+++ b/artemis/modules/nosql_injection_detector.py
@@ -1,0 +1,313 @@
+import json
+import re
+import uuid
+from enum import Enum
+from typing import Any, Callable, TypeVar
+
+import more_itertools
+from karton.core import Task
+
+from artemis import load_risk_class
+from artemis.binds import Service, TaskStatus, TaskType
+from artemis.config import Config
+from artemis.crawling import collect_parameters, get_links_to_scan, strip_query_string
+from artemis.http_requests import HTTPResponse
+from artemis.module_base import ArtemisBase
+from artemis.modules.base.injection_helpers import (
+    build_result_data,
+    create_status_reason,
+    responses_differ,
+)
+from artemis.nosql_injection_data import (
+    BLIND_FALSE_OPERATOR,
+    BLIND_TRUE_OPERATOR,
+    BRACKET_OPERATOR_PAYLOADS,
+    JSON_OPERATOR_PAYLOADS,
+    NOSQL_ERROR_MESSAGES,
+    PARAMS_PER_BATCH,
+)
+from artemis.task_utils import get_target_url
+
+JSON_HEADERS = {"Content-Type": "application/json"}
+
+# A random value no record holds ("$ne" then matches every record, "$eq" none), kept to 8 hex chars
+# so that a full batch of bracket parameters stays under the URL-length limit.
+UNLIKELY_VALUE = uuid.uuid4().hex[:8]
+
+T = TypeVar("T")
+
+
+class Statements(Enum):
+    nosql_injection = "nosql_injection"
+    nosql_injection_json_body = "nosql_injection_json_body"
+    nosql_injection_blind = "nosql_injection_blind"
+
+
+@load_risk_class.load_risk_class(load_risk_class.LoadRiskClass.HIGH)
+class NoSqlInjectionDetector(ArtemisBase):
+    """
+    Module for detecting MongoDB-style NoSQL injection vulnerabilities.
+    """
+
+    num_retries = Config.Miscellaneous.SLOW_MODULE_NUM_RETRIES
+    identity = "nosql_injection_detector"
+    filters = [
+        {"type": TaskType.SERVICE.value, "service": Service.HTTP.value},
+    ]
+
+    @staticmethod
+    def _baseline_operator(operator: str) -> str:
+        # Removing the leading "$" yields a key the query engine reads as a literal subdocument
+        # field rather than an operator, so the baseline request differs from the payload request
+        # only in whether an operator is present.
+        return operator.removeprefix("$")
+
+    @staticmethod
+    def _build_bracket_url(url: str, params: list[str], operator: str, value: str) -> str:
+        # The brackets and "$" are sent literally so the target's query parser reads them as a nested
+        # operator object; percent-encoding them would decode to the same thing before parsing.
+        base = strip_query_string(url)
+        query = "&".join(f"{name}[{operator}]={value}" for name in params)
+        return f"{base}?{query}"
+
+    @staticmethod
+    def _build_json_body(params: list[str], operator: str, value: Any) -> str:
+        return json.dumps({name: {operator: value} for name in params})
+
+    def _contains_error(self, url: str, response: HTTPResponse | None) -> str | None:
+        if response is None:
+            return None
+
+        for message in NOSQL_ERROR_MESSAGES:
+            if re.search(message, response.content):
+                self.log.debug("Matched NoSQL error: %s on %s", message, url)
+                return message
+        return None
+
+    def _probe_get(self, url: str, params: list[str], operator: str, value: str) -> tuple[str | None, bool]:
+        payload_url = self._build_bracket_url(url, params, operator, value)
+        baseline_url = self._build_bracket_url(url, params, self._baseline_operator(operator), value)
+
+        response_payload = self.forgiving_http_get(payload_url)
+        response_baseline = self.forgiving_http_get(baseline_url)
+        if response_payload is None or response_baseline is None:
+            return None, False
+
+        error = self._contains_error(payload_url, response_payload)
+        if error and not self._contains_error(baseline_url, response_baseline):
+            return error, True
+        return None, True
+
+    def _probe_post(self, url: str, params: list[str], operator: str, value: Any) -> tuple[str | None, bool]:
+        base = strip_query_string(url)
+        payload_body = self._build_json_body(params, operator, value)
+        baseline_body = self._build_json_body(params, self._baseline_operator(operator), value)
+
+        response_payload = self.forgiving_http_post(base, data=payload_body, headers=JSON_HEADERS)
+        response_baseline = self.forgiving_http_post(base, data=baseline_body, headers=JSON_HEADERS)
+        if response_payload is None or response_baseline is None:
+            return None, False
+
+        error = self._contains_error(base, response_payload)
+        if error and not self._contains_error(base, response_baseline):
+            return error, True
+        return None, True
+
+    def _has_dynamic_content(self, url: str) -> bool:
+        # Two identical requests that already differ mean the endpoint is non-deterministic (timestamps,
+        # tokens), so the blind differential below would flag it on every run. Skip those.
+        return responses_differ(self.forgiving_http_get(url), self.forgiving_http_get(url))
+
+    def _probe_boolean_get(self, url: str, params: list[str]) -> tuple[dict[str, str] | None, bool]:
+        # Blind probe: "$ne" matches (almost) every record while "$eq" matches none, so a difference
+        # between the two responses proves the operator reached the query even when no error leaks.
+        true_url = self._build_bracket_url(url, params, BLIND_TRUE_OPERATOR, UNLIKELY_VALUE)
+        false_url = self._build_bracket_url(url, params, BLIND_FALSE_OPERATOR, UNLIKELY_VALUE)
+
+        response_true = self.forgiving_http_get(true_url)
+        response_false = self.forgiving_http_get(false_url)
+        if response_true is None or response_false is None:
+            return None, False
+
+        if responses_differ(response_true, response_false):
+            return {"true": true_url, "false": false_url}, True
+        return None, True
+
+    def _probe_boolean_post(self, url: str, params: list[str]) -> tuple[dict[str, str] | None, bool]:
+        base = strip_query_string(url)
+        true_body = self._build_json_body(params, BLIND_TRUE_OPERATOR, UNLIKELY_VALUE)
+        false_body = self._build_json_body(params, BLIND_FALSE_OPERATOR, UNLIKELY_VALUE)
+
+        response_true = self.forgiving_http_post(base, data=true_body, headers=JSON_HEADERS)
+        response_false = self.forgiving_http_post(base, data=false_body, headers=JSON_HEADERS)
+        if response_true is None or response_false is None:
+            return None, False
+
+        if responses_differ(response_true, response_false):
+            return {"true": true_body, "false": false_body}, True
+        return None, True
+
+    def _confirm(self, probe: Callable[..., tuple[T | None, bool]], *args: Any) -> tuple[T | None, bool]:
+        """Re-runs a probe and confirms it only when every run reproduces the match, returning as soon
+        as one run disagrees. The second value reports whether any run completed both its requests, so
+        the caller can tell a clean result from one where the target could not be reached."""
+        any_completed = False
+        confirmed: T | None = None
+        for _ in range(max(1, Config.Modules.NoSqlInjectionDetector.NOSQL_INJECTION_NUM_CONFIRMATIONS)):
+            matched, completed = probe(*args)
+            if completed:
+                any_completed = True
+            if not completed or matched is None:
+                return None, any_completed
+            confirmed = matched
+        return confirmed, any_completed
+
+    def minimize_parameters(
+        self, url: str, params: list[str], probe: Callable[..., tuple[Any, bool]], *probe_args: Any
+    ) -> list[str]:
+        """Finds the minimal set of parameters that still triggers the match on their own, capped at
+        ``NOSQL_INJECTION_MINIMAL_PARAMS_MAX_LEN``. Falls back to the full batch when no single
+        parameter reproduces it. Works for any probe (error-based or blind) via ``probe_args``."""
+        minimal: list[str] = []
+        for param in params:
+            matched, _ = probe(url, [param], *probe_args)
+            if matched:
+                minimal.append(param)
+            if len(minimal) >= Config.Modules.NoSqlInjectionDetector.NOSQL_INJECTION_MINIMAL_PARAMS_MAX_LEN:
+                break
+
+        if minimal:
+            self.log.info("NoSQL injection parameter minimization: %s -> %s", params, minimal)
+            return minimal
+        return params
+
+    def scan(self, urls: list[str]) -> tuple[list[dict[str, Any]], list[str]]:
+        self.log.info("Scanning URLs: %s", urls)
+        message: list[dict[str, Any]] = []
+        untestable_urls: list[str] = []
+        stop_on_first_match = Config.Modules.NoSqlInjectionDetector.NOSQL_INJECTION_STOP_ON_FIRST_MATCH
+
+        for current_url in urls:
+            all_params = collect_parameters(current_url)
+            blind_enabled = not self._has_dynamic_content(current_url)
+
+            url_completed = False
+            for param_batch in more_itertools.batched(all_params, PARAMS_PER_BATCH):
+                batch = list(param_batch)
+
+                for operator, value in BRACKET_OPERATOR_PAYLOADS:
+                    matched, completed = self._confirm(self._probe_get, current_url, batch, operator, value)
+                    url_completed = url_completed or completed
+                    if matched:
+                        minimal = self.minimize_parameters(current_url, batch, self._probe_get, operator, value)
+                        message.append(
+                            {
+                                "url": self._build_bracket_url(current_url, minimal, operator, value),
+                                "method": "GET",
+                                "parameters": minimal,
+                                "payload": f"[{operator}]={value}",
+                                "matched_error": matched,
+                                "statement": "It appears that this URL is vulnerable to NoSQL injection",
+                                "code": Statements.nosql_injection.value,
+                            }
+                        )
+                        if stop_on_first_match:
+                            return message, untestable_urls
+
+                for operator, value in JSON_OPERATOR_PAYLOADS:
+                    matched, completed = self._confirm(self._probe_post, current_url, batch, operator, value)
+                    url_completed = url_completed or completed
+                    if matched:
+                        minimal = self.minimize_parameters(current_url, batch, self._probe_post, operator, value)
+                        message.append(
+                            {
+                                "url": strip_query_string(current_url),
+                                "method": "POST",
+                                "parameters": minimal,
+                                "payload": self._build_json_body(minimal, operator, value),
+                                "matched_error": matched,
+                                "statement": "It appears that this URL is vulnerable to NoSQL injection through a JSON body",
+                                "code": Statements.nosql_injection_json_body.value,
+                            }
+                        )
+                        if stop_on_first_match:
+                            return message, untestable_urls
+
+                if not blind_enabled:
+                    continue
+
+                blind_matched, completed = self._confirm(self._probe_boolean_get, current_url, batch)
+                url_completed = url_completed or completed
+                if blind_matched:
+                    minimal = self.minimize_parameters(current_url, batch, self._probe_boolean_get)
+                    message.append(
+                        {
+                            "url": self._build_bracket_url(current_url, minimal, BLIND_TRUE_OPERATOR, UNLIKELY_VALUE),
+                            "method": "GET",
+                            "parameters": minimal,
+                            "payload": f"[{BLIND_TRUE_OPERATOR}]={UNLIKELY_VALUE}",
+                            "baseline": f"[{BLIND_FALSE_OPERATOR}]={UNLIKELY_VALUE}",
+                            "statement": "It appears that this URL is vulnerable to blind NoSQL injection",
+                            "code": Statements.nosql_injection_blind.value,
+                        }
+                    )
+                    if stop_on_first_match:
+                        return message, untestable_urls
+
+                blind_matched, completed = self._confirm(self._probe_boolean_post, current_url, batch)
+                url_completed = url_completed or completed
+                if blind_matched:
+                    minimal = self.minimize_parameters(current_url, batch, self._probe_boolean_post)
+                    message.append(
+                        {
+                            "url": strip_query_string(current_url),
+                            "method": "POST",
+                            "parameters": minimal,
+                            "payload": self._build_json_body(minimal, BLIND_TRUE_OPERATOR, UNLIKELY_VALUE),
+                            "baseline": self._build_json_body(minimal, BLIND_FALSE_OPERATOR, UNLIKELY_VALUE),
+                            "statement": "It appears that this URL is vulnerable to blind NoSQL injection through a JSON body",
+                            "code": Statements.nosql_injection_blind.value,
+                        }
+                    )
+                    if stop_on_first_match:
+                        return message, untestable_urls
+
+            if not url_completed:
+                untestable_urls.append(current_url)
+
+        return message, untestable_urls
+
+    def run(self, current_task: Task) -> None:
+        url = get_target_url(current_task)
+
+        scanned = get_links_to_scan(url)
+
+        message, untestable_urls = self.scan(urls=scanned)
+
+        if message:
+            status = TaskStatus.INTERESTING
+            status_reason = create_status_reason(message)
+        elif scanned and len(untestable_urls) == len(scanned):
+            # Every discovered URL failed its baseline request, so nothing could actually be tested.
+            # A failed check must be saved as an error, not as a clean OK with no findings.
+            status = TaskStatus.ERROR
+            status_reason = "Could not test any discovered URL: " + ", ".join(untestable_urls)
+        else:
+            status = TaskStatus.OK
+            status_reason = None
+
+        data = build_result_data(
+            message,
+            {
+                "nosql_injection": Statements.nosql_injection.value,
+                "nosql_injection_json_body": Statements.nosql_injection_json_body.value,
+                "nosql_injection_blind": Statements.nosql_injection_blind.value,
+            },
+            untestable_urls=untestable_urls,
+        )
+
+        self.save_task_result(task=current_task, status=status, status_reason=status_reason, data=data)
+
+
+if __name__ == "__main__":
+    NoSqlInjectionDetector.parallel_loop()

--- a/artemis/modules/nosql_injection_detector.py
+++ b/artemis/modules/nosql_injection_detector.py
@@ -2,7 +2,7 @@ import json
 import re
 import uuid
 from enum import Enum
-from typing import Any, Callable, TypeVar
+from typing import Any, Callable, Iterator, TypeVar
 
 import more_itertools
 from karton.core import Task
@@ -12,12 +12,12 @@ from artemis.binds import Service, TaskStatus, TaskType
 from artemis.config import Config
 from artemis.crawling import collect_parameters, get_links_to_scan, strip_query_string
 from artemis.http_requests import HTTPResponse
-from artemis.module_base import ArtemisBase
-from artemis.modules.base.injection_helpers import (
+from artemis.injection_helpers import (
     build_result_data,
     create_status_reason,
     responses_differ,
 )
+from artemis.module_base import ArtemisBase
 from artemis.nosql_injection_data import (
     BLIND_FALSE_OPERATOR,
     BLIND_TRUE_OPERATOR,
@@ -30,8 +30,8 @@ from artemis.task_utils import get_target_url
 
 JSON_HEADERS = {"Content-Type": "application/json"}
 
-# A random value no record holds ("$ne" then matches every record, "$eq" none), kept to 8 hex chars
-# so that a full batch of bracket parameters stays under the URL-length limit.
+# Randomly generated value that is unlikely to exist in any record ("$ne" then matches every record,
+# "$eq" none), kept to 8 hex chars so a full batch of bracket parameters stays under the URL-length limit.
 UNLIKELY_VALUE = uuid.uuid4().hex[:8]
 
 T = TypeVar("T")
@@ -113,10 +113,19 @@ class NoSqlInjectionDetector(ArtemisBase):
             return error, True
         return None, True
 
-    def _has_dynamic_content(self, url: str) -> bool:
-        # Two identical requests that already differ mean the endpoint is non-deterministic (timestamps,
-        # tokens), so the blind differential below would flag it on every run. Skip those.
+    def _has_dynamic_get_content(self, url: str) -> bool:
+        # Two identical GET requests that already differ mean the endpoint is non-deterministic
+        # (timestamps, tokens), so the blind differential below would flag it on every run. Skip those.
         return responses_differ(self.forgiving_http_get(url), self.forgiving_http_get(url))
+
+    def _has_dynamic_post_content(self, url: str) -> bool:
+        # Same guard on POST: the GET check says nothing about how the endpoint answers a JSON body, so a
+        # noisy POST endpoint would false-positive and a real vuln would be skipped on GET noise alone.
+        base = strip_query_string(url)
+        body = json.dumps({})
+        first = self.forgiving_http_post(base, data=body, headers=JSON_HEADERS)
+        second = self.forgiving_http_post(base, data=body, headers=JSON_HEADERS)
+        return responses_differ(first, second)
 
     def _probe_boolean_get(self, url: str, params: list[str]) -> tuple[dict[str, str] | None, bool]:
         # Blind probe: "$ne" matches (almost) every record while "$eq" matches none, so a difference
@@ -189,93 +198,118 @@ class NoSqlInjectionDetector(ArtemisBase):
 
         for current_url in urls:
             all_params = collect_parameters(current_url)
-            blind_enabled = not self._has_dynamic_content(current_url)
+            if not all_params:
+                # collect_parameters unions in the URL_PARAMS wordlist, so this is rare - but bailing here
+                # keeps a param-less URL from firing probes or being counted untestable and forcing an ERROR.
+                continue
 
-            url_completed = False
-            for param_batch in more_itertools.batched(all_params, PARAMS_PER_BATCH):
-                batch = list(param_batch)
-
-                for operator, value in BRACKET_OPERATOR_PAYLOADS:
-                    matched, completed = self._confirm(self._probe_get, current_url, batch, operator, value)
-                    url_completed = url_completed or completed
-                    if matched:
-                        minimal = self.minimize_parameters(current_url, batch, self._probe_get, operator, value)
-                        message.append(
-                            {
-                                "url": self._build_bracket_url(current_url, minimal, operator, value),
-                                "method": "GET",
-                                "parameters": minimal,
-                                "payload": f"[{operator}]={value}",
-                                "matched_error": matched,
-                                "statement": "It appears that this URL is vulnerable to NoSQL injection",
-                                "code": Statements.nosql_injection.value,
-                            }
-                        )
-                        if stop_on_first_match:
-                            return message, untestable_urls
-
-                for operator, value in JSON_OPERATOR_PAYLOADS:
-                    matched, completed = self._confirm(self._probe_post, current_url, batch, operator, value)
-                    url_completed = url_completed or completed
-                    if matched:
-                        minimal = self.minimize_parameters(current_url, batch, self._probe_post, operator, value)
-                        message.append(
-                            {
-                                "url": strip_query_string(current_url),
-                                "method": "POST",
-                                "parameters": minimal,
-                                "payload": self._build_json_body(minimal, operator, value),
-                                "matched_error": matched,
-                                "statement": "It appears that this URL is vulnerable to NoSQL injection through a JSON body",
-                                "code": Statements.nosql_injection_json_body.value,
-                            }
-                        )
-                        if stop_on_first_match:
-                            return message, untestable_urls
-
-                if not blind_enabled:
-                    continue
-
-                blind_matched, completed = self._confirm(self._probe_boolean_get, current_url, batch)
-                url_completed = url_completed or completed
-                if blind_matched:
-                    minimal = self.minimize_parameters(current_url, batch, self._probe_boolean_get)
-                    message.append(
-                        {
-                            "url": self._build_bracket_url(current_url, minimal, BLIND_TRUE_OPERATOR, UNLIKELY_VALUE),
-                            "method": "GET",
-                            "parameters": minimal,
-                            "payload": f"[{BLIND_TRUE_OPERATOR}]={UNLIKELY_VALUE}",
-                            "baseline": f"[{BLIND_FALSE_OPERATOR}]={UNLIKELY_VALUE}",
-                            "statement": "It appears that this URL is vulnerable to blind NoSQL injection",
-                            "code": Statements.nosql_injection_blind.value,
-                        }
-                    )
-                    if stop_on_first_match:
-                        return message, untestable_urls
-
-                blind_matched, completed = self._confirm(self._probe_boolean_post, current_url, batch)
-                url_completed = url_completed or completed
-                if blind_matched:
-                    minimal = self.minimize_parameters(current_url, batch, self._probe_boolean_post)
-                    message.append(
-                        {
-                            "url": strip_query_string(current_url),
-                            "method": "POST",
-                            "parameters": minimal,
-                            "payload": self._build_json_body(minimal, BLIND_TRUE_OPERATOR, UNLIKELY_VALUE),
-                            "baseline": self._build_json_body(minimal, BLIND_FALSE_OPERATOR, UNLIKELY_VALUE),
-                            "statement": "It appears that this URL is vulnerable to blind NoSQL injection through a JSON body",
-                            "code": Statements.nosql_injection_blind.value,
-                        }
-                    )
-                    if stop_on_first_match:
-                        return message, untestable_urls
-
-            if not url_completed:
+            findings, completed = self._scan_url(current_url, all_params, stop_on_first_match)
+            message.extend(findings)
+            if findings and stop_on_first_match:
+                return message, untestable_urls
+            # Not one probe reached its baseline, so this URL was never actually tested.
+            if not completed:
                 untestable_urls.append(current_url)
 
         return message, untestable_urls
+
+    def _scan_url(
+        self, current_url: str, all_params: list[str], stop_on_first_match: bool
+    ) -> tuple[list[dict[str, Any]], bool]:
+        # The determinism guards are measured once per URL, not per batch, to keep the request count down.
+        findings: list[dict[str, Any]] = []
+        completed = False
+
+        blind_get_enabled = not self._has_dynamic_get_content(current_url)
+        blind_post_enabled = not self._has_dynamic_post_content(current_url)
+
+        for param_batch in more_itertools.batched(all_params, PARAMS_PER_BATCH):
+            batch = list(param_batch)
+            for finding, done in self._iter_batch_findings(current_url, batch, blind_get_enabled, blind_post_enabled):
+                completed = completed or done
+                if finding is not None:
+                    findings.append(finding)
+                    if stop_on_first_match:
+                        return findings, completed
+
+        return findings, completed
+
+    def _iter_batch_findings(
+        self, current_url: str, batch: list[str], blind_get_enabled: bool, blind_post_enabled: bool
+    ) -> Iterator[tuple[dict[str, Any] | None, bool]]:
+        # Lazy on purpose: when the caller stops on the first match, the remaining probes never fire.
+        for operator, value in BRACKET_OPERATOR_PAYLOADS:
+            yield self._check_error_get(current_url, batch, operator, value)
+        for operator, value in JSON_OPERATOR_PAYLOADS:
+            yield self._check_error_post(current_url, batch, operator, value)
+        if blind_get_enabled:
+            yield self._check_blind_get(current_url, batch)
+        if blind_post_enabled:
+            yield self._check_blind_post(current_url, batch)
+
+    def _check_error_get(
+        self, current_url: str, batch: list[str], operator: str, value: str
+    ) -> tuple[dict[str, Any] | None, bool]:
+        matched, completed = self._confirm(self._probe_get, current_url, batch, operator, value)
+        if matched is None:
+            return None, completed
+        minimal = self.minimize_parameters(current_url, batch, self._probe_get, operator, value)
+        return {
+            "url": self._build_bracket_url(current_url, minimal, operator, value),
+            "method": "GET",
+            "parameters": minimal,
+            "payload": f"[{operator}]={value}",
+            "matched_error": matched,
+            "statement": "It appears that this URL is vulnerable to NoSQL injection",
+            "code": Statements.nosql_injection.value,
+        }, completed
+
+    def _check_error_post(
+        self, current_url: str, batch: list[str], operator: str, value: Any
+    ) -> tuple[dict[str, Any] | None, bool]:
+        matched, completed = self._confirm(self._probe_post, current_url, batch, operator, value)
+        if matched is None:
+            return None, completed
+        minimal = self.minimize_parameters(current_url, batch, self._probe_post, operator, value)
+        return {
+            "url": strip_query_string(current_url),
+            "method": "POST",
+            "parameters": minimal,
+            "payload": self._build_json_body(minimal, operator, value),
+            "matched_error": matched,
+            "statement": "It appears that this URL is vulnerable to NoSQL injection through a JSON body",
+            "code": Statements.nosql_injection_json_body.value,
+        }, completed
+
+    def _check_blind_get(self, current_url: str, batch: list[str]) -> tuple[dict[str, Any] | None, bool]:
+        matched, completed = self._confirm(self._probe_boolean_get, current_url, batch)
+        if matched is None:
+            return None, completed
+        minimal = self.minimize_parameters(current_url, batch, self._probe_boolean_get)
+        return {
+            "url": self._build_bracket_url(current_url, minimal, BLIND_TRUE_OPERATOR, UNLIKELY_VALUE),
+            "method": "GET",
+            "parameters": minimal,
+            "payload": f"[{BLIND_TRUE_OPERATOR}]={UNLIKELY_VALUE}",
+            "baseline": f"[{BLIND_FALSE_OPERATOR}]={UNLIKELY_VALUE}",
+            "statement": "It appears that this URL is vulnerable to blind NoSQL injection",
+            "code": Statements.nosql_injection_blind.value,
+        }, completed
+
+    def _check_blind_post(self, current_url: str, batch: list[str]) -> tuple[dict[str, Any] | None, bool]:
+        matched, completed = self._confirm(self._probe_boolean_post, current_url, batch)
+        if matched is None:
+            return None, completed
+        minimal = self.minimize_parameters(current_url, batch, self._probe_boolean_post)
+        return {
+            "url": strip_query_string(current_url),
+            "method": "POST",
+            "parameters": minimal,
+            "payload": self._build_json_body(minimal, BLIND_TRUE_OPERATOR, UNLIKELY_VALUE),
+            "baseline": self._build_json_body(minimal, BLIND_FALSE_OPERATOR, UNLIKELY_VALUE),
+            "statement": "It appears that this URL is vulnerable to blind NoSQL injection through a JSON body",
+            "code": Statements.nosql_injection_blind.value,
+        }, completed
 
     def run(self, current_task: Task) -> None:
         url = get_target_url(current_task)
@@ -288,8 +322,7 @@ class NoSqlInjectionDetector(ArtemisBase):
             status = TaskStatus.INTERESTING
             status_reason = create_status_reason(message)
         elif scanned and len(untestable_urls) == len(scanned):
-            # Every discovered URL failed its baseline request, so nothing could actually be tested.
-            # A failed check must be saved as an error, not as a clean OK with no findings.
+            # Every URL failed its baseline, so this is an error, not a clean OK with no findings.
             status = TaskStatus.ERROR
             status_reason = "Could not test any discovered URL: " + ", ".join(untestable_urls)
         else:

--- a/artemis/modules/orm_injection_detector.py
+++ b/artemis/modules/orm_injection_detector.py
@@ -1,6 +1,4 @@
-import json
 import uuid
-from difflib import SequenceMatcher
 from enum import Enum
 from typing import Any, Callable, Optional
 from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
@@ -10,14 +8,13 @@ from karton.core import Task
 from artemis import load_risk_class
 from artemis.binds import Service, TaskStatus, TaskType
 from artemis.config import Config
-from artemis.crawling import (
-    get_injectable_parameters,
-    get_links_to_scan,
-    strip_query_string,
-)
-from artemis.http_requests import HTTPResponse
+from artemis.crawling import collect_parameters, get_links_to_scan, strip_query_string
 from artemis.module_base import ArtemisBase
-from artemis.modules.data.parameters import URL_PARAMS
+from artemis.modules.base.injection_helpers import (
+    build_result_data,
+    create_status_reason,
+    responses_differ,
+)
 from artemis.orm_injection_data import (
     ORM_LOOKUP_SUFFIXES,
     SENSITIVE_FIELD_PROBES,
@@ -49,29 +46,6 @@ class OrmInjectionDetector(ArtemisBase):
         {"type": TaskType.SERVICE.value, "service": Service.HTTP.value},
     ]
 
-    @staticmethod
-    def _get_response_text(response: Optional[HTTPResponse]) -> str:
-        if response is None:
-            return ""
-        return response.content
-
-    def _responses_differ(self, response_a: Optional[HTTPResponse], response_b: Optional[HTTPResponse]) -> bool:
-        if response_a is None or response_b is None:
-            return False
-
-        # Skip server errors — a 5xx is noise (e.g. the server crashing on an unexpected param),
-        # not evidence of ORM processing. 4xx responses are kept as some apps return e.g. 404
-        # for "no matching records".
-        status_a = response_a.status_code
-        status_b = response_b.status_code
-        if status_a >= 500 or status_b >= 500:
-            return False
-
-        text_a = self._get_response_text(response_a)
-        text_b = self._get_response_text(response_b)
-
-        return SequenceMatcher(None, text_a, text_b).quick_ratio() < 0.9
-
     def _build_url_with_params(self, base_url: str, params: dict[str, str]) -> str:
         parsed = urlparse(base_url)
         existing_params = parse_qs(parsed.query)
@@ -86,7 +60,7 @@ class OrmInjectionDetector(ArtemisBase):
         produce false positives."""
         response_a = self.forgiving_http_get(url)
         response_b = self.forgiving_http_get(url)
-        return self._responses_differ(response_a, response_b)
+        return responses_differ(response_a, response_b)
 
     def _test_lookup_suffix(
         self, original_url: str, param_name: str, suffix: str, likely_value: str
@@ -109,7 +83,7 @@ class OrmInjectionDetector(ArtemisBase):
         response_likely = self.forgiving_http_get(url_likely)
         response_unlikely = self.forgiving_http_get(url_unlikely)
 
-        if self._responses_differ(response_likely, response_unlikely):
+        if responses_differ(response_likely, response_unlikely):
             return {"matching_url": url_likely, "baseline_url": url_unlikely}
         return None
 
@@ -128,7 +102,7 @@ class OrmInjectionDetector(ArtemisBase):
         response_probe = self.forgiving_http_get(url_with_probe)
         response_unlikely = self.forgiving_http_get(url_with_unlikely)
 
-        if self._responses_differ(response_probe, response_unlikely):
+        if responses_differ(response_probe, response_unlikely):
             return {"matching_url": url_with_probe, "baseline_url": url_with_unlikely}
         return None
 
@@ -257,8 +231,7 @@ class OrmInjectionDetector(ArtemisBase):
             query_params = parse_qs(parsed.query)
             base_url = strip_query_string(current_url)
 
-            injectable = get_injectable_parameters(current_url)
-            all_param_names = list(dict.fromkeys(list(query_params.keys()) + injectable + list(URL_PARAMS)))
+            all_param_names = collect_parameters(current_url)
             params_to_test = {name: query_params.get(name, ["test"]) for name in all_param_names}
 
             lookup_results = self._test_django_style_lookups(current_url, params_to_test)
@@ -273,32 +246,6 @@ class OrmInjectionDetector(ArtemisBase):
 
         return message
 
-    @staticmethod
-    def create_status_reason(message: Any) -> str:
-        status_reason = []
-        for injection_message in message:
-            status_reason.append(f"{injection_message.get('url')}: {injection_message.get('statement')}")
-        return ", ".join(set(status_reason))
-
-    @staticmethod
-    def create_data(message: Any) -> dict[str, Any]:
-        seen: set[str] = set()
-        deduplicated_message = []
-        for item in message:
-            item_json = json.dumps(item, sort_keys=True)
-            if item_json not in seen:
-                seen.add(item_json)
-                deduplicated_message.append(item)
-
-        data = {
-            "result": deduplicated_message,
-            "statements": {
-                "orm_injection": Statements.orm_injection.value,
-                "orm_sensitive_field_access": Statements.orm_sensitive_field_access.value,
-            },
-        }
-        return data
-
     def run(self, current_task: Task) -> None:
         url = get_target_url(current_task)
         links = get_links_to_scan(url)
@@ -307,12 +254,18 @@ class OrmInjectionDetector(ArtemisBase):
 
         if message:
             status = TaskStatus.INTERESTING
-            status_reason = self.create_status_reason(message=message)
+            status_reason = create_status_reason(message)
         else:
             status = TaskStatus.OK
             status_reason = None
 
-        data = self.create_data(message=message)
+        data = build_result_data(
+            message,
+            {
+                "orm_injection": Statements.orm_injection.value,
+                "orm_sensitive_field_access": Statements.orm_sensitive_field_access.value,
+            },
+        )
 
         self.save_task_result(task=current_task, status=status, status_reason=status_reason, data=data)
 

--- a/artemis/modules/orm_injection_detector.py
+++ b/artemis/modules/orm_injection_detector.py
@@ -9,12 +9,12 @@ from artemis import load_risk_class
 from artemis.binds import Service, TaskStatus, TaskType
 from artemis.config import Config
 from artemis.crawling import collect_parameters, get_links_to_scan, strip_query_string
-from artemis.module_base import ArtemisBase
-from artemis.modules.base.injection_helpers import (
+from artemis.injection_helpers import (
     build_result_data,
     create_status_reason,
     responses_differ,
 )
+from artemis.module_base import ArtemisBase
 from artemis.orm_injection_data import (
     ORM_LOOKUP_SUFFIXES,
     SENSITIVE_FIELD_PROBES,

--- a/artemis/modules/sql_injection_detector.py
+++ b/artemis/modules/sql_injection_detector.py
@@ -14,8 +14,8 @@ from artemis.binds import Service, TaskStatus, TaskType
 from artemis.config import Config
 from artemis.crawling import get_injectable_parameters, get_links_to_scan
 from artemis.http_requests import HTTPResponse
+from artemis.injection_helpers import build_result_data
 from artemis.module_base import ArtemisBase
-from artemis.modules.base.injection_helpers import build_result_data
 from artemis.modules.data.parameters import URL_PARAMS
 from artemis.sql_injection_data import HEADERS, SQL_ERROR_MESSAGES
 from artemis.task_utils import get_target_url

--- a/artemis/modules/sql_injection_detector.py
+++ b/artemis/modules/sql_injection_detector.py
@@ -15,6 +15,7 @@ from artemis.config import Config
 from artemis.crawling import get_injectable_parameters, get_links_to_scan
 from artemis.http_requests import HTTPResponse
 from artemis.module_base import ArtemisBase
+from artemis.modules.base.injection_helpers import build_result_data
 from artemis.modules.data.parameters import URL_PARAMS
 from artemis.sql_injection_data import HEADERS, SQL_ERROR_MESSAGES
 from artemis.task_utils import get_target_url
@@ -250,24 +251,6 @@ class SqlInjectionDetector(ArtemisBase):
 
             status_reason.append(base_reason)
         return ", ".join(set(status_reason))
-
-    @staticmethod
-    def create_data(message: Any) -> Dict[str, List[str] | dict[str, Any]]:
-        new_message = []
-        for item in message:
-            if item not in new_message:
-                new_message.append(item)
-
-        data = {
-            "result": new_message,
-            "statements": {
-                "sql_injection": Statements.sql_injection.value,
-                "sql_time_based_injection": Statements.sql_time_based_injection.value,
-                "headers_sql_injection": Statements.headers_sql_injection.value,
-                "headers_time_based_sql_injection": Statements.headers_time_based_sql_injection.value,
-            },
-        }
-        return data  # type: ignore
 
     def scan(self, urls: List[str], task: Task) -> List[Dict[str, Any]]:
         self.log.info("Scanning URLs: %s", urls)
@@ -534,7 +517,15 @@ class SqlInjectionDetector(ArtemisBase):
             status = TaskStatus.OK
             status_reason = None
 
-        data = self.create_data(message=message)
+        data = build_result_data(
+            message,
+            {
+                "sql_injection": Statements.sql_injection.value,
+                "sql_time_based_injection": Statements.sql_time_based_injection.value,
+                "headers_sql_injection": Statements.headers_sql_injection.value,
+                "headers_time_based_sql_injection": Statements.headers_time_based_sql_injection.value,
+            },
+        )
 
         self.save_task_result(task=current_task, status=status, status_reason=status_reason, data=data)
 

--- a/artemis/nosql_injection_data.py
+++ b/artemis/nosql_injection_data.py
@@ -1,0 +1,42 @@
+from typing import Any
+
+NOSQL_ERROR_MESSAGES: list[str] = [
+    # MongoDB server / driver
+    "MongoServerError",
+    "MongoError",
+    "MongoServerSelectionError",
+    "MongoInvalidArgumentError",
+    "unknown operator: \\$",
+    "unknown top level operator: \\$",
+    "BSONTypeError",
+    "BSONError",
+    "\\$err",
+    "errmsg",
+    "E11000",
+    # Mongoose ODM
+    "CastError",
+    "Cast to \\w+ failed",
+    "ValidationError",
+    "ValidatorError",
+    "ObjectParameterError",
+    "StrictModeError",
+]
+
+BRACKET_OPERATOR_PAYLOADS: list[tuple[str, str]] = [
+    ("$ne", "1"),
+    ("$gt", ""),
+    ("$regex", ".*"),
+    ("$artemisProbe", "1"),
+]
+
+JSON_OPERATOR_PAYLOADS: list[tuple[str, Any]] = [
+    ("$ne", None),
+    ("$gt", ""),
+    ("$regex", ".*"),
+    ("$artemisProbe", 1),
+]
+
+PARAMS_PER_BATCH = 50
+
+BLIND_TRUE_OPERATOR = "$ne"
+BLIND_FALSE_OPERATOR = "$eq"

--- a/artemis/reporting/modules/nosql_injection_detector/reporter.py
+++ b/artemis/reporting/modules/nosql_injection_detector/reporter.py
@@ -1,0 +1,59 @@
+import os
+import urllib.parse
+from typing import Any, Callable
+
+from artemis.reporting.base.language import Language
+from artemis.reporting.base.normal_form import NormalForm, get_domain_normal_form
+from artemis.reporting.base.report import Report
+from artemis.reporting.base.report_type import ReportType
+from artemis.reporting.base.reporter import Reporter
+from artemis.reporting.base.templating import ReportEmailTemplateFragment
+from artemis.reporting.utils import get_top_level_target
+
+
+class NoSqlInjectionDetectorReporter(Reporter):
+    NOSQL_INJECTION = ReportType("nosql_injection")
+
+    @staticmethod
+    def create_reports(task_result: dict[str, Any], language: Language) -> list[Report]:
+        if task_result["headers"]["receiver"] != "nosql_injection_detector":
+            return []
+
+        if not task_result["status"] == "INTERESTING":
+            return []
+
+        if not isinstance(task_result["result"], dict):
+            return []
+
+        url_parsed = urllib.parse.urlparse(task_result["result"]["result"][0]["url"])
+
+        return [
+            Report(
+                top_level_target=get_top_level_target(task_result),
+                target=f"{url_parsed.scheme}://{url_parsed.netloc}",
+                report_type=NoSqlInjectionDetectorReporter.NOSQL_INJECTION,
+                additional_data=task_result["result"],
+                timestamp=task_result["created_at"],
+            )
+        ]
+
+    @staticmethod
+    def get_email_template_fragments() -> list[ReportEmailTemplateFragment]:
+        return [
+            ReportEmailTemplateFragment.from_file(
+                os.path.join(os.path.dirname(__file__), "template_nosql_injection.jinja2"),
+                priority=8,
+            ),
+        ]
+
+    @staticmethod
+    def get_normal_form_rules() -> dict[ReportType, Callable[[Report], NormalForm]]:
+        """See the docstring in the Reporter class."""
+        return {
+            NoSqlInjectionDetectorReporter.NOSQL_INJECTION: lambda report: Reporter.dict_to_tuple(
+                {
+                    "type": report.report_type,
+                    "target": get_domain_normal_form(urllib.parse.urlparse(report.target).hostname or ""),
+                }
+            )
+        }

--- a/artemis/reporting/modules/nosql_injection_detector/template_nosql_injection.jinja2
+++ b/artemis/reporting/modules/nosql_injection_detector/template_nosql_injection.jinja2
@@ -1,0 +1,40 @@
+{% if "nosql_injection" in data.contains_type %}
+    <li>{% trans %}We identified that the following URLs are vulnerable to NoSQL injection:{% endtrans %}
+        <ul>
+            {% for report in data.reports %}
+                {% if report.report_type == "nosql_injection" %}
+                    {% for message in report.additional_data.result %}
+                        <li>
+                            {{ message.url }} ({% trans %}method:{% endtrans %} {{ message.method }}, {% trans %}parameters:{% endtrans %} {{ message.parameters|join(", ") }})
+                            {% if message.code == report.additional_data.statements.nosql_injection_json_body %}
+                                :
+                                {% trans trimmed %}
+                                    NoSQL injection through a JSON request body: user input is passed directly into a
+                                    database query, so an attacker can send query operators instead of plain values to
+                                    change what the query matches. This can be used to bypass authentication or read
+                                    records the query was not meant to return.
+                                {% endtrans %}
+                            {% else %}
+                                :
+                                {% trans trimmed %}
+                                    NoSQL injection: user input is passed directly into a database query, so an attacker
+                                    can send query operators instead of plain values to change what the query matches.
+                                    This can be used to bypass authentication or read records the query was not meant to
+                                    return.
+                                {% endtrans %}
+                            {% endif %}
+                        </li>
+                    {% endfor %}
+                {% endif %}
+            {% endfor %}
+        </ul>
+        <p>
+            {% trans trimmed %}
+                NoSQL injection occurs when user input reaches a database query without validation, letting an attacker
+                supply query operators (for example the MongoDB operators $ne, $gt or $regex) in place of ordinary
+                values. To fix this, validate that each parameter is of the expected type and reject values that are
+                objects or that contain operator keys before passing them to the database.
+            {% endtrans %}
+        </p>
+    </li>
+{% endif %}

--- a/artemis/reporting/modules/nosql_injection_detector/translations/en_US/LC_MESSAGES/messages.po
+++ b/artemis/reporting/modules/nosql_injection_detector/translations/en_US/LC_MESSAGES/messages.po
@@ -1,0 +1,38 @@
+#: artemis/reporting/modules/nosql_injection_detector/template_nosql_injection.jinja2:2
+msgid "We identified that the following URLs are vulnerable to NoSQL injection:"
+msgstr ""
+
+#: artemis/reporting/modules/nosql_injection_detector/template_nosql_injection.jinja2:8
+msgid "method:"
+msgstr ""
+
+#: artemis/reporting/modules/nosql_injection_detector/template_nosql_injection.jinja2:8
+msgid "parameters:"
+msgstr ""
+
+#: artemis/reporting/modules/nosql_injection_detector/template_nosql_injection.jinja2:11
+msgid ""
+"NoSQL injection through a JSON request body: user input is passed "
+"directly into a database query, so an attacker can send query operators "
+"instead of plain values to change what the query matches. This can be "
+"used to bypass authentication or read records the query was not meant to "
+"return."
+msgstr ""
+
+#: artemis/reporting/modules/nosql_injection_detector/template_nosql_injection.jinja2:19
+msgid ""
+"NoSQL injection: user input is passed directly into a database query, so "
+"an attacker can send query operators instead of plain values to change "
+"what the query matches. This can be used to bypass authentication or read"
+" records the query was not meant to return."
+msgstr ""
+
+#: artemis/reporting/modules/nosql_injection_detector/template_nosql_injection.jinja2:32
+msgid ""
+"NoSQL injection occurs when user input reaches a database query without "
+"validation, letting an attacker supply query operators (for example the "
+"MongoDB operators $ne, $gt or $regex) in place of ordinary values. To fix"
+" this, validate that each parameter is of the expected type and reject "
+"values that are objects or that contain operator keys before passing them"
+" to the database."
+msgstr ""

--- a/artemis/reporting/modules/nosql_injection_detector/translations/pl_PL/LC_MESSAGES/messages.po
+++ b/artemis/reporting/modules/nosql_injection_detector/translations/pl_PL/LC_MESSAGES/messages.po
@@ -1,0 +1,38 @@
+#: artemis/reporting/modules/nosql_injection_detector/template_nosql_injection.jinja2:2
+msgid "We identified that the following URLs are vulnerable to NoSQL injection:"
+msgstr ""
+
+#: artemis/reporting/modules/nosql_injection_detector/template_nosql_injection.jinja2:8
+msgid "method:"
+msgstr ""
+
+#: artemis/reporting/modules/nosql_injection_detector/template_nosql_injection.jinja2:8
+msgid "parameters:"
+msgstr ""
+
+#: artemis/reporting/modules/nosql_injection_detector/template_nosql_injection.jinja2:11
+msgid ""
+"NoSQL injection through a JSON request body: user input is passed "
+"directly into a database query, so an attacker can send query operators "
+"instead of plain values to change what the query matches. This can be "
+"used to bypass authentication or read records the query was not meant to "
+"return."
+msgstr ""
+
+#: artemis/reporting/modules/nosql_injection_detector/template_nosql_injection.jinja2:19
+msgid ""
+"NoSQL injection: user input is passed directly into a database query, so "
+"an attacker can send query operators instead of plain values to change "
+"what the query matches. This can be used to bypass authentication or read"
+" records the query was not meant to return."
+msgstr ""
+
+#: artemis/reporting/modules/nosql_injection_detector/template_nosql_injection.jinja2:32
+msgid ""
+"NoSQL injection occurs when user input reaches a database query without "
+"validation, letting an attacker supply query operators (for example the "
+"MongoDB operators $ne, $gt or $regex) in place of ordinary values. To fix"
+" this, validate that each parameter is of the expected type and reject "
+"values that are objects or that contain operator keys before passing them"
+" to the database."
+msgstr ""

--- a/docker-compose.test-e2e.yaml
+++ b/docker-compose.test-e2e.yaml
@@ -58,6 +58,13 @@ services:
       SQL_INJECTION_STOP_ON_FIRST_MATCH: "false"
     volumes: ["./docker/karton-test.ini:/etc/karton/karton.ini"]
 
+  karton-nosql_injection_detector:
+    <<: *artemis-build
+    env_file: env.test
+    environment:
+      NOSQL_INJECTION_STOP_ON_FIRST_MATCH: "false"
+    volumes: ["./docker/karton-test.ini:/etc/karton/karton.ini"]
+
   karton-system:
     env_file: env.test
     volumes: ["./docker/karton-test.ini:/etc/karton/karton.ini"]

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -31,6 +31,7 @@ services:
 
       SQL_INJECTION_STOP_ON_FIRST_MATCH: "false"
       ORM_INJECTION_STOP_ON_FIRST_MATCH: "false"
+      NOSQL_INJECTION_STOP_ON_FIRST_MATCH: "false"
 
       NUCLEI_INTERACTSH_SERVER: https://interactsh.lab.cert.pl
 
@@ -80,6 +81,10 @@ services:
     image: mysql:5.6
     environment:
       MYSQL_ROOT_PASSWORD: root
+
+  nosql-injection-test-mongo:
+    image: mongo
+    restart: always
 
   test-dast-vuln-app:
     build:
@@ -368,6 +373,16 @@ services:
       context: test/data/orm_injection
       dockerfile: Dockerfile
     restart: on-failure
+
+  test-express-with-nosql-injection:
+    build:
+      context: test/data/nosql_injection
+      dockerfile: Dockerfile
+    restart: on-failure
+    networks:
+      default:
+        aliases:
+          - test-express-with-nosql-injection.local
 
   test-apache-with-sql-injection-postgres:
     build:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -371,6 +371,13 @@ services:
     restart: always
     volumes: ["${DOCKER_COMPOSE_ADDITIONAL_SHARED_DIRECTORY:-./shared}:/shared/"]
 
+  karton-nosql_injection_detector:
+    <<: [*logging, *artemis-build-or-image]
+    command: "python3 -m artemis.modules.nosql_injection_detector"
+    env_file: .env
+    restart: always
+    volumes: ["${DOCKER_COMPOSE_ADDITIONAL_SHARED_DIRECTORY:-./shared}:/shared/"]
+
   karton-sql_injection_detector:
     <<: [*logging, *artemis-build-or-image]
     command: "python3 -m artemis.modules.sql_injection_detector"

--- a/test/data/nosql_injection/Dockerfile
+++ b/test/data/nosql_injection/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:22-slim
+
+WORKDIR /app
+COPY package.json package-lock.json /app/
+RUN npm ci --omit=dev
+COPY app.js /app/
+
+CMD ["node", "app.js"]

--- a/test/data/nosql_injection/app.js
+++ b/test/data/nosql_injection/app.js
@@ -1,0 +1,128 @@
+const express = require("express");
+const { MongoClient } = require("mongodb");
+
+const MONGO_URL = process.env.MONGO_URL || "mongodb://nosql-injection-test-mongo:27017";
+const DB_NAME = "testdb";
+const PORT = 3000;
+
+async function connectWithRetry() {
+  for (;;) {
+    try {
+      const client = new MongoClient(MONGO_URL, { serverSelectionTimeoutMS: 2000 });
+      await client.connect();
+      await client.db(DB_NAME).command({ ping: 1 });
+      return client;
+    } catch (err) {
+      console.log("Waiting for MongoDB:", err.message);
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+  }
+}
+
+async function seed(db) {
+  const items = db.collection("items");
+  if ((await items.countDocuments()) === 0) {
+    await items.insertMany([
+      { q: "first post", title: "First", content: "hello world", id: 1 },
+      { q: "second post", title: "Second", content: "another entry", id: 2 },
+    ]);
+  }
+  const users = db.collection("users");
+  if ((await users.countDocuments()) === 0) {
+    await users.insertMany([
+      { username: "admin", password: "s3cret" },
+      { username: "alice", password: "password123" },
+    ]);
+  }
+}
+
+function pageHtml(count) {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>NoSQL Injection Test App</title></head>
+<body>
+<h1>Item search</h1>
+<form method="get" action="/">
+  <input name="q" placeholder="search text">
+  <input name="id" placeholder="item id">
+  <button type="submit">Search</button>
+</form>
+<form method="post" action="/api/login">
+  <input name="username" placeholder="username">
+  <input name="password" placeholder="password">
+  <button type="submit">Log in</button>
+</form>
+<p>${count} item(s) found.</p>
+<ul>
+  <li><a href="/not_vuln?id=1">safe endpoint</a></li>
+  <li><a href="/noisy">verbose endpoint</a></li>
+  <li><a href="/blind?q=first">error-swallowing endpoint</a></li>
+</ul>
+</body>
+</html>`;
+}
+
+async function main() {
+  const client = await connectWithRetry();
+  const db = client.db(DB_NAME);
+  await seed(db);
+
+  const app = express();
+  app.use(express.json());
+
+  app.get("/", async (req, res) => {
+    try {
+      const results = await db.collection("items").find(req.query).toArray();
+      res.type("html").send(pageHtml(results.length));
+    } catch (err) {
+      res.status(500).type("text/plain").send(String(err));
+    }
+  });
+
+  app.post("/", async (req, res) => {
+    try {
+      const results = await db.collection("items").find(req.body || {}).toArray();
+      res.type("application/json").send(JSON.stringify({ count: results.length }));
+    } catch (err) {
+      res.status(500).type("text/plain").send(String(err));
+    }
+  });
+
+  app.post("/api/login", async (req, res) => {
+    try {
+      const user = await db.collection("users").findOne(req.body || {});
+      res.type("application/json").send(JSON.stringify({ authenticated: Boolean(user) }));
+    } catch (err) {
+      res.status(500).type("text/plain").send(String(err));
+    }
+  });
+
+  app.get("/blind", async (req, res) => {
+    try {
+      const results = await db.collection("items").find(req.query).toArray();
+      res.type("application/json").send(JSON.stringify(results));
+    } catch (err) {
+      res.type("application/json").send("[]");
+    }
+  });
+
+  app.get("/not_vuln", async (req, res) => {
+    const filter = {};
+    for (const key of Object.keys(req.query)) {
+      filter[key] = String(req.query[key]);
+    }
+    const results = await db.collection("items").find(filter).toArray();
+    res.type("application/json").send(JSON.stringify({ count: results.length }));
+  });
+
+  app.get("/noisy", (req, res) => {
+    res.type("html").send("<p>Status errmsg: none. Last CastError: none. ValidationError: none.</p>");
+  });
+
+  app.listen(PORT, () => console.log(`listening on ${PORT}`));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/test/data/nosql_injection/app.js
+++ b/test/data/nosql_injection/app.js
@@ -119,6 +119,12 @@ async function main() {
     res.type("html").send("<p>Status errmsg: none. Last CastError: none. ValidationError: none.</p>");
   });
 
+  // Returns a different body on every request (GET or POST) so the module's determinism guard flags it
+  // as non-deterministic and skips its blind probes instead of matching on the endpoint's own noise.
+  app.all("/dynamic", (req, res) => {
+    res.type("text/plain").send(`nonce ${Date.now()} ${Math.random()}`);
+  });
+
   app.listen(PORT, () => console.log(`listening on ${PORT}`));
 }
 

--- a/test/data/nosql_injection/package-lock.json
+++ b/test/data/nosql_injection/package-lock.json
@@ -1,0 +1,976 @@
+{
+  "name": "nosql-injection-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nosql-injection-test",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "4.22.2",
+        "mongodb": "6.21.0"
+      }
+    },
+    "node_modules/@mongodb-js/saslprep": {
+      "version": "1.4.13",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.13.tgz",
+      "integrity": "sha512-E3Sv4eCYAlKYUTx8S3ioQcDUscOif+8zZ5OnW1IzJ+Tt+EO+ke8mn+Y3FX6N1H79picwbdOavVOb1jPi2EOyrg==",
+      "license": "MIT",
+      "dependencies": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bson": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
+      "integrity": "sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "license": "MIT"
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mongodb": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.21.0.tgz",
+      "integrity": "sha512-URyb/VXMjJ4da46OeSXg+puO39XH9DeQpWCslifrRn9JWugy0D+DvvBvkm2WxmHe61O/H19JM66p1z7RHVkZ6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.3.0",
+        "bson": "^6.10.4",
+        "mongodb-connection-string-url": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0 || ^2.0.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.3.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mongodb-connection-string-url": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.2.tgz",
+      "integrity": "sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^14.1.0 || ^13.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/test/data/nosql_injection/package.json
+++ b/test/data/nosql_injection/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "nosql-injection-test",
+  "version": "1.0.0",
+  "private": true,
+  "main": "app.js",
+  "dependencies": {
+    "express": "4.22.2",
+    "mongodb": "6.21.0"
+  }
+}

--- a/test/modules/test_nosql_injection_detector.py
+++ b/test/modules/test_nosql_injection_detector.py
@@ -1,0 +1,95 @@
+# type: ignore
+from test.base import ArtemisModuleTestCase
+
+from karton.core import Task
+
+from artemis.binds import Service, TaskStatus, TaskType
+from artemis.modules.nosql_injection_detector import NoSqlInjectionDetector
+
+TARGET_HOST = "test-express-with-nosql-injection"
+TARGET = f"http://{TARGET_HOST}:3000"
+
+
+class NoSqlInjectionDetectorTestCase(ArtemisModuleTestCase):
+    karton_class = NoSqlInjectionDetector
+
+    def test_nosql_injection_detector(self) -> None:
+        task = Task(
+            {"type": TaskType.SERVICE.value, "service": Service.HTTP.value},
+            payload={"host": TARGET_HOST, "port": 3000},
+        )
+        self.run_task(task)
+        (call,) = self.mock_db.save_task_result.call_args_list
+
+        self.assertEqual(call.kwargs["status"], TaskStatus.INTERESTING)
+
+        results = call.kwargs["data"]["result"]
+        self.assertTrue(results)
+
+        detected_parameters = set()
+        for result in results:
+            self.assertIn(f"{TARGET_HOST}:3000", result["url"])
+            self.assertNotIn("/noisy", result["url"])
+            self.assertNotIn("/not_vuln", result["url"])
+            detected_parameters.update(result["parameters"])
+
+        self.assertIn("q", detected_parameters)
+        self.assertIn("id", detected_parameters)
+        self.assertIn("username", detected_parameters)
+
+        codes = {result["code"] for result in results}
+        self.assertIn("nosql_injection", codes)
+        self.assertIn("nosql_injection_json_body", codes)
+        self.assertIn("nosql_injection_blind", codes)
+
+    def test_json_body_probe_detects_login_endpoint(self) -> None:
+        matched, completed = self.karton._probe_post(
+            f"{TARGET}/api/login", ["username", "password"], "$artemisProbe", 1
+        )
+        self.assertTrue(completed)
+        self.assertIsNotNone(matched)
+
+    def test_noisy_endpoint_is_not_reported(self) -> None:
+        matched, completed = self.karton._probe_get(f"{TARGET}/noisy", ["id"], "$artemisProbe", "1")
+        self.assertTrue(completed)
+        self.assertIsNone(matched)
+
+    def test_not_vuln_endpoint_is_not_reported(self) -> None:
+        matched, completed = self.karton._probe_get(f"{TARGET}/not_vuln", ["id"], "$artemisProbe", "1")
+        self.assertTrue(completed)
+        self.assertIsNone(matched)
+
+    def test_error_probe_misses_error_swallowing_endpoint(self) -> None:
+        matched, completed = self.karton._probe_get(f"{TARGET}/blind", ["q"], "$artemisProbe", "1")
+        self.assertTrue(completed)
+        self.assertIsNone(matched)
+
+    def test_blind_probe_detects_error_swallowing_endpoint(self) -> None:
+        matched, completed = self.karton._probe_boolean_get(f"{TARGET}/blind", ["q"])
+        self.assertTrue(completed)
+        self.assertIsNotNone(matched)
+
+    def test_blind_probe_not_reported_on_coercing_endpoint(self) -> None:
+        matched, completed = self.karton._probe_boolean_get(f"{TARGET}/not_vuln", ["q"])
+        self.assertTrue(completed)
+        self.assertIsNone(matched)
+
+    def test_blind_probe_not_reported_on_noisy_endpoint(self) -> None:
+        matched, completed = self.karton._probe_boolean_get(f"{TARGET}/noisy", ["id"])
+        self.assertTrue(completed)
+        self.assertIsNone(matched)
+
+    def test_bracket_url_construction(self) -> None:
+        url = self.karton._build_bracket_url(f"{TARGET}/search", ["id", "q"], "$ne", "1")
+        self.assertEqual(url, f"{TARGET}/search?id[$ne]=1&q[$ne]=1")
+
+    def test_baseline_operator_strips_dollar(self) -> None:
+        self.assertEqual(self.karton._baseline_operator("$ne"), "ne")
+        self.assertEqual(self.karton._baseline_operator("$artemisProbe"), "artemisProbe")
+
+    def test_minimize_parameters_caps_and_falls_back(self) -> None:
+        params = ["a", "b", "c"]
+        minimal = self.karton.minimize_parameters(
+            f"{TARGET}/not_vuln", params, self.karton._probe_get, "$artemisProbe", "1"
+        )
+        self.assertEqual(minimal, params)

--- a/test/modules/test_nosql_injection_detector.py
+++ b/test/modules/test_nosql_injection_detector.py
@@ -49,6 +49,12 @@ class NoSqlInjectionDetectorTestCase(ArtemisModuleTestCase):
         self.assertTrue(completed)
         self.assertIsNotNone(matched)
 
+    def test_blind_json_body_probe_detects_login_endpoint(self) -> None:
+        # The login endpoint leaks no error, so only the blind "$ne" vs "$eq" differential catches it.
+        matched, completed = self.karton._probe_boolean_post(f"{TARGET}/api/login", ["password"])
+        self.assertTrue(completed)
+        self.assertIsNotNone(matched)
+
     def test_noisy_endpoint_is_not_reported(self) -> None:
         matched, completed = self.karton._probe_get(f"{TARGET}/noisy", ["id"], "$artemisProbe", "1")
         self.assertTrue(completed)
@@ -78,6 +84,18 @@ class NoSqlInjectionDetectorTestCase(ArtemisModuleTestCase):
         matched, completed = self.karton._probe_boolean_get(f"{TARGET}/noisy", ["id"])
         self.assertTrue(completed)
         self.assertIsNone(matched)
+
+    def test_dynamic_get_content_is_detected(self) -> None:
+        # The GET guard must flag an endpoint that changes on every request and leave a stable one alone,
+        # otherwise the blind GET differential fires on the endpoint's own noise.
+        self.assertTrue(self.karton._has_dynamic_get_content(f"{TARGET}/dynamic"))
+        self.assertFalse(self.karton._has_dynamic_get_content(f"{TARGET}/noisy"))
+
+    def test_dynamic_post_content_is_detected(self) -> None:
+        # The POST guard is measured on its own - a stable GET says nothing about the JSON-body response,
+        # so a deterministic login endpoint must read as stable while the changing one reads as dynamic.
+        self.assertTrue(self.karton._has_dynamic_post_content(f"{TARGET}/dynamic"))
+        self.assertFalse(self.karton._has_dynamic_post_content(f"{TARGET}/api/login"))
 
     def test_bracket_url_construction(self) -> None:
         url = self.karton._build_bracket_url(f"{TARGET}/search", ["id", "q"], "$ne", "1")

--- a/test/unit/test_injection_helpers.py
+++ b/test/unit/test_injection_helpers.py
@@ -1,0 +1,154 @@
+import unittest
+from typing import Any
+
+from artemis.http_requests import HTTPResponse
+from artemis.injection_helpers import (
+    build_result_data,
+    create_status_reason,
+    deduplicate_findings,
+    responses_differ,
+)
+
+
+def make_response(content: str, status_code: int = 200) -> HTTPResponse:
+    return HTTPResponse(
+        status_code=status_code,
+        content_bytes=content.encode("utf-8"),
+        encoding="utf-8",
+        is_redirect=False,
+        url="http://example.com/",
+        headers={},
+    )
+
+
+class TestResponsesDiffer(unittest.TestCase):
+    """responses_differ backs the blind/differential probes in the injection detectors: a
+    difference between two responses is what proves a payload reached the query. Anything that
+    isn't usable evidence must read as "not different" so that it cannot become a finding."""
+
+    def test_identical_content_does_not_differ(self) -> None:
+        self.assertFalse(responses_differ(make_response("hello world"), make_response("hello world")))
+
+    def test_clearly_different_content_differs(self) -> None:
+        self.assertTrue(responses_differ(make_response("a" * 100), make_response("b" * 100)))
+
+    def test_missing_response_does_not_differ(self) -> None:
+        # forgiving_http_get returns None when a request could not be completed - a failed
+        # request is not evidence of anything.
+        self.assertFalse(responses_differ(None, make_response("hello")))
+        self.assertFalse(responses_differ(make_response("hello"), None))
+        self.assertFalse(responses_differ(None, None))
+
+    def test_server_error_does_not_differ(self) -> None:
+        # A 5xx is noise (e.g. the server crashing on an unexpected parameter), not evidence,
+        # even when the two bodies are completely different.
+        self.assertFalse(responses_differ(make_response("a" * 100, status_code=500), make_response("b" * 100)))
+        self.assertFalse(responses_differ(make_response("a" * 100), make_response("b" * 100, status_code=503)))
+
+    def test_client_error_is_still_compared(self) -> None:
+        # Only 5xx is excluded - a 404 vs 200 difference is a legitimate signal.
+        self.assertTrue(responses_differ(make_response("a" * 100, status_code=404), make_response("b" * 100)))
+
+    def test_threshold_is_respected(self) -> None:
+        similar_a = make_response("the quick brown fox jumps over the lazy dog")
+        similar_b = make_response("the quick brown fox jumps over the lazy cat")
+        self.assertFalse(responses_differ(similar_a, similar_b))
+        # The same pair counts as different once almost-perfect similarity is demanded.
+        self.assertTrue(responses_differ(similar_a, similar_b, threshold=1.0))
+
+
+class TestCreateStatusReason(unittest.TestCase):
+    """create_status_reason builds the human-readable status_reason stored per task result."""
+
+    def test_formats_url_and_statement(self) -> None:
+        self.assertEqual(
+            create_status_reason([{"url": "http://example.com/?a=1", "statement": "nosql_injection"}]),
+            "http://example.com/?a=1: nosql_injection",
+        )
+
+    def test_deduplicates_repeated_findings(self) -> None:
+        item = {"url": "http://example.com/", "statement": "nosql_injection"}
+        self.assertEqual(create_status_reason([item, dict(item)]), "http://example.com/: nosql_injection")
+
+    def test_output_is_sorted_and_therefore_stable(self) -> None:
+        # The ordering must not depend on input order or on set iteration order, so that the same
+        # findings always produce the same string across runs.
+        findings: list[dict[str, Any]] = [
+            {"url": f"http://{host}.example.com/", "statement": "nosql_injection"} for host in "ebadc"
+        ]
+        expected = ", ".join(f"http://{host}.example.com/: nosql_injection" for host in "abcde")
+        self.assertEqual(create_status_reason(findings), expected)
+        self.assertEqual(create_status_reason(list(reversed(findings))), expected)
+
+    def test_empty_message_yields_empty_string(self) -> None:
+        self.assertEqual(create_status_reason([]), "")
+
+    def test_missing_keys_do_not_raise(self) -> None:
+        self.assertEqual(create_status_reason([{}]), "None: None")
+
+
+class TestDeduplicateFindings(unittest.TestCase):
+    """deduplicate_findings drops repeated findings before they are saved as a task result."""
+
+    def test_removes_exact_duplicates_keeping_first_seen_order(self) -> None:
+        findings: list[dict[str, Any]] = [{"url": "b"}, {"url": "a"}, {"url": "b"}]
+        self.assertEqual(deduplicate_findings(findings), [{"url": "b"}, {"url": "a"}])
+
+    def test_key_order_does_not_affect_identity(self) -> None:
+        # Findings are built by different code paths, so the same finding can arrive with its
+        # keys in a different order - it is still a duplicate.
+        findings: list[dict[str, Any]] = [{"url": "a", "code": "x"}, {"code": "x", "url": "a"}]
+        self.assertEqual(deduplicate_findings(findings), [{"url": "a", "code": "x"}])
+
+    def test_distinct_findings_are_kept(self) -> None:
+        findings: list[dict[str, Any]] = [{"url": "a"}, {"url": "b"}]
+        self.assertEqual(deduplicate_findings(findings), findings)
+
+    def test_nested_values_are_compared_by_value(self) -> None:
+        findings: list[dict[str, Any]] = [
+            {"url": "a", "parameters": ["p", "q"]},
+            {"url": "a", "parameters": ["p", "q"]},
+            {"url": "a", "parameters": ["q", "p"]},
+        ]
+        self.assertEqual(len(deduplicate_findings(findings)), 2)
+
+    def test_empty_input(self) -> None:
+        self.assertEqual(deduplicate_findings([]), [])
+
+
+class TestBuildResultData(unittest.TestCase):
+    """build_result_data is the result envelope every injection detector saves."""
+
+    def test_deduplicates_and_attaches_statements(self) -> None:
+        statements = {"nosql_injection": "nosql_injection"}
+        result = build_result_data([{"url": "a"}, {"url": "a"}], statements)
+        self.assertEqual(result, {"result": [{"url": "a"}], "statements": statements})
+
+    def test_extra_keys_are_merged(self) -> None:
+        result = build_result_data([], {"s": "s"}, untestable_urls=["http://example.com/"])
+        self.assertEqual(result["untestable_urls"], ["http://example.com/"])
+        self.assertEqual(result["result"], [])
+
+    def test_envelope_contains_result_extras_and_statements(self) -> None:
+        # The full contract in one assertion: findings are deduplicated, detector-specific extras
+        # are merged in alongside, and the statement map the reporter reads is preserved.
+        statements = {"nosql_injection": "nosql_injection"}
+        result = build_result_data(
+            [{"url": "a"}, {"url": "a"}],
+            statements,
+            untestable_urls=["http://example.com/"],
+            scanned_parameters=["q"],
+        )
+        self.assertEqual(
+            result,
+            {
+                "result": [{"url": "a"}],
+                "untestable_urls": ["http://example.com/"],
+                "scanned_parameters": ["q"],
+                "statements": statements,
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds a module for detecting NoSQL (MongoDB-style) injection, where a framework like Express parses `?q[$ne]=1` into a nested object `{q: {$ne: "1"}}` and passes it straight into the query, so a user can control the query structure instead of just a value.

The module detects this two ways. The error-based check injects an operator no engine knows (`$artemisProbe`) together with a baseline that has the `$` stripped, so the same key is read as a plain field name. If the operator reaches the query, MongoDB raises an `unknown operator` error that shows up with the operator but not in the baseline, which a reflection or a WAF can't reproduce. The same check also runs through a JSON request body for login-style endpoints.

The blind check covers what the error-based one misses, like an authentication bypass with `username[$ne]=x` where the app processes the operator but never leaks an error. It compares `[$ne]=<random>` (matches almost everything) against `[$eq]=<random>` (matches nothing) and reports when the responses differ. This is the same idea the ORM detector already uses, so the two now share the response similarity check, the dynamic-content guard, and the confirmation loop (`NOSQL_INJECTION_NUM_CONFIRMATIONS`, 10 by default) that only reports a difference if it reproduces every time.

I've also bundled the shared-helper extraction into this PR. The result-building moves into `artemis/injection_helpers.py` and the parameter collection into `crawling.collect_parameters`, and the SQL and ORM detectors are wired onto them so there's one copy instead of three. It sits at the top level next to `crawling.py` and `task_utils.py` because `artemis/modules/base/` holds base classes that modules subclass, while these are loose functions. `sql_injection_detector` keeps its own `create_status_reason` - it appends the `Headers used:` detail, so it isn't the same function.

The test app is a real Express + MongoDB service with an endpoint that leaks database errors, one that swallows them so only the blind check catches it, and coercing/noisy endpoints to confirm the module doesn't false-positive.