### PR TITLE
refactor: factor out common injection and URL manipulation utilities

### DIFF
--- a/artemis/injection_utils.py
+++ b/artemis/injection_utils.py
@@ -1,0 +1,88 @@
+import datetime
+from timeit import default_timer as timer
+from typing import Any, Callable, Dict, List, Optional, Sequence
+from urllib.parse import parse_qs, unquote, urlencode, urlparse, urlunparse
+
+import requests
+
+
+def has_query_parameters(url: str) -> bool:
+    """Check whether a URL has query parameters."""
+    return "?" in url or bool(urlparse(url).query)
+
+
+def create_url_with_batch_payload(url: str, param_batch: Sequence[str], payload: str) -> str:
+    """Append a batch of query parameters all assigned to the same payload to a URL."""
+    assignments = {key: payload for key in param_batch}
+    concatenation = "&" if has_query_parameters(url) else "?"
+    return f"{url}{concatenation}" + "&".join([f"{key}={value}" for key, value in assignments.items()])
+
+
+def change_url_params(url: str, payload: str, param_batch: Sequence[str]) -> str:
+    """
+    Replace existing query parameters in the URL with payload,
+    and append any additional parameters in param_batch with the payload.
+    """
+    parsed_url = urlparse(url)
+    query_params = parse_qs(parsed_url.query)
+    params = list(query_params.keys())
+    new_query_params = {}
+    assignments = {key: payload for key in param_batch}
+
+    for param in params:
+        new_query_params[param] = [payload]
+
+    new_query_string = urlencode(new_query_params, doseq=True)
+    new_url = urlunparse(
+        (
+            parsed_url.scheme,
+            parsed_url.netloc,
+            parsed_url.path,
+            parsed_url.params,
+            new_query_string,
+            parsed_url.fragment,
+        )
+    )
+    concatenation = "&" if has_query_parameters(new_url) else "?"
+    new_url = f"{new_url}" + concatenation + "&".join([f"{key}={value}" for key, value in assignments.items()])
+    return unquote(new_url)
+
+
+def measure_request_time(
+    http_get_func: Callable[..., Any],
+    url: str,
+    timeout_threshold: float,
+    headers: Optional[Dict[str, str]] = None,
+) -> float:
+    """Measure the time in seconds taken to perform a GET request."""
+    start = timer()
+    try:
+        if headers is not None:
+            http_get_func(url, headers=headers)
+        else:
+            http_get_func(url)
+    except requests.exceptions.Timeout:
+        return timeout_threshold
+    return datetime.timedelta(seconds=timer() - start).seconds
+
+
+def minimize_parameters(
+    params: Sequence[str],
+    test_func: Callable[[str], bool],
+    max_len: Optional[int] = None,
+) -> List[str]:
+    """
+    Try to find a minimal subset of parameters that satisfy test_func (which checks if param triggers the finding).
+    If any individual parameter triggers the test, returns the list of matching parameters (up to max_len).
+    Otherwise, returns the original params list.
+    """
+    minimal_params: List[str] = []
+    for param in params:
+        if test_func(param):
+            minimal_params.append(param)
+        if max_len is not None and len(minimal_params) >= max_len:
+            break
+
+    if minimal_params:
+        return minimal_params
+    return list(params)

--- a/artemis/modules/lfi_detector.py
+++ b/artemis/modules/lfi_detector.py
@@ -8,6 +8,11 @@ from artemis.binds import Service, TaskStatus, TaskType
 from artemis.config import Config
 from artemis.crawling import get_injectable_parameters, get_links_to_scan
 from artemis.http_requests import HTTPResponse
+from artemis.injection_utils import (
+    create_url_with_batch_payload,
+    has_query_parameters,
+    minimize_parameters,
+)
 from artemis.module_base import ArtemisBase
 from artemis.modules.data.lfi_detector.lfi_detector_data import (
     LFI_PAYLOADS,
@@ -41,12 +46,10 @@ class LFIDetector(ArtemisBase):
     ]
 
     def create_url_with_batch_payload(self, url: str, param_batch: List[str], payload: str) -> str:
-        assignments = {key: payload for key in param_batch}
-        concatenation = "&" if self.is_url_with_parameters(url) else "?"
-        return f"{url}{concatenation}" + "&".join([f"{key}={value}" for key, value in assignments.items()])
+        return create_url_with_batch_payload(url=url, param_batch=param_batch, payload=payload)
 
     def is_url_with_parameters(self, url: str) -> bool:
