### PR TITLE
Fix MAX_MODULE_TASK_PROCESSING_TIME__SECONDS default: 3 days, not ~29 years

### DIFF
--- a/artemis/config.py
+++ b/artemis/config.py
@@ -320,7 +320,7 @@ class Config:
             int,
             "After this number of module running time, each scanning module will get restarted. This is to prevent situations "
             "such as slow memory leaks.",
-        ] = get_config("MAX_MODULE_TASK_PROCESSING_TIME__SECONDS", default=3 * 24 * 3600 * 3600, cast=int)
+        ] = get_config("MAX_MODULE_TASK_PROCESSING_TIME__SECONDS", default=3 * 24 * 3600, cast=int)
 
         CONTENT_PREFIX_SIZE: Annotated[
             int,


### PR DESCRIPTION
Fixes #3105

## Problem

The default value contained a double `*3600` (hours-to-seconds applied twice), turning the intended 3-day module recycling interval into ~29.6 years (933,120,000 seconds):

```python
default=3 * 24 * 3600 * 3600  # 933,120,000 s ≈ 29.6 years
```

`module_base.py` uses this value as the main loop lifetime of every scanning module (`artemis/module_base.py:300`); after it elapses the loop exits and Docker `restart: always` recycles the container. With the wrong default, that exit condition is unreachable in practice, so the memory-leak mitigation described in the config docstring is effectively disabled in every default deployment (no repo deployment file sets the env var explicitly).

## Fix

```diff
-        ] = get_config("MAX_MODULE_TASK_PROCESSING_TIME__SECONDS", default=3 * 24 * 3600 * 3600, cast=int)
+        ] = get_config("MAX_MODULE_TASK_PROCESSING_TIME__SECONDS", default=3 * 24 * 3600, cast=int)
```

## Verification

- [x] `Config.Miscellaneous.MAX_MODULE_TASK_PROCESSING_TIME__SECONDS == 259200` (= 3 days) after the change
- [x] Explicit env override still takes precedence (e.g. `MAX_MODULE_TASK_PROCESSING_TIME__SECONDS=86400` → `86400`), so deployments that configured the value themselves are unaffected
- [x] Restart happens gracefully at the next task boundary (inside the `graceful_killer()` context, `module_base.py:297`), so in-flight tasks always complete before the container is recycled - no task loss
- [x] `pre-commit run --files artemis/config.py`: black, isort, mypy, flake8 - all pass