### PR TITLE
Add CPE to wordpress plugins

### DIFF
--- a/artemis/reporting/modules/wordpress_plugins/reporter.py
+++ b/artemis/reporting/modules/wordpress_plugins/reporter.py
@@ -1,6 +1,6 @@
 import os
 import re
-from typing import Any, Callable, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, List, Set
 
 from packaging import version
 
@@ -18,10 +18,6 @@ from artemis.reporting.base.templating import ReportEmailTemplateFragment
 from artemis.reporting.utils import get_target_url, get_top_level_target
 
 logger = utils.build_logger(__name__)
-
-
-def _get_cpe(slug: str) -> Optional[str]:
-    return lookup_cpe_by_plugin_slug(slug, "wordpress")
 
 
 class WordpressPluginsReporter(Reporter):
@@ -197,7 +193,7 @@ class WordpressPluginsReporter(Reporter):
                 name=get_target_url(task_result),
                 additional_type="wordpress-plugin:" + slug,
                 version=data.get("version", ""),
-                cpe=_get_cpe(slug),
+                cpe=lookup_cpe_by_plugin_slug(slug, "wordpress"),
             )
             for slug, data in task_result["result"].get("plugins", {}).items()
         ]

--- a/artemis/reporting/modules/wordpress_plugins/reporter.py
+++ b/artemis/reporting/modules/wordpress_plugins/reporter.py
@@ -1,10 +1,11 @@
 import os
 import re
-from typing import Any, Callable, Dict, List, Set
+from typing import Any, Callable, Dict, List, Optional, Set
 
 from packaging import version
 
 from artemis import utils
+from artemis.cpe_tools.cpe_utils import lookup_cpe_by_plugin_slug
 from artemis.fallback_api_cache import FallbackAPICache
 from artemis.reporting.base.asset import Asset
 from artemis.reporting.base.asset_type import AssetType
@@ -17,6 +18,10 @@ from artemis.reporting.base.templating import ReportEmailTemplateFragment
 from artemis.reporting.utils import get_target_url, get_top_level_target
 
 logger = utils.build_logger(__name__)
+
+
+def _get_cpe(slug: str) -> Optional[str]:
+    return lookup_cpe_by_plugin_slug(slug, "wordpress")
 
 
 class WordpressPluginsReporter(Reporter):
@@ -192,6 +197,7 @@ class WordpressPluginsReporter(Reporter):
                 name=get_target_url(task_result),
                 additional_type="wordpress-plugin:" + slug,
                 version=data.get("version", ""),
+                cpe=_get_cpe(slug),
             )
             for slug, data in task_result["result"].get("plugins", {}).items()
         ]