-        return "?" in url
+        return has_query_parameters(url)
 
     def contains_lfi_indicator(self, original_response: HTTPResponse, response: HTTPResponse) -> Optional[str]:
         """Check if the response contains indicators of LFI.
@@ -93,27 +96,25 @@ class LFIDetector(ArtemisBase):
         Try to find the minimal set of parameters that still triggers LFI. Currently minimizes to single parameters only.
         Falls back to original params if none work individually.
         """
-        minimal_params: List[str] = []
-
-        for param in params:
+        def test_param(param: str) -> bool:
             test_url = self.create_url_with_batch_payload(url, [param], payload)
             response = self.http_get(test_url)
+            return bool(self.contains_lfi_indicator(original_response, response))
 
-            if self.contains_lfi_indicator(original_response, response):
-                minimal_params.append(param)
-            if len(minimal_params) >= Config.Modules.LFIDetector.LFI_MINIMAL_PARAMS_MAX_LEN:
-                break
+        minimal_params = minimize_parameters(
+            params=params,
+            test_func=test_param,
+            max_len=Config.Modules.LFIDetector.LFI_MINIMAL_PARAMS_MAX_LEN,
+        )
 
-        if minimal_params:
+        if minimal_params != params:
             self.log.info(
                 "LFI parameter minimization: %s -> %s",
                 params,
                 minimal_params,
             )
-            return minimal_params
 
-        # fallback if no single param triggers LFI
-        return params
+        return minimal_params
 
     def scan(self, urls: List[str], task: Task) -> List[Dict[str, Any]]:
         """Scan URLs for LFI vulnerabilities."""

--- a/artemis/modules/sql_injection_detector.py
+++ b/artemis/modules/sql_injection_detector.py
@@ -1,12 +1,8 @@
-import datetime
 import re
 from enum import Enum
-from timeit import default_timer as timer
-from typing import Any, Dict, List, Literal, Optional
-from urllib.parse import parse_qs, unquote, urlencode, urlparse, urlunparse
+from typing import Any, Dict, List, Literal, Optional, Sequence
 
 import more_itertools
-import requests
 from karton.core import Task
 
 from artemis import load_risk_class
@@ -14,6 +10,13 @@ from artemis.binds import Service, TaskStatus, TaskType
 from artemis.config import Config
 from artemis.crawling import get_injectable_parameters, get_links_to_scan
 from artemis.http_requests import HTTPResponse
+from artemis.injection_utils import (
+    change_url_params,
+    create_url_with_batch_payload,
+    has_query_parameters,
+    measure_request_time,
+    minimize_parameters,
+)
 from artemis.module_base import ArtemisBase
 from artemis.modules.data.parameters import URL_PARAMS
 from artemis.sql_injection_data import HEADERS, SQL_ERROR_MESSAGES
@@ -39,13 +42,8 @@ class SqlInjectionDetector(ArtemisBase):
         {"type": TaskType.SERVICE.value, "service": Service.HTTP.value},
     ]
 
-    def create_url_with_batch_payload(self, url: str, param_batch: tuple[Any, ...], payload: str) -> str:
-        assignments = {key: payload for key in param_batch}
-        concatenation = "&" if self.is_url_with_parameters(url) else "?"
-
-        url_with_payload = f"{url}{concatenation}" + "&".join([f"{key}={value}" for key, value in assignments.items()])
-
-        return url_with_payload
+    def create_url_with_batch_payload(self, url: str, param_batch: Sequence[str], payload: str) -> str:
+        return create_url_with_batch_payload(url=url, param_batch=param_batch, payload=payload)
 
     @staticmethod
     def change_sleep_to_0(payload: str) -> str:
@@ -55,47 +53,20 @@ class SqlInjectionDetector(ArtemisBase):
 
     @staticmethod
     def is_url_with_parameters(url: str) -> bool:
-        if re.search("/?/*=", url):
-            return True
-        return False
+        return has_query_parameters(url)
 
     @staticmethod
