### PR TITLE
Unify CPE version filling between cve_lookup and cpe_tools

### DIFF
--- a/artemis/cpe_tools/cpe_utils.py
+++ b/artemis/cpe_tools/cpe_utils.py
@@ -1,4 +1,5 @@
 import logging
+import re
 from pathlib import Path
 
 from artemis.cpe_tools.cpe_main_process import (
@@ -36,17 +37,50 @@ _STOPWORDS = frozenset(
 )
 
 
-def with_version(cpe: str, version: str) -> str:
-    # Components are: cpe, 2.3, part, vendor, product, version, update, edition,
-    # language, sw_edition, target_sw, target_hw, other. Replace the version field
-    # (index 5) and re-join;
-    VERSION_FIELD_INDEX = 5
+# Components of a cpe:2.3 name are: cpe, 2.3, part, vendor, product, version, update,
+# edition, language, sw_edition, target_sw, target_hw, other.
+_VERSION_FIELD_INDEX = 5
 
+# A version slot must look like a real version: it starts with a digit and carries only
+# characters a version is made of. The version reaching ``fill_version`` is whatever a
+# scanner reported next to the technology, so guarding against a stray value such as
+# "latest" - or anything carrying a ":", which would silently add a component - keeps us
+# from building a malformed CPE that NVD matches nothing for. The match is anchored with
+# ``\Z`` rather than ``$``, which in Python also matches before a trailing newline and
+# would let "1.0\n" through into the CPE.
+_VERSION_RE = re.compile(r"^[0-9][0-9A-Za-z.\-+]*\Z")
+
+
+def with_version(cpe: str, version: str) -> str:
+    """Replace the version field of a cpe:2.3 name with ``version``, whatever it holds now.
+
+    Used to normalize a dictionary CPE down to its wildcard family. To insert a version
+    that a scanner reported, use ``fill_version`` instead - it validates the value and
+    leaves an already-concrete slot alone.
+    """
     parts = split_cpe(cpe)
-    if len(parts) <= VERSION_FIELD_INDEX:
+    if len(parts) <= _VERSION_FIELD_INDEX:
         return cpe
-    parts[VERSION_FIELD_INDEX] = version
+    parts[_VERSION_FIELD_INDEX] = version
     return ":".join(parts)
+
+
+def fill_version(cpe: str, version: str | None) -> str:
+    """Substitute a scanner-reported version into the wildcard version slot of a cpe:2.3 name.
+
+    A CPE we store (e.g. ``Asset.cpe``) keeps ``*`` in the version slot by definition, with
+    the version living alongside it, so filling the slot is the consumer's job - done here,
+    right before the CPE is used to query something.
+
+    The CPE comes back unchanged when the version is missing, doesn't look like a version,
+    or the slot already carries something concrete that we would rather not contradict.
+    """
+    if not version or not _VERSION_RE.match(version):
+        return cpe
+    parts = split_cpe(cpe)
+    if len(parts) <= _VERSION_FIELD_INDEX or parts[_VERSION_FIELD_INDEX] != "*":
+        return cpe
+    return with_version(cpe, version)
 
 
 def resolve(nvd_dir: Path, normalized: str) -> str | None:
@@ -87,7 +121,7 @@ def lookup_cpe(name: str, version: str | None = None) -> str | None:
     family_cpe = resolve(nvd_dir, normalized)
     if family_cpe is None:
         return None
-    return with_version(family_cpe, version) if version else family_cpe
+    return fill_version(family_cpe, version)
 
 
 def lookup_cpe_by_plugin_slug(slug: str, cms: str, version: str | None = None) -> str | None:
@@ -104,7 +138,7 @@ def lookup_cpe_by_plugin_slug(slug: str, cms: str, version: str | None = None) -
     cpe = plugins.get(f"{cms}:{slug.strip().lower()}")
     if cpe is None:
         return None
-    return with_version(cpe, version) if version else with_version(cpe, "*")
+    return fill_version(with_version(cpe, "*"), version)
 
 
 def lookup_cpe_by_url(url: str, version: str | None = None) -> str | None:
@@ -126,4 +160,4 @@ def lookup_cpe_by_url(url: str, version: str | None = None) -> str | None:
     cpe = urls.get(key)
     if cpe is None:
         return None
-    return with_version(cpe, version) if version else with_version(cpe, "*")
+    return fill_version(with_version(cpe, "*"), version)

--- a/artemis/cpe_tools/cpe_utils.py
+++ b/artemis/cpe_tools/cpe_utils.py
@@ -41,21 +41,16 @@ _STOPWORDS = frozenset(
 # edition, language, sw_edition, target_sw, target_hw, other.
 _VERSION_FIELD_INDEX = 5
 
-# A version slot must look like a real version: it starts with a digit and carries only
-# characters a version is made of. The version reaching ``fill_version`` is whatever a
-# scanner reported next to the technology, so guarding against a stray value such as
-# "latest" - or anything carrying a ":", which would silently add a component - keeps us
-# from building a malformed CPE that NVD matches nothing for. The match is anchored with
-# ``\Z`` rather than ``$``, which in Python also matches before a trailing newline and
-# would let "1.0\n" through into the CPE.
+# A version has to look like one: a digit first, then only characters versions are made of.
+# Anchored with ``\Z``, because Python's ``$`` also matches before a trailing newline.
 _VERSION_RE = re.compile(r"^[0-9][0-9A-Za-z.\-+]*\Z")
 
 
 def with_version(cpe: str, version: str) -> str:
     """Replace the version field of a cpe:2.3 name with ``version``, whatever it holds now.
 
-    Used to normalize a dictionary CPE down to its wildcard family. To insert a version
-    that a scanner reported, use ``fill_version`` instead - it validates the value and
+    Used to normalize a dictionary CPE down to its wildcard family. To insert a
+    caller-supplied version use ``fill_version`` instead - it validates the value and
     leaves an already-concrete slot alone.
     """
     parts = split_cpe(cpe)
@@ -66,11 +61,10 @@ def with_version(cpe: str, version: str) -> str:
 
 
 def fill_version(cpe: str, version: str | None) -> str:
-    """Substitute a scanner-reported version into the wildcard version slot of a cpe:2.3 name.
+    """Substitute ``version`` into the wildcard version slot of a cpe:2.3 name.
 
-    A CPE we store (e.g. ``Asset.cpe``) keeps ``*`` in the version slot by definition, with
-    the version living alongside it, so filling the slot is the consumer's job - done here,
-    right before the CPE is used to query something.
+    A name carrying ``*`` in the version slot denotes the product as a whole; filling that
+    slot narrows it to a single release.
 
     The CPE comes back unchanged when the version is missing, doesn't look like a version,
     or the slot already carries something concrete that we would rather not contradict.

--- a/artemis/cpe_tools/cpe_utils.py
+++ b/artemis/cpe_tools/cpe_utils.py
@@ -42,39 +42,28 @@ _STOPWORDS = frozenset(
 _VERSION_FIELD_INDEX = 5
 
 # A version has to look like one: a digit first, then only characters versions are made of.
+# ``*`` (ANY) and ``-`` (NA) are the two special values CPE 2.3 defines for a field, and are
+# accepted so that a name can also be reset to its versionless family.
 # Anchored with ``\Z``, because Python's ``$`` also matches before a trailing newline.
-_VERSION_RE = re.compile(r"^[0-9][0-9A-Za-z.\-+]*\Z")
+_VERSION_RE = re.compile(r"^(?:[0-9][0-9A-Za-z.\-+]*|\*|-)\Z")
 
 
-def with_version(cpe: str, version: str) -> str:
-    """Replace the version field of a cpe:2.3 name with ``version``, whatever it holds now.
+def with_version(cpe: str, version: str | None) -> str:
+    """Set the version field of a cpe:2.3 name to ``version``.
 
-    Used to normalize a dictionary CPE down to its wildcard family. To insert a
-    caller-supplied version use ``fill_version`` instead - it validates the value and
-    leaves an already-concrete slot alone.
+    A name carrying ``*`` in the version slot denotes the product as a whole; setting that
+    slot narrows it to a single release, and setting it back to ``*`` widens it again.
+
+    The CPE comes back unchanged when the version is missing, doesn't look like a version,
+    or the name is too short to have a version field.
     """
+    if not version or not _VERSION_RE.match(version):
+        return cpe
     parts = split_cpe(cpe)
     if len(parts) <= _VERSION_FIELD_INDEX:
         return cpe
     parts[_VERSION_FIELD_INDEX] = version
     return ":".join(parts)
-
-
-def fill_version(cpe: str, version: str | None) -> str:
-    """Substitute ``version`` into the wildcard version slot of a cpe:2.3 name.
-
-    A name carrying ``*`` in the version slot denotes the product as a whole; filling that
-    slot narrows it to a single release.
-
-    The CPE comes back unchanged when the version is missing, doesn't look like a version,
-    or the slot already carries something concrete that we would rather not contradict.
-    """
-    if not version or not _VERSION_RE.match(version):
-        return cpe
-    parts = split_cpe(cpe)
-    if len(parts) <= _VERSION_FIELD_INDEX or parts[_VERSION_FIELD_INDEX] != "*":
-        return cpe
-    return with_version(cpe, version)
 
 
 def resolve(nvd_dir: Path, normalized: str) -> str | None:
@@ -115,7 +104,7 @@ def lookup_cpe(name: str, version: str | None = None) -> str | None:
     family_cpe = resolve(nvd_dir, normalized)
     if family_cpe is None:
         return None
-    return fill_version(family_cpe, version)
+    return with_version(family_cpe, version)
 
 
 def lookup_cpe_by_plugin_slug(slug: str, cms: str, version: str | None = None) -> str | None:
@@ -132,7 +121,8 @@ def lookup_cpe_by_plugin_slug(slug: str, cms: str, version: str | None = None) -
     cpe = plugins.get(f"{cms}:{slug.strip().lower()}")
     if cpe is None:
         return None
-    return fill_version(with_version(cpe, "*"), version)
+    family = with_version(cpe, "*")
+    return with_version(family, version)
 
 
 def lookup_cpe_by_url(url: str, version: str | None = None) -> str | None:
@@ -154,4 +144,5 @@ def lookup_cpe_by_url(url: str, version: str | None = None) -> str | None:
     cpe = urls.get(key)
     if cpe is None:
         return None
-    return fill_version(with_version(cpe, "*"), version)
+    family = with_version(cpe, "*")
+    return with_version(family, version)

--- a/artemis/modules/cve_lookup.py
+++ b/artemis/modules/cve_lookup.py
@@ -9,7 +9,7 @@ from artemis import http_requests, load_risk_class
 from artemis.binds import TaskStatus, TaskType
 from artemis.config import Config
 from artemis.cpe_tools.cpe_main_process import split_cpe
-from artemis.cpe_tools.cpe_utils import fill_version
+from artemis.cpe_tools.cpe_utils import with_version
 from artemis.module_base import ArtemisBase
 
 NVD_RESPONSE_MAX_BYTES = 5 * 1024 * 1024
@@ -315,7 +315,7 @@ class CveLookup(ArtemisBase):
                 continue
 
             technology_version = technology.get("version")
-            normalized_cpe = fill_version(cpe, technology_version)
+            normalized_cpe = with_version(cpe, technology_version)
             if not _has_concrete_version(normalized_cpe):
                 # No usable version - NVD answers a wildcard cpeName with 404, and "some release
                 # of this product has a CVE" says nothing about this host, so skip the lookup.

--- a/artemis/modules/cve_lookup.py
+++ b/artemis/modules/cve_lookup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import json
-import re
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import urlencode
 
@@ -9,6 +8,8 @@ from karton.core import Task
 from artemis import http_requests, load_risk_class
 from artemis.binds import TaskStatus, TaskType
 from artemis.config import Config
+from artemis.cpe_tools.cpe_main_process import split_cpe
+from artemis.cpe_tools.cpe_utils import fill_version
 from artemis.module_base import ArtemisBase
 
 NVD_RESPONSE_MAX_BYTES = 5 * 1024 * 1024
@@ -27,31 +28,6 @@ NVD_FAILURE_MARKER = "lookup_failed"
 NVD_MAX_PAGES = 10
 
 
-# A CPE version slot must look like a real version. Wappalyzer reports the version
-# separately from its static CPE template, so guarding against a stray value such as
-# "latest" (or anything carrying a ":") keeps us from building a malformed CPE that
-# NVD would silently match nothing for.
-_CPE_VERSION_RE = re.compile(r"^[0-9][0-9A-Za-z.\-+]*$")
-
-
-def _fill_cpe_version(cpe: str, version: Optional[str]) -> str:
-    """
-    Wappalyzer keeps the version slot as ``*`` even when the version is known, so
-    substitute the real version (slot 5 of a cpe:2.3 URI) before hitting the API.
-    A version that doesn't look like one is left as the wildcard, which
-    ``_has_concrete_version`` then rejects rather than sending junk to NVD.
-    """
-    if not version or not _CPE_VERSION_RE.match(version):
-        return cpe
-    parts = cpe.split(":")
-    if len(parts) < 6:
-        return cpe
-    if parts[5] != "*":
-        return cpe
-    parts[5] = version
-    return ":".join(parts)
-
-
 def _has_concrete_version(cpe: str) -> bool:
     """
     Whether the cpe:2.3 URI carries a real version in slot 5.
@@ -61,13 +37,13 @@ def _has_concrete_version(cpe: str) -> bool:
     wouldn't want to anyway, since the only thing NVD could return is "every CVE ever filed for
     this product", which says nothing about the host we scanned.
     """
-    parts = cpe.split(":")
+    parts = split_cpe(cpe)
     return len(parts) > 5 and parts[5] not in ("", "*", "-")
 
 
 def _cpe_product_key(cpe: str) -> str:
     """Return the ``part:vendor:product`` portion of a cpe:2.3 URI (e.g. ``a:apache:http_server``)."""
-    parts = cpe.split(":")
+    parts = split_cpe(cpe)
     if len(parts) < 5:
         return ""
     return ":".join(parts[2:5])
@@ -339,7 +315,7 @@ class CveLookup(ArtemisBase):
                 continue
 
             technology_version = technology.get("version")
-            normalized_cpe = _fill_cpe_version(cpe, technology_version)
+            normalized_cpe = fill_version(cpe, technology_version)
             if not _has_concrete_version(normalized_cpe):
                 # No usable version - NVD answers a wildcard cpeName with 404, and "some release
                 # of this product has a CVE" says nothing about this host, so skip the lookup.

--- a/test/unit/test_cpe_utils.py
+++ b/test/unit/test_cpe_utils.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 from artemis.config import Config
 from artemis.cpe_tools.cpe_utils import (
+    fill_version,
     lookup_cpe,
     lookup_cpe_by_plugin_slug,
     lookup_cpe_by_url,
@@ -32,6 +33,52 @@ def _product(
     if deprecated:
         cpe["deprecated"] = True
     return {"cpe": cpe}
+
+
+class FillVersionTest(unittest.TestCase):
+    """
+    A stored CPE keeps ``*`` in the version slot by definition; the consumer fills it in
+    just before use (e.g. cve_lookup, before querying NVD).
+    """
+
+    def test_substitutes_wildcard_slot(self) -> None:
+        self.assertEqual(
+            fill_version("cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*", "2.4.53"),
+            "cpe:2.3:a:apache:http_server:2.4.53:*:*:*:*:*:*:*",
+        )
+
+    def test_keeps_slot_that_already_holds_a_version(self) -> None:
+        cpe = "cpe:2.3:a:apache:http_server:2.4.53:*:*:*:*:*:*:*"
+        self.assertEqual(fill_version(cpe, "2.4.54"), cpe)
+
+    def test_no_version_returns_unchanged(self) -> None:
+        cpe = "cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*"
+        self.assertEqual(fill_version(cpe, None), cpe)
+        self.assertEqual(fill_version(cpe, ""), cpe)
+
+    def test_invalid_version_leaves_wildcard(self) -> None:
+        # A non-version value must not be injected into the CPE; the wildcard is kept so
+        # the caller can tell nothing concrete was filled in.
+        cpe = "cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*"
+        for version in ("latest", "v2.4", "stable", "1.0:extra", " 1.0", "1.0\n"):
+            with self.subTest(version=version):
+                self.assertEqual(fill_version(cpe, version), cpe)
+
+    def test_short_cpe_returns_unchanged(self) -> None:
+        # Fewer than six components means there is no version slot to fill.
+        self.assertEqual(fill_version("garbage", "1.0"), "garbage")
+        self.assertEqual(fill_version("cpe:2.3:a:apache:http_server", "1.0"), "cpe:2.3:a:apache:http_server")
+
+    def test_escaped_colon_in_product_does_not_shift_the_slot(self) -> None:
+        # CPE 2.3 escapes a colon inside a field, so a naive split would land on the
+        # product's own text instead of the version.
+        self.assertEqual(
+            fill_version("cpe:2.3:a:cgiirc:cgi\\:irc:*:*:*:*:*:*:*:*", "0.5.7"),
+            "cpe:2.3:a:cgiirc:cgi\\:irc:0.5.7:*:*:*:*:*:*:*",
+        )
+        # ... and the same name with a version already in place is left alone.
+        cpe = "cpe:2.3:a:cgiirc:cgi\\:irc:0.5.7:*:*:*:*:*:*:*"
+        self.assertEqual(fill_version(cpe, "0.5.9"), cpe)
 
 
 class CpeUtilsTest(unittest.TestCase):

--- a/test/unit/test_cpe_utils.py
+++ b/test/unit/test_cpe_utils.py
@@ -7,10 +7,10 @@ from unittest.mock import patch
 
 from artemis.config import Config
 from artemis.cpe_tools.cpe_utils import (
-    fill_version,
     lookup_cpe,
     lookup_cpe_by_plugin_slug,
     lookup_cpe_by_url,
+    with_version,
 )
 from artemis.reporting.base.cpe import extract_cpe
 
@@ -35,50 +35,60 @@ def _product(
     return {"cpe": cpe}
 
 
-class FillVersionTest(unittest.TestCase):
+class WithVersionTest(unittest.TestCase):
     """
-    A stored CPE keeps ``*`` in the version slot by definition; the consumer fills it in
-    just before use (e.g. cve_lookup, before querying NVD).
+    A CPE keeps ``*`` in the version slot until someone sets it.
     """
 
-    def test_substitutes_wildcard_slot(self) -> None:
+    def test_sets_wildcard_slot(self) -> None:
         self.assertEqual(
-            fill_version("cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*", "2.4.53"),
+            with_version("cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*", "2.4.53"),
             "cpe:2.3:a:apache:http_server:2.4.53:*:*:*:*:*:*:*",
         )
 
-    def test_keeps_slot_that_already_holds_a_version(self) -> None:
+    def test_replaces_a_slot_that_already_holds_a_version(self) -> None:
+        self.assertEqual(
+            with_version("cpe:2.3:a:apache:http_server:2.4.53:*:*:*:*:*:*:*", "2.4.54"),
+            "cpe:2.3:a:apache:http_server:2.4.54:*:*:*:*:*:*:*",
+        )
+
+    def test_special_values_are_accepted(self) -> None:
+        # ``*`` (ANY) and ``-`` (NA) are CPE 2.3 field values, and resetting a dictionary
+        # CPE to its versionless family depends on them passing validation.
         cpe = "cpe:2.3:a:apache:http_server:2.4.53:*:*:*:*:*:*:*"
-        self.assertEqual(fill_version(cpe, "2.4.54"), cpe)
+        self.assertEqual(with_version(cpe, "*"), "cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*")
+        self.assertEqual(with_version(cpe, "-"), "cpe:2.3:a:apache:http_server:-:*:*:*:*:*:*:*")
 
     def test_no_version_returns_unchanged(self) -> None:
         cpe = "cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*"
-        self.assertEqual(fill_version(cpe, None), cpe)
-        self.assertEqual(fill_version(cpe, ""), cpe)
+        self.assertEqual(with_version(cpe, None), cpe)
+        self.assertEqual(with_version(cpe, ""), cpe)
 
-    def test_invalid_version_leaves_wildcard(self) -> None:
-        # A non-version value must not be injected into the CPE; the wildcard is kept so
-        # the caller can tell nothing concrete was filled in.
+    def test_invalid_version_leaves_the_slot_alone(self) -> None:
+        # A non-version value must not be injected into the CPE; the slot is left as it was
+        # so the caller can tell nothing was set.
         cpe = "cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*"
         for version in ("latest", "v2.4", "stable", "1.0:extra", " 1.0", "1.0\n"):
             with self.subTest(version=version):
-                self.assertEqual(fill_version(cpe, version), cpe)
+                self.assertEqual(with_version(cpe, version), cpe)
 
     def test_short_cpe_returns_unchanged(self) -> None:
-        # Fewer than six components means there is no version slot to fill.
-        self.assertEqual(fill_version("garbage", "1.0"), "garbage")
-        self.assertEqual(fill_version("cpe:2.3:a:apache:http_server", "1.0"), "cpe:2.3:a:apache:http_server")
+        # Fewer than six components means there is no version slot to set.
+        self.assertEqual(with_version("garbage", "1.0"), "garbage")
+        self.assertEqual(with_version("cpe:2.3:a:apache:http_server", "1.0"), "cpe:2.3:a:apache:http_server")
 
     def test_escaped_colon_in_product_does_not_shift_the_slot(self) -> None:
         # CPE 2.3 escapes a colon inside a field, so a naive split would land on the
         # product's own text instead of the version.
         self.assertEqual(
-            fill_version("cpe:2.3:a:cgiirc:cgi\\:irc:*:*:*:*:*:*:*:*", "0.5.7"),
+            with_version("cpe:2.3:a:cgiirc:cgi\\:irc:*:*:*:*:*:*:*:*", "0.5.7"),
             "cpe:2.3:a:cgiirc:cgi\\:irc:0.5.7:*:*:*:*:*:*:*",
         )
-        # ... and the same name with a version already in place is left alone.
-        cpe = "cpe:2.3:a:cgiirc:cgi\\:irc:0.5.7:*:*:*:*:*:*:*"
-        self.assertEqual(fill_version(cpe, "0.5.9"), cpe)
+        # ... and the same name with a version already in place is replaced, not appended to.
+        self.assertEqual(
+            with_version("cpe:2.3:a:cgiirc:cgi\\:irc:0.5.7:*:*:*:*:*:*:*", "0.5.9"),
+            "cpe:2.3:a:cgiirc:cgi\\:irc:0.5.9:*:*:*:*:*:*:*",
+        )
 
 
 class CpeUtilsTest(unittest.TestCase):

--- a/test/unit/test_cve_lookup_helpers.py
+++ b/test/unit/test_cve_lookup_helpers.py
@@ -5,7 +5,6 @@ from artemis.modules.cve_lookup import (
     _best_base_score,
     _cpe_product_key,
     _extract_cves,
-    _fill_cpe_version,
     _has_concrete_version,
     _is_product_vulnerable,
 )
@@ -30,31 +29,11 @@ class HasConcreteVersionTest(unittest.TestCase):
     def test_false_for_truncated_cpe(self) -> None:
         self.assertFalse(_has_concrete_version("cpe:2.3:a:apache"))
 
-
-class FillCpeVersionTest(unittest.TestCase):
-    def test_substitutes_wildcard_slot(self) -> None:
-        cpe = "cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*"
-        self.assertEqual(
-            _fill_cpe_version(cpe, "2.4.53"),
-            "cpe:2.3:a:apache:http_server:2.4.53:*:*:*:*:*:*:*",
-        )
-
-    def test_keeps_real_version(self) -> None:
-        cpe = "cpe:2.3:a:apache:http_server:2.4.53:*:*:*:*:*:*:*"
-        self.assertEqual(_fill_cpe_version(cpe, "2.4.54"), cpe)
-
-    def test_no_version_returns_unchanged(self) -> None:
-        cpe = "cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*"
-        self.assertEqual(_fill_cpe_version(cpe, None), cpe)
-
-    def test_malformed_cpe_returns_unchanged(self) -> None:
-        self.assertEqual(_fill_cpe_version("garbage", "1.0"), "garbage")
-
-    def test_junk_version_leaves_wildcard(self) -> None:
-        # A non-version value (e.g. "latest") must not be injected into the CPE; the
-        # wildcard is kept so NVD still range-matches the product.
-        cpe = "cpe:2.3:a:apache:http_server:*:*:*:*:*:*:*:*"
-        self.assertEqual(_fill_cpe_version(cpe, "latest"), cpe)
+    def test_escaped_colon_in_product_does_not_shift_the_slot(self) -> None:
+        # A colon escaped inside the product field must not be counted as a separator,
+        # or slot 5 would read a piece of the product name and pass as a "version".
+        self.assertFalse(_has_concrete_version("cpe:2.3:a:cgiirc:cgi\\:irc:*:*:*:*:*:*:*:*"))
+        self.assertTrue(_has_concrete_version("cpe:2.3:a:cgiirc:cgi\\:irc:0.5.7:*:*:*:*:*:*:*"))
 
 
 class ExtractCvesTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

Unifies the two independent implementations of "insert a version into a CPE" into a
single `with_version()` in `artemis/cpe_tools/cpe_utils.py`, and fixes a splitting bug
that made the `cve_lookup` copy read the wrong field on ~5,000 NVD CPE names.

## Why

`Asset.cpe` holds a wildcard in the version slot by definition; the version lives
separately in `Asset.version`. Setting the slot is the consumer's job, done right before
use - e.g. `cve_lookup`, before querying NVD. That job had two divergent implementations:

| | `cve_lookup._fill_cpe_version` | `cpe_utils.with_version` |
|---|---|---|
| splitting | `cpe.split(":")` - **wrong**, see below | `split_cpe()` - correct |
| validates the version | yes (regex) | no |

CPE 2.3 escapes a colon inside a field (`cpe:2.3:a:cgiirc:cgi\:irc:0.5.7:...`), so a
naive `split(":")` yields 14 components instead of 13 and index 5 lands on part of the
product name rather than the version. This currently affects **5,093 of 1,823,483** names
in the NVD dictionary (escaped colons occur in fields 3/4/5 - 815/4,993/100 respectively).
`split_cpe()` returns exactly 13 components for all 1,823,483 (as of now).

The user-visible consequence in `cve_lookup` was worse than a missing version: for those
products `_has_concrete_version` read the product text (`irc`) as the version and returned
`True`, so the module queried NVD with a **wildcard-version** `cpeName`, which NVD answers
with 404 - recorded as a *failed lookup* rather than a skip. Those products never got a
real CVE lookup at all.

## What changed

- **One `with_version(cpe, version)`** in `cpe_utils.py` - correct splitting plus version
  validation. `_fill_cpe_version` is gone; `cve_lookup` and the three `lookup_*` helpers
  all go through it.
- The old "don't overwrite a slot that already holds a version" guard is dropped: it never
  fired. Currently in wappalyzergo every fingerprint with a CPE carries `*` in the version
  slot, and the `lookup_*` path widens to the family first, so the slot is always a
  wildcard by the time it gets there.
- **The version regex now also accepts `*` (ANY) and `-` (NA)**, the two special field
  values CPE 2.3 defines. Without them, widening a dictionary CPE back to its versionless
  family would stop working once the setter validates its input.
- `lookup_*` behaviour: an invalid version (`"latest"`) is now rejected and the slot stays
  wildcarded, where before it was substituted verbatim. No production caller passes a
  version today - #3103 removed the last one from `wp_scanner` - so nothing changes in
  practice.
- **`cve_lookup`**: `_fill_cpe_version` and `_CPE_VERSION_RE` removed; `_has_concrete_version`
  and `_cpe_product_key` now use `split_cpe()` too. `_has_concrete_version` keeps its own
  separate responsibility (whether to query NVD at all).
- **Version regex anchored with `\Z` instead of `$`**: in Python `$` also matches before a
  trailing newline, so `"1.0\n"` passed validation and put a newline inside the CPE.

## Tests

`WithVersionTest` covers the escaped colon (both directions), invalid versions
(`latest`, `v2.4`, `1.0:extra`, leading space, trailing newline), an empty/`None` version,
the special values `*` and `-`, replacing a slot that already holds a version, and a CPE
shorter than six fields. The escaped-colon case for `_has_concrete_version` is pinned where
that function lives.

The escaped-colon cases fail against the old naive split - that's the regression they guard.