--- a/test/unit/test_wordpress_plugin_asset_cpe.py
+++ b/test/unit/test_wordpress_plugin_asset_cpe.py
@@ -1,0 +1,70 @@
+import unittest
+from typing import Any, Dict, List, Optional
+from unittest.mock import patch
+
+from artemis.reporting.base.asset import Asset
+from artemis.reporting.base.asset_type import AssetType
+from artemis.reporting.modules.wordpress_plugins.reporter import (
+    WordpressPluginsReporter,
+)
+
+# An IP is used instead of a domain so that Asset.__post_init__ doesn't perform a DNS lookup.
+TARGET = "http://127.0.0.1:80/"
+
+CONTACT_FORM_7_CPE = "cpe:2.3:a:rocklobster:contact_form_7:*:*:*:*:*:wordpress:*:*"
+
+# What artemis.cpe_tools would answer, so these tests don't depend on the NVD dictionary having been
+# downloaded - that mapping is built and tested there, this module only has to consult it correctly.
+FAKE_INDEX = {"contact-form-7": CONTACT_FORM_7_CPE}
+
+
+def _fake_lookup(slug: str, cms: str, version: Optional[str] = None) -> Optional[str]:
+    assert cms == "wordpress", "a WordPress plugin must be looked up under the WordPress namespace"
+    return FAKE_INDEX.get(slug.strip().lower())
+
+
+def _assets(plugins: Dict[str, Any]) -> List[Asset]:
+    return WordpressPluginsReporter.get_assets(
+        {
+            "headers": {"receiver": "wordpress_plugins", "type": "webapp", "webapp": "wordpress"},
+            "payload": {"url": TARGET},
+            "payload_persistent": {"original_domain": "127.0.0.1"},
+            "created_at": None,
+            "result": {"plugins": plugins},
+        }
+    )
+
+
+@patch("artemis.reporting.modules.wordpress_plugins.reporter.lookup_cpe_by_plugin_slug", _fake_lookup)
+class WordpressPluginAssetCPETest(unittest.TestCase):
+    def test_detected_plugins_carry_their_cpe(self) -> None:
+        contact_form_7, kirki = _assets(
+            {
+                "contact-form-7": {"version": "5.9.8"},
+                "kirki": {"version": "4.0.24"},
+            }
+        )
+
+        self.assertEqual(contact_form_7.asset_type, AssetType.CMS_PLUGIN)
+        self.assertEqual(contact_form_7.name, TARGET)
+        self.assertEqual(contact_form_7.additional_type, "wordpress-plugin:contact-form-7")
+        # The detected version stays in `version` - the CPE keeps its version slot wildcarded, the same
+        # way the CPEs coming from Nuclei and Wappalyzer do.
+        self.assertEqual(contact_form_7.version, "5.9.8")
+        self.assertEqual(contact_form_7.cpe, CONTACT_FORM_7_CPE)
+
+        # A plugin the dictionary doesn't name is still reported as an asset, just without a CPE.
+        self.assertEqual(kirki.additional_type, "wordpress-plugin:kirki")
+        self.assertEqual(kirki.version, "4.0.24")
+        self.assertIsNone(kirki.cpe)
+
+    def test_asset_without_version_still_gets_a_cpe(self) -> None:
+        # The CPE names the product, so not knowing which version runs doesn't prevent naming it.
+        (asset,) = _assets({"contact-form-7": {}})
+
+        self.assertEqual(asset.version, "")
+        self.assertEqual(asset.cpe, CONTACT_FORM_7_CPE)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this does

`wordpress_plugins` already reports every plugin it detects as a `CMS_PLUGIN`
asset. This fills in the one field those assets were always missing, `cpe`, so a
plugin can be matched against the CVE database and correlated with other tools'
output, which the free-form `additional_type` cannot do.

```python
cpe=lookup_cpe_by_plugin_slug(slug, "wordpress")
```

## Why it looks this way

Neither source this module consumes publishes a CPE. The WordFence
vulnerability feed names software by `type`/`name`/`slug` only, its v3 feed
format documents no CPE field, and the wordpress.org plugin API does not mention
CPEs at all. The CVE records where WordFence is the CNA carry neither
`affected[].cpes` nor `cpeApplicability`.

What does tie the two together is NVD's own CPE dictionary. A plugin's CPE
carries its wordpress.org directory URL among its references:

```
cpe:2.3:a:rocklobster:contact_form_7:3.7.1:*:*:*:*:wordpress:*:*
    refs: http://wordpress.org/plugins/contact-form-7/changelog/
```

That reference is an authoritative join between the slug the scanner detects and
the name NIST assigned. `cpe_tools` builds the index from it, so this module only
has to consult it.

It matters that the name comes from there rather than from the slug's spelling,
because the two often differ: `google-analytics-for-wordpress` is
MonsterInsights in NVD, `insert-headers-and-footers` is WPCode,
`host-webfonts-local` is OMGF. Plugins get rebranded and keep their old slug, and
no spelling rule recovers that.

The version slot stays wildcarded, following the convention in `Asset.cpe`: the
detected version stays in the asset's `version` field, and a consumer that needs
a versioned CPE combines the two, the way `cve_lookup` does before querying NVD.

Most plugins get `None`, and that is the correct answer. NVD names a plugin when
it first gets a CVE, so plugins that never had a vulnerability reported are
simply absent from the dictionary. `Asset.cpe` already documents an absent CPE as
the normal case rather than a failure.

## Tests

`WordpressPluginAssetCPETest` patches the lookup and checks what this reporter puts
on the Asset: the CPE in `cpe`, the detected version in `version`, and a plugin the
dictionary doesn't name still reported as an asset without a CPE.

## Notes for the reviewer

The lookup only answers once `cpe-nvd-service` has downloaded the dictionary into
the volume `autoreporter` reads. `docker-compose.test-e2e.yaml` has an `autoreporter`
but no `cpe-nvd-service` and no volume, so e2e runs will see `None` for every CPE.
Nothing asserts on CPEs there today, so nothing breaks; flagging it in case someone
later wonders why.