-    def change_url_params(url: str, payload: str, param_batch: tuple[Any, ...]) -> str:
-        parsed_url = urlparse(url)
-        query_params = parse_qs(parsed_url.query)
-        params = list(query_params.keys())
-        new_query_params = {}
-        assignments = {key: payload for key in param_batch}
-
-        for param in params:
-            new_query_params[param] = [payload]
-
-        new_query_string = urlencode(new_query_params, doseq=True)
-        new_url = urlunparse(
-            (
-                parsed_url.scheme,
-                parsed_url.netloc,
-                parsed_url.path,
-                parsed_url.params,
-                new_query_string,
-                parsed_url.fragment,
-            )
-        )
-        concatenation = "&" if SqlInjectionDetector.is_url_with_parameters(new_url) else "?"
-        new_url = f"{new_url}" + concatenation + "&".join([f"{key}={value}" for key, value in assignments.items()])
-        return unquote(new_url)
+    def change_url_params(url: str, payload: str, param_batch: Sequence[str]) -> str:
+        return change_url_params(url=url, payload=payload, param_batch=param_batch)
 
     def measure_request_time(self, url: str, **kwargs: Dict[str, Any]) -> float:
-        start = timer()
-        try:
-            if "headers" not in kwargs:
-                self.forgiving_http_get(url)
-            else:
-                self.forgiving_http_get(url, headers=kwargs.get("headers"))
-        except requests.exceptions.Timeout:
-            return Config.Modules.SqlInjectionDetector.SQL_INJECTION_TIME_THRESHOLD
-
-        return datetime.timedelta(seconds=timer() - start).seconds
+        headers = kwargs.get("headers")  # type: ignore
+        return measure_request_time(
+            http_get_func=self.forgiving_http_get,
+            url=url,
+            timeout_threshold=Config.Modules.SqlInjectionDetector.SQL_INJECTION_TIME_THRESHOLD,
+            headers=headers,
+        )
 
     def contains_error(self, url: str, response: Optional[HTTPResponse]) -> str | None:
         if response is None:
@@ -132,13 +103,12 @@ class SqlInjectionDetector(ArtemisBase):
         if minimization_mode == "error" and baseline_payload is None:
             raise ValueError("baseline_payload is required for error-based minimization")
 
-        minimal_params: List[str] = []
         if minimization_mode == "error":
             payload_without_effect = baseline_payload if baseline_payload is not None else ""
         else:
             payload_without_effect = self.change_sleep_to_0(payload)
 
