### PR TITLE
Ignore the downloaded NVD CPE dictionary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ output
 
 # Artemis additional modules
 Artemis-modules-extra
+
+# NVD CPE dictionary downloaded by cpe_main_process (default CPE_NVD_DIR)
+artemis/cpe_tools/nvdcpe-2.0/


### PR DESCRIPTION
## What

Adds `artemis/cpe_tools/nvdcpe-2.0/` to `.gitignore`, so the NVD CPE dictionary that
`cpe_main_process` downloads no longer shows up as untracked files in the working tree.

## Why

`Config.CpeDictionary.CPE_NVD_DIR` defaults to a path *inside the repository*:

```python
CPE_NVD_DIR = get_config(
    "CPE_NVD_DIR",
    default=str(Path(__file__).resolve().parent / "cpe_tools" / "nvdcpe-2.0"),
)
```

That default is what makes this a git problem rather than just a disk-space one. Anyone
running `download_and_refresh()` / `build_index()` without overriding the env var — which is
the documented default path, so that is the normal local run — has `get_nvd_dir()` resolve to
the bundled directory, and the dictionary plus its derived indexes get written there.

## Fix

One rule appended to `.gitignore`:

```
# NVD CPE dictionary downloaded by cpe_main_process (default CPE_NVD_DIR)
artemis/cpe_tools/nvdcpe-2.0/
```

## Notes / Out of scope

- Only the downloaded dictionary is ignored. The rest of `artemis/cpe_tools/` — the module
  source and its tests — stays tracked exactly as before.
- No code, config default, or `docker-compose.yaml` volume is touched. Whether the default
  `CPE_NVD_DIR` *should* point inside the source tree at all is a separate question and
  deliberately left alone here.