### PR TITLE
Classifier: require full match for ASN detection

### DIFF
--- a/artemis/modules/classifier.py
+++ b/artemis/modules/classifier.py
@@ -88,7 +88,7 @@ class Classifier(ArtemisBase):
         if "://" in data:
             return direct_url_scanning.is_scannable_url(data)
 
-        if re.match(ASN_REGEX, data):
+        if re.fullmatch(ASN_REGEX, data):
             return True
 
         if to_ip_range(data):
@@ -120,7 +120,7 @@ class Classifier(ArtemisBase):
             return False
         if "://" in data:
             return True
-        if re.match(ASN_REGEX, data) or to_ip_range(data):
+        if re.fullmatch(ASN_REGEX, data) or to_ip_range(data):
             return False
         return not Classifier._is_ip_or_domain(Classifier._clean_ipv6_brackets(data))
 
@@ -218,7 +218,7 @@ class Classifier(ArtemisBase):
             )
             return
 
-        if re.match(ASN_REGEX, data):
+        if re.fullmatch(ASN_REGEX, data):
             ips = []
             for prefix in get_ip_prefixes_for_asn(data):
                 self.log.info(f"Converted {data} to IP prefixes, processing {prefix}")

--- a/test/modules/test_classifier.py
+++ b/test/modules/test_classifier.py
@@ -1,3 +1,4 @@
+import re
 from test.base import ArtemisModuleTestCase
 from typing import Any, Dict, List, NamedTuple
 from unittest.mock import patch
@@ -6,7 +7,7 @@ from karton.core import Task
 
 from artemis import direct_url_scanning
 from artemis.binds import TaskType
-from artemis.modules.classifier import Classifier
+from artemis.modules.classifier import ASN_REGEX, Classifier
 
 
 class ExpectedTaskData(NamedTuple):
@@ -59,6 +60,8 @@ class ClassifierTest(ArtemisModuleTestCase):
         self.assertTrue(Classifier.is_supported("1.2.3.4:56"))
         self.assertTrue(Classifier.is_supported("CERT.pl"))
         self.assertFalse(Classifier.is_supported("root@cert.pl"))
+        # A domain whose label happens to look like an ASN prefix is supported as a domain
+        self.assertTrue(Classifier.is_supported("as7822.example.com"))
 
     def test_is_scannable_url(self) -> None:
         # Root URLs that map to a service are accepted as direct scan targets
@@ -88,6 +91,7 @@ class ClassifierTest(ArtemisModuleTestCase):
         self.assertFalse(Classifier.is_service_target("1.2.3.4"))
         self.assertFalse(Classifier.is_service_target("127.0.0.1-127.0.0.5"))
         self.assertFalse(Classifier.is_service_target("AS123"))
+        self.assertFalse(Classifier.is_service_target("as7822.example.com"))
         # Unsupported inputs (non-root URL, malformed port) are not service targets
         self.assertFalse(Classifier.is_service_target("http://cert.pl/admin"))
         self.assertFalse(Classifier.is_service_target("cert.pl:8080port"))
@@ -245,6 +249,23 @@ class ClassifierTest(ArtemisModuleTestCase):
             for i in range(len(results)):
                 del results[i].payload["created_at"]
             self.assertTasksEqual(results, expected_tasks)
+
+    def test_asn_prefix_input_is_classified_as_domain(self) -> None:
+        # A domain starting with "as<digits>" must not be misrouted to the ASN path (which
+        # would query RIPEstat with a non-ASN resource and error out).
+        with patch("artemis.modules.classifier.get_ip_prefixes_for_asn") as mock_ripe:
+            task = Task({"type": TaskType.NEW}, payload={"data": "as7822.example.com"})
+            results = self.run_task(task)
+            mock_ripe.assert_not_called()
+
+        types = [result.headers["type"] for result in results]
+        self.assertIn(TaskType.DOMAIN_THAT_MAY_NOT_EXIST.value, types)
+
+    def test_asn_still_detected(self) -> None:
+        # Positive control: real ASNs still take the ASN path.
+        self.assertTrue(re.fullmatch(ASN_REGEX, "AS123"))
+        self.assertTrue(re.fullmatch(ASN_REGEX, "as48282"))
+        self.assertFalse(re.fullmatch(ASN_REGEX, "as7822.example.com"))
 
     def test_invalid_data(self) -> None:
         task = Task({"type": TaskType.NEW}, payload={"data": "INVALID_DATA"})


### PR DESCRIPTION
Fixes #3108

## Problem

The ASN detection in the classifier used `re.match(ASN_REGEX, data)`, which is prefix-anchored only. Any input merely *starting* with `as<digits>` - e.g. the valid domain `as7822.example.com` - was misrouted to the ASN path: `get_ip_prefixes_for_asn()` built a RIPEstat request with the domain as the `resource` parameter, the API rejected it, and the task ended up in an error/retry loop, hammering the RIPEstat API each time. Valid domains like this were therefore never scanned.

## Fix

`re.match` -> `re.fullmatch` at the three call sites (`is_supported`, `is_service_target`, `run`):

```diff
-if re.match(ASN_REGEX, data):
+if re.fullmatch(ASN_REGEX, data):
```

- Real ASNs (`AS123`, `as48282`) are unaffected - the regex keeps its case-insensitive prefix and `ASN_REGEX` itself is untouched, since `is_supported()` is also called externally with mixed-case input.
- Domains like `as7822.example.com` now fall through to `_is_ip_or_domain()` and take the normal domain flow.
- For `is_supported`/`is_service_target` the result is identical for every legitimate input; only the broken inputs change behavior.

## Tests

Added to `test/modules/test_classifier.py`:

- `test_asn_prefix_input_is_classified_as_domain` - runs the full module on `as7822.example.com` with `get_ip_prefixes_for_asn` patched and asserts it is **never called** (previously it would be, and error out); asserts the input routes to the domain path (`domain_that_may_not_exist`).
- `test_asn_still_detected` - positive control: `AS123` / `as48282` still fullmatch, `as7822.example.com` does not.
- Assertions for `is_supported("as7822.example.com")` (True) and `is_service_target("as7822.example.com")` (False).

## Verification

- [x] `pytest test/modules/test_classifier.py` - 10/10 passed
- [x] `pre-commit run --files artemis/modules/classifier.py test/modules/test_classifier.py` - black, isort, mypy, flake8 all pass