### PR TITLE
emit URL tasks from robots module for pipeline-wide path scanning

### DIFF
--- a/artemis/modules/lfi_detector.py
+++ b/artemis/modules/lfi_detector.py
@@ -38,6 +38,7 @@ class LFIDetector(ArtemisBase):
     identity = "lfi_detector"
     filters = [
         {"type": TaskType.SERVICE.value, "service": Service.HTTP.value},
+        {"type": TaskType.URL.value},
     ]
 
     def create_url_with_batch_payload(self, url: str, param_batch: List[str], payload: str) -> str:

--- a/artemis/modules/robots.py
+++ b/artemis/modules/robots.py
@@ -110,11 +110,31 @@ class RobotsScanner(ArtemisBase):
         result = RobotsResult(response.status_code, groups, self._download(current_task, url, groups))
         return result
 
+    def _emit_url_tasks(self, current_task: Task, url: str, groups: List[RobotsGroup]) -> None:
+        seen: set = set()
+        for g in groups:
+            for path in g.allow + g.disallow:
+                if any(re.match(p, path) for p in NOT_INTERESTING_PATHS):
+                    continue
+                if "*" in path:
+                    continue
+                path = path.rstrip("$")
+                full_url = f"{url}{path}"
+                if full_url in seen:
+                    continue
+                seen.add(full_url)
+                new_task = Task(
+                    {"type": TaskType.URL},
+                    payload={"url": full_url},
+                )
+                self.add_task(current_task, new_task)
+
     def run(self, current_task: Task) -> None:
         url = get_target_url(current_task)
         self.log.info(f"robots looking for {url}/robots.txt")
 
         result = self.download_robots(current_task, url)
+        self._emit_url_tasks(current_task, url, result.groups)
 
         if result.found_urls:
             status = TaskStatus.INTERESTING

--- a/artemis/modules/sql_injection_detector.py
+++ b/artemis/modules/sql_injection_detector.py
@@ -37,6 +37,7 @@ class SqlInjectionDetector(ArtemisBase):
     identity = "sql_injection_detector"
     filters = [
         {"type": TaskType.SERVICE.value, "service": Service.HTTP.value},
+        {"type": TaskType.URL.value},
     ]
 
     def create_url_with_batch_payload(self, url: str, param_batch: tuple[Any, ...], payload: str) -> str:

--- a/test/modules/test_robots.py
+++ b/test/modules/test_robots.py
@@ -56,3 +56,13 @@ class RobotsTest(ArtemisModuleTestCase):
                 [path["url"] for path in call.kwargs["data"]["result"]["found_urls"]],
                 ["http://test-robots-service:80/secret-url/"],
             )
+            url_tasks = [t for t in self.karton.backend.produced_tasks if t.headers["type"] == TaskType.URL]
+            emitted_urls = sorted([t.get_payload("url") for t in url_tasks])
+            self.assertEqual(
+                emitted_urls,
+                [
+                    "http://test-robots-service:80/icons/",
+                    "http://test-robots-service:80/secret-url-noindex/",
+                    "http://test-robots-service:80/secret-url/",
+                ],
+            )


### PR DESCRIPTION
Closes #2405

## What

The robots module parses `robots.txt` and discovers paths that site owners intentionally (or accidentally) want to hide. Previously these paths were only checked for directory index exposure inside the module itself.

This PR emits a `TaskType.URL` task for each non-trivial discovered path, feeding them into the broader Artemis scanning pipeline.

## Changes

- `artemis/modules/robots.py` -> added `_emit_url_tasks()` which emits a `TaskType.URL` task per discovered path, applying the same filters already used for directory-index checks (skips `NOT_INTERESTING_PATHS`, wildcard paths, and deduplicates across groups).
- `artemis/modules/lfi_detector.py` -> added `TaskType.URL` to filters so it picks up and probes paths discovered by robots.
- `artemis/modules/sql_injection_detector.py` -> same.
- `test/modules/test_robots.py` -> added assertion that the expected URL tasks are emitted for the test host.

## Why

Paths listed in `robots.txt` are often sensitive endpoints (admin panels, API routes, internal tools). By routing them through the pipeline, modules like `lfi_detector` and `sql_injection_detector` will crawl and probe them, surfacing vulnerabilities that would be missed when scanning only from the root URL.