-        for param in params:
+        def test_param(param: str) -> bool:
             single_batch = (param,)
             url_with = self._create_injected_url(
                 url=url, payload=payload, param_batch=single_batch, use_change_url_params=use_change_url_params
@@ -152,19 +122,22 @@ class SqlInjectionDetector(ArtemisBase):
 
             if minimization_mode == "error":
                 error = self.contains_error(url_with, self.forgiving_http_get(url_with))
-                if not self.contains_error(url_without, self.forgiving_http_get(url_without)) and error:
-                    minimal_params.append(param)
-            elif (
-                self.measure_request_time(url_without)
-                < Config.Modules.SqlInjectionDetector.SQL_INJECTION_TIME_THRESHOLD / 2
-                and self.measure_request_time(url_with)
-                >= Config.Modules.SqlInjectionDetector.SQL_INJECTION_TIME_THRESHOLD
-            ):
-                minimal_params.append(param)
-            if len(minimal_params) >= Config.Modules.SqlInjectionDetector.SQL_INJECTION_MINIMAL_PARAMS_MAX_LEN:
-                break
+                return bool(not self.contains_error(url_without, self.forgiving_http_get(url_without)) and error)
+            else:
+                return bool(
+                    self.measure_request_time(url_without)
+                    < Config.Modules.SqlInjectionDetector.SQL_INJECTION_TIME_THRESHOLD / 2
+                    and self.measure_request_time(url_with)
+                    >= Config.Modules.SqlInjectionDetector.SQL_INJECTION_TIME_THRESHOLD
+                )
 
-        if minimal_params:
+        minimal_params = minimize_parameters(
+            params=params,
+            test_func=test_param,
+            max_len=Config.Modules.SqlInjectionDetector.SQL_INJECTION_MINIMAL_PARAMS_MAX_LEN,
+        )
+
+        if minimal_params != params:
             mode_label = "error-based" if minimization_mode == "error" else "time-based"
             self.log.info(
                 "SQLi %s parameter minimization: %s -> %s",
@@ -172,10 +145,8 @@ class SqlInjectionDetector(ArtemisBase):
                 params,
                 minimal_params,
             )
-            return minimal_params
 
-        # fallback if no single param triggers SQLi
-        return params
+        return minimal_params
 
     @staticmethod
     def create_headers(payload: str) -> dict[str, str]:

--- a/test/unit/test_injection_utils.py
+++ b/test/unit/test_injection_utils.py
@@ -1,0 +1,67 @@
+import time
+import unittest
+from unittest.mock import MagicMock
+
+import requests
+
+from artemis.injection_utils import (
+    change_url_params,
+    create_url_with_batch_payload,
+    has_query_parameters,
+    measure_request_time,
+    minimize_parameters,
+)
+
+
+class TestInjectionUtils(unittest.TestCase):
+    def test_has_query_parameters(self) -> None:
+        self.assertTrue(has_query_parameters("http://example.com/?id=1"))
+        self.assertTrue(has_query_parameters("http://example.com/test?param=val"))
+        self.assertTrue(has_query_parameters("http://example.com/?"))
+        self.assertFalse(has_query_parameters("http://example.com"))
+        self.assertFalse(has_query_parameters("http://example.com/path/to/page"))
+
+    def test_create_url_with_batch_payload(self) -> None:
+        url = "http://example.com/page"
+        result = create_url_with_batch_payload(url, ["param1", "param2"], "test_payload")
+        self.assertEqual(result, "http://example.com/page?param1=test_payload&param2=test_payload")
+
+        url_with_params = "http://example.com/page?existing=1"
+        result_with_params = create_url_with_batch_payload(url_with_params, ["param1"], "test_payload")
+        self.assertEqual(result_with_params, "http://example.com/page?existing=1&param1=test_payload")
+
+    def test_change_url_params(self) -> None:
+        url = "http://example.com/page?id=old&other=value"
+        result = change_url_params(url, "injected", ["extra"])
+        self.assertIn("id=injected", result)
+        self.assertIn("other=injected", result)
+        self.assertIn("extra=injected", result)
+
+    def test_measure_request_time(self) -> None:
+        def fake_fast_get(url: str, **kwargs: object) -> None:
+            pass
+
+        def fake_slow_get(url: str, **kwargs: object) -> None:
+            time.sleep(0.1)
+
+        def fake_timeout_get(url: str, **kwargs: object) -> None:
+            raise requests.exceptions.Timeout("Timed out")
+
+        self.assertLess(measure_request_time(fake_fast_get, "http://example.com", 5.0), 1.0)
+        self.assertGreaterEqual(measure_request_time(fake_slow_get, "http://example.com", 5.0), 0.0)
+        self.assertEqual(measure_request_time(fake_timeout_get, "http://example.com", 5.0), 5.0)
+
+    def test_minimize_parameters(self) -> None:
+        params = ["a", "b", "c", "d", "e", "f"]
+
+        # Only 'b' and 'd' trigger the condition
+        minimal = minimize_parameters(params, test_func=lambda p: p in {"b", "d"}, max_len=5)
+        self.assertEqual(minimal, ["b", "d"])
+
+        # With capping
+        minimal_capped = minimize_parameters(params, test_func=lambda p: p in {"a", "b", "c", "d"}, max_len=2)
+        self.assertEqual(minimal_capped, ["a", "b"])
+
+        # Fallback when none trigger
+        minimal_fallback = minimize_parameters(params, test_func=lambda p: False, max_len=5)
+        self.assertEqual(minimal_fallback, params)


### PR DESCRIPTION
Closes #2409                                                                                                                                           

## What                                                                                                                                                
lfi_detector and sql_injection_detector shared duplicate logic for:                                                                                
- URL parameter injection and batching 
- URL query parameter existence checking             
- Request timing measurement and timeout handling 
- Parameter minimization loops and capping 

This PR factors these common routines into a dedicated `artemis.injection_utils` module, simplifying the detector modules while maintaining full backwards compatibility.                                                                                                                                 

## Changes

- **`artemis/injection_utils.py`**: Added reusable helper functions (`has_query_parameters`, `create_url_with_batch_payload`, `change_url_params`,`measure_request_time`, and `minimize_parameters`).                                                                                                      
- **`artemis/modules/lfi_detector.py`**: Refactored URL payload creation and parameter minimization to use `artemis.injection_utils`.
- **`artemis/modules/sql_injection_detector.py`**: Refactored URL payload injection, timing measurement, and parameter minimization to use `artemis. injection_utils`; removed unused imports.                                                                                                                
- **`test/unit/test_injection_utils.py`**: Added unit tests covering all functions in `injection_utils` (URL injection, parameter modification, timing measurement, minimization, capping, and fallback).