### PR TITLE
ResourceLock: release only locks owned by the caller (owner-checked, Lua)

### DIFF
--- a/artemis/resource_lock.py
+++ b/artemis/resource_lock.py
@@ -31,13 +31,32 @@ LOCKS_TO_SUSTAIN_LOCK = threading.Lock()
 
 REDIS = Redis.from_url(Config.Data.REDIS_CONN_STR)
 
+# Deletes the key only if it is still owned by the expected owner, to prevent one process from
+# releasing a lock that has already expired and been re-acquired by another process.
+_COMPARE_AND_DELETE_SCRIPT = (
+    "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end"
+)
+
+# Refreshes the key's expiry only if it is still owned by the expected owner, for the same reason.
+_COMPARE_AND_SET_SCRIPT = (
+    "if redis.call('get', KEYS[1]) == ARGV[1] then " "return redis.call('pexpire', KEYS[1], ARGV[2]) else return 0 end"
+)
+
+
+def _compare_and_delete(res_name: str, owner_lid: str) -> bool:
+    return bool(REDIS.eval(_COMPARE_AND_DELETE_SCRIPT, 1, res_name, owner_lid))  # type: ignore
+
+
+def _compare_and_set(res_name: str, owner_lid: str, ex_seconds: int) -> bool:
+    return bool(REDIS.eval(_COMPARE_AND_SET_SCRIPT, 1, res_name, owner_lid, str(ex_seconds * 1000)))  # type: ignore
+
 
 def sustain_locks() -> None:
     while True:
         try:
             with LOCKS_TO_SUSTAIN_LOCK:
                 for key, value in LOCKS_TO_SUSTAIN.items():
-                    REDIS.set(key, value, ex=LOCK_HEARTBEAT_TIMEOUT)
+                    _compare_and_set(key, value, LOCK_HEARTBEAT_TIMEOUT)
         except Exception:
             logger.exception("Failed to sustain locks, will retry")
         time.sleep(1)
@@ -76,9 +95,9 @@ class ResourceLock:
     @staticmethod
     def release_all_locks(logger: Logger) -> None:
         with LOCKS_TO_SUSTAIN_LOCK:
-            for lock in list(LOCKS_TO_SUSTAIN.keys()):
-                logger.info(f"Releasing lock: {lock} -> {LOCKS_TO_SUSTAIN[lock]}")
-                REDIS.delete(lock)
+            for lock, owner_lid in list(LOCKS_TO_SUSTAIN.items()):
+                logger.info(f"Releasing lock: {lock} -> {owner_lid}")
+                _compare_and_delete(lock, owner_lid)
             LOCKS_TO_SUSTAIN.clear()
 
     def acquire(self) -> None:
@@ -104,7 +123,7 @@ class ResourceLock:
         with LOCKS_TO_SUSTAIN_LOCK:
             if self.res_name in LOCKS_TO_SUSTAIN:
                 del LOCKS_TO_SUSTAIN[self.res_name]
-        REDIS.delete(self.res_name)
+        _compare_and_delete(self.res_name, self.lid)
 
     def __enter__(self) -> None:
         self.acquire()

--- a/test/unit/test_resource_lock.py
+++ b/test/unit/test_resource_lock.py
@@ -1,7 +1,8 @@
 import logging
 import threading
 import unittest
-from unittest.mock import MagicMock, patch
+from typing import Any, Dict, List, Tuple
+from unittest import mock
 
 from artemis.resource_lock import (
     LOCKS_TO_SUSTAIN,
@@ -11,8 +12,61 @@ from artemis.resource_lock import (
 )
 
 
+class FakeRedis:
+    """Minimal dict-backed Redis implementing only the semantics ResourceLock uses:
+    SET (with optional NX and EX), GET, DEL, and EVAL of the compare-and-delete /
+    compare-and-set Lua scripts. This lets ownership-transfer scenarios be tested
+    deterministically without a live Redis."""
+
+    _COMPARE_AND_DELETE = (
+        "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end"
+    )
+    _COMPARE_AND_SET = (
+        "if redis.call('get', KEYS[1]) == ARGV[1] then "
+        "return redis.call('pexpire', KEYS[1], ARGV[2]) else return 0 end"
+    )
+
+    def __init__(self) -> None:
+        self.data: Dict[str, str] = {}
+        self.eval_calls: List[Tuple[str, int, str, Tuple[Any, ...]]] = []
+
+    def set(self, key: str, value: str, nx: bool = False, ex: Any = None) -> Any:
+        if nx and key in self.data:
+            return None
+        self.data[key] = value
+        return True
+
+    def get(self, key: str) -> Any:
+        return self.data.get(key)
+
+    def delete(self, *keys: str) -> int:
+        deleted = 0
+        for key in keys:
+            if key in self.data:
+                del self.data[key]
+                deleted += 1
+        return deleted
+
+    def eval(self, script: str, numkeys: int, key: str, *args: Any) -> Any:
+        self.eval_calls.append((script, numkeys, key, args))
+        if script == self._COMPARE_AND_DELETE:
+            if self.data.get(key) == args[0]:
+                del self.data[key]
+                return 1
+            return 0
+        if script == self._COMPARE_AND_SET:
+            if self.data.get(key) == args[0]:
+                # expiry is not modeled - ownership comparison is what matters here
+                return 1
+            return 0
+        raise ValueError("Unsupported script in FakeRedis")
+
+    def is_locked(self, key: str) -> bool:
+        return key in self.data
+
+
 class TestReleaseAllLocks(unittest.TestCase):
-    """Tests for ResourceLock.release_all_locks — the safety-net method called
+    """Tests for ResourceLock.release_all_locks - the safety-net method called
     at the start of every worker iteration to clean up leaked locks."""
 
     def setUp(self) -> None:
@@ -20,72 +74,67 @@ class TestReleaseAllLocks(unittest.TestCase):
         with LOCKS_TO_SUSTAIN_LOCK:
             LOCKS_TO_SUSTAIN.clear()
         self.logger = logging.getLogger("test_resource_lock")
+        self.redis = FakeRedis()
 
     def tearDown(self) -> None:
         with LOCKS_TO_SUSTAIN_LOCK:
             LOCKS_TO_SUSTAIN.clear()
 
-    @patch("artemis.resource_lock.REDIS")
-    def test_release_all_locks_deletes_redis_keys(self, mock_redis: MagicMock) -> None:
-        """release_all_locks must call REDIS.delete for every held lock."""
+    def test_release_all_locks_deletes_redis_keys(self) -> None:
+        """release_all_locks must delete every held lock from Redis (owner-checked)."""
         with LOCKS_TO_SUSTAIN_LOCK:
             LOCKS_TO_SUSTAIN["lock-1.2.3.4"] = "uuid-1"
             LOCKS_TO_SUSTAIN["lock-5.6.7.8"] = "uuid-2"
+        self.redis.set("lock-1.2.3.4", "uuid-1")
+        self.redis.set("lock-5.6.7.8", "uuid-2")
 
-        ResourceLock.release_all_locks(self.logger)
+        with mock.patch("artemis.resource_lock.REDIS", self.redis):
+            ResourceLock.release_all_locks(self.logger)
 
-        mock_redis.delete.assert_any_call("lock-1.2.3.4")
-        mock_redis.delete.assert_any_call("lock-5.6.7.8")
-        self.assertEqual(mock_redis.delete.call_count, 2)
+        self.assertEqual(self.redis.data, {})
 
-    @patch("artemis.resource_lock.REDIS")
-    def test_release_all_locks_clears_sustain_dict(self, mock_redis: MagicMock) -> None:
+    def test_release_all_locks_clears_sustain_dict(self) -> None:
         """After release_all_locks, LOCKS_TO_SUSTAIN must be empty so the
         heartbeat thread stops refreshing the deleted keys."""
         with LOCKS_TO_SUSTAIN_LOCK:
             LOCKS_TO_SUSTAIN["lock-target-a"] = "uuid-a"
             LOCKS_TO_SUSTAIN["lock-target-b"] = "uuid-b"
 
-        ResourceLock.release_all_locks(self.logger)
+        with mock.patch("artemis.resource_lock.REDIS", self.redis):
+            ResourceLock.release_all_locks(self.logger)
 
         with LOCKS_TO_SUSTAIN_LOCK:
             self.assertEqual(len(LOCKS_TO_SUSTAIN), 0)
 
-    @patch("artemis.resource_lock.REDIS")
-    def test_release_all_locks_noop_when_empty(self, mock_redis: MagicMock) -> None:
+    def test_release_all_locks_noop_when_empty(self) -> None:
         """Calling release_all_locks with no held locks must not raise."""
-        ResourceLock.release_all_locks(self.logger)
+        with mock.patch("artemis.resource_lock.REDIS", self.redis):
+            ResourceLock.release_all_locks(self.logger)
 
-        mock_redis.delete.assert_not_called()
+        self.assertEqual(self.redis.eval_calls, [])
         with LOCKS_TO_SUSTAIN_LOCK:
             self.assertEqual(len(LOCKS_TO_SUSTAIN), 0)
 
-    @patch("artemis.resource_lock.REDIS")
-    def test_acquire_then_release_all_cleans_up(self, mock_redis: MagicMock) -> None:
+    def test_acquire_then_release_all_cleans_up(self) -> None:
         """Simulates a lock leak: acquire a lock, then call release_all_locks
         instead of the normal release path. The lock must be fully cleaned up."""
-        mock_redis.set.return_value = True  # simulate successful SET NX
+        with mock.patch("artemis.resource_lock.REDIS", self.redis):
+            lock = ResourceLock("lock-leaked-target", max_tries=1)
+            lock.acquire()
 
-        lock = ResourceLock("lock-leaked-target", max_tries=1)
-        lock.acquire()
+            with LOCKS_TO_SUSTAIN_LOCK:
+                self.assertIn("lock-leaked-target", LOCKS_TO_SUSTAIN)
 
-        # Verify the lock is tracked
-        with LOCKS_TO_SUSTAIN_LOCK:
-            self.assertIn("lock-leaked-target", LOCKS_TO_SUSTAIN)
+            ResourceLock.release_all_locks(self.logger)
 
-        # Simulate the safety-net cleanup
-        ResourceLock.release_all_locks(self.logger)
-
-        mock_redis.delete.assert_any_call("lock-leaked-target")
+        self.assertFalse(self.redis.is_locked("lock-leaked-target"))
         with LOCKS_TO_SUSTAIN_LOCK:
             self.assertNotIn("lock-leaked-target", LOCKS_TO_SUSTAIN)
 
-    @patch("artemis.resource_lock.REDIS")
-    def test_release_all_locks_is_thread_safe(self, mock_redis: MagicMock) -> None:
+    def test_release_all_locks_is_thread_safe(self) -> None:
         """release_all_locks must not corrupt state when called concurrently
         with lock acquire/release on other threads."""
-        mock_redis.set.return_value = True
-        errors = []
+        errors: List[Exception] = []
 
         def acquire_and_release() -> None:
             try:
@@ -93,14 +142,14 @@ class TestReleaseAllLocks(unittest.TestCase):
                     lock = ResourceLock(f"lock-thread-{threading.current_thread().name}-{i}", max_tries=1)
                     lock.acquire()
                     lock.release()
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 errors.append(e)
 
         def release_all_repeatedly() -> None:
             try:
                 for _ in range(20):
                     ResourceLock.release_all_locks(self.logger)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 errors.append(e)
 
         threads = [
@@ -122,56 +171,158 @@ class TestResourceLockBasics(unittest.TestCase):
     def setUp(self) -> None:
         with LOCKS_TO_SUSTAIN_LOCK:
             LOCKS_TO_SUSTAIN.clear()
+        self.redis = FakeRedis()
 
     def tearDown(self) -> None:
         with LOCKS_TO_SUSTAIN_LOCK:
             LOCKS_TO_SUSTAIN.clear()
 
-    @patch("artemis.resource_lock.REDIS")
-    def test_acquire_adds_to_sustain_dict(self, mock_redis: MagicMock) -> None:
-        mock_redis.set.return_value = True
-
-        lock = ResourceLock("lock-test-target", max_tries=1)
-        lock.acquire()
+    def test_acquire_adds_to_sustain_dict(self) -> None:
+        with mock.patch("artemis.resource_lock.REDIS", self.redis):
+            lock = ResourceLock("lock-test-target", max_tries=1)
+            lock.acquire()
 
         with LOCKS_TO_SUSTAIN_LOCK:
             self.assertIn("lock-test-target", LOCKS_TO_SUSTAIN)
 
-    @patch("artemis.resource_lock.REDIS")
-    def test_release_removes_from_sustain_dict_and_redis(self, mock_redis: MagicMock) -> None:
-        mock_redis.set.return_value = True
-
-        lock = ResourceLock("lock-test-target", max_tries=1)
-        lock.acquire()
-        lock.release()
+    def test_release_removes_from_sustain_dict_and_redis(self) -> None:
+        with mock.patch("artemis.resource_lock.REDIS", self.redis):
+            lock = ResourceLock("lock-test-target", max_tries=1)
+            lock.acquire()
+            lock.release()
 
         with LOCKS_TO_SUSTAIN_LOCK:
             self.assertNotIn("lock-test-target", LOCKS_TO_SUSTAIN)
-        mock_redis.delete.assert_called_with("lock-test-target")
+        self.assertFalse(self.redis.is_locked("lock-test-target"))
 
-    @patch("artemis.resource_lock.REDIS")
-    def test_failed_acquire_raises(self, mock_redis: MagicMock) -> None:
-        mock_redis.set.return_value = False  # NX fails — lock already held
+    def test_failed_acquire_raises(self) -> None:
+        self.redis.set("lock-contended", "some-other-owner")
 
-        lock = ResourceLock("lock-contended", max_tries=1)
+        with mock.patch("artemis.resource_lock.REDIS", self.redis):
+            lock = ResourceLock("lock-contended", max_tries=1)
 
-        with self.assertRaises(FailedToAcquireLockException):
-            lock.acquire()
+            with self.assertRaises(FailedToAcquireLockException):
+                lock.acquire()
 
         with LOCKS_TO_SUSTAIN_LOCK:
             self.assertNotIn("lock-contended", LOCKS_TO_SUSTAIN)
 
-    @patch("artemis.resource_lock.REDIS")
-    def test_context_manager_releases_on_exit(self, mock_redis: MagicMock) -> None:
-        mock_redis.set.return_value = True
-
-        with ResourceLock("lock-ctx", max_tries=1):
-            with LOCKS_TO_SUSTAIN_LOCK:
-                self.assertIn("lock-ctx", LOCKS_TO_SUSTAIN)
+    def test_context_manager_releases_on_exit(self) -> None:
+        with mock.patch("artemis.resource_lock.REDIS", self.redis):
+            with ResourceLock("lock-ctx", max_tries=1):
+                with LOCKS_TO_SUSTAIN_LOCK:
+                    self.assertIn("lock-ctx", LOCKS_TO_SUSTAIN)
 
         with LOCKS_TO_SUSTAIN_LOCK:
             self.assertNotIn("lock-ctx", LOCKS_TO_SUSTAIN)
-        mock_redis.delete.assert_called_with("lock-ctx")
+        self.assertFalse(self.redis.is_locked("lock-ctx"))
+
+
+class TestOwnershipCheckedRelease(unittest.TestCase):
+    """The core regression tests: a release must never delete a lock that is
+    now owned by a different holder."""
+
+    def setUp(self) -> None:
+        with LOCKS_TO_SUSTAIN_LOCK:
+            LOCKS_TO_SUSTAIN.clear()
+        self.redis = FakeRedis()
+
+    def tearDown(self) -> None:
+        with LOCKS_TO_SUSTAIN_LOCK:
+            LOCKS_TO_SUSTAIN.clear()
+
+    def test_stray_release_does_not_delete_another_holders_lock(self) -> None:
+        """A's release-after-release (or the WAF-skip path creating a fresh lock
+        object for the same resource) must not destroy B's lock."""
+        with mock.patch("artemis.resource_lock.REDIS", self.redis):
+            lock_a = ResourceLock("lock-shared-target", max_tries=1)
+            lock_a.acquire()
+            lock_a.release()
+
+            # B acquires the now-free lock
+            lock_b = ResourceLock("lock-shared-target", max_tries=1)
+            lock_b.acquire()
+            self.assertTrue(self.redis.is_locked("lock-shared-target"))
+
+            # A's stray/double release must be a no-op
+            lock_a.release()
+            self.assertTrue(self.redis.is_locked("lock-shared-target"))
+
+            # And a third holder must still be refused
+            with self.assertRaises(FailedToAcquireLockException):
+                ResourceLock("lock-shared-target", max_tries=1).acquire()
+
+            # B releases correctly
+            lock_b.release()
+            self.assertFalse(self.redis.is_locked("lock-shared-target"))
+
+    def test_fresh_lock_object_with_same_name_cannot_release(self) -> None:
+        """Simulates check_connection_to_base_url_and_save_error(): a fresh
+        ResourceLock instance (different lid) for the same resource must not be
+        able to release the lock held by the original owner."""
+        with mock.patch("artemis.resource_lock.REDIS", self.redis):
+            owner = ResourceLock("lock-scan-destination", max_tries=1)
+            owner.acquire()
+
+            fresh = ResourceLock("lock-scan-destination", max_tries=1)
+            fresh.release()
+
+            self.assertTrue(self.redis.is_locked("lock-scan-destination"))
+
+    def test_owner_release_after_sustain_refresh_still_works(self) -> None:
+        """The heartbeat refreshes the key with the owner's lid; the owner must
+        still be able to release afterwards."""
+        with mock.patch("artemis.resource_lock.REDIS", self.redis):
+            lock = ResourceLock("lock-refreshed", max_tries=1)
+            lock.acquire()
+
+            # simulate the sustain thread refreshing ownership
+            self.redis.set("lock-refreshed", lock.lid)
+
+            lock.release()
+            self.assertFalse(self.redis.is_locked("lock-refreshed"))
+
+    def test_release_all_locks_cannot_delete_foreign_lock(self) -> None:
+        """Even if a foreign lid somehow lands in LOCKS_TO_SUSTAIN (e.g. a stale
+        entry from a previous process state), release_all_locks must not delete
+        a key owned by someone else."""
+        with LOCKS_TO_SUSTAIN_LOCK:
+            LOCKS_TO_SUSTAIN["lock-foreign"] = "stale-uuid"
+        self.redis.set("lock-foreign", "actual-owner-uuid")
+
+        with mock.patch("artemis.resource_lock.REDIS", self.redis):
+            ResourceLock.release_all_locks(logging.getLogger("test"))
+
+        self.assertTrue(self.redis.is_locked("lock-foreign"))
+
+
+class TestSustainOwnership(unittest.TestCase):
+    """The heartbeat must not overwrite another process's lock ownership."""
+
+    def setUp(self) -> None:
+        with LOCKS_TO_SUSTAIN_LOCK:
+            LOCKS_TO_SUSTAIN.clear()
+        self.redis = FakeRedis()
+
+    def tearDown(self) -> None:
+        with LOCKS_TO_SUSTAIN_LOCK:
+            LOCKS_TO_SUSTAIN.clear()
+
+    def test_compare_and_set_does_not_overwrite_foreign_owner(self) -> None:
+        from artemis.resource_lock import _compare_and_set
+
+        self.redis.set("lock-held", "actual-owner")
+        with mock.patch("artemis.resource_lock.REDIS", self.redis):
+            self.assertFalse(_compare_and_set("lock-held", "stale-lid", 60))
+        self.assertEqual(self.redis.get("lock-held"), "actual-owner")
+
+    def test_compare_and_set_succeeds_for_owner(self) -> None:
+        from artemis.resource_lock import _compare_and_set
+
+        self.redis.set("lock-held", "my-lid")
+        with mock.patch("artemis.resource_lock.REDIS", self.redis):
+            self.assertTrue(_compare_and_set("lock-held", "my-lid", 60))
+        self.assertEqual(self.redis.get("lock-held"), "my-lid")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #3110

## Problem

Every lock records an owner id (`self.lid`, `resource_lock.py:73`) and `acquire()` stores it in Redis via `SET ... nx` - but `release()` never consulted it and called `REDIS.delete()` unconditionally. Any release call therefore deleted *whatever holder currently owned the key*, possibly a different process entirely.

A concrete race exists in the current code: `check_connection_to_base_url_and_save_error()` (`module_base.py:824-870`, the WAF-skip path) creates a **fresh** `ResourceLock` object for the same `lock-{scan_destination}` (a different `lid`) and calls `release()` on it, while the real owner (the lock from `_take_and_lock_tasks()`) also releases after the batch (`module_base.py:406-408`). The interleaving - WAF-skip releases early, another scanner acquires, the original owner releases at batch end deleting the other scanner's lock - lets two scanners race the same target, exactly what this subsystem exists to prevent. The same unconditional pattern existed in `release_all_locks()` and, second-order, in `sustain_locks()` (unconditional `SET` overwriting whoever now owns the key).

## Fix (contained in `resource_lock.py`, no `module_base.py` changes)

Redis already provides the exact primitive needed - an atomic Lua compare-and-delete; the owner `lid` was already threaded through `LOCKS_TO_SUSTAIN`, so nothing new needed tracking:

```python
_COMPARE_AND_DELETE_SCRIPT = (
    "if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end"
)
```

- `release()` -> delete only if `GET(res_name) == self.lid`
- `release_all_locks()` -> delete using the `lid` already stored per key in `LOCKS_TO_SUSTAIN`
- `sustain_locks()` -> a matching compare-and-`PEXPIRE` heartbeat, so it can refresh but never *claim* a foreign-owned key

Deliberate behavior note: the WAF-skip path's `lock.release()` becomes a safe no-op (that fresh object was never the owner) - the destination is released exactly once, by its real owner, at batch end.

## Tests

Extended `test/unit/test_resource_lock.py` (existing tests ported to the same harness) with a small dependency-free **FakeRedis** (dict-backed, honoring `SET nx` plus the two Lua scripts) so ownership transfer is tested deterministically, with no sleeps or timing dependence:

- the headline scenario as an actual test: A acquires -> A releases -> B acquires -> A's stray release **must leave B's lock intact**, and a third holder must still be refused
- the exact WAF-path shape: fresh lock object, same key, different `lid`, `release()` is a no-op
- owner release still works, including after a heartbeat refresh (guards against over-tightening)
- `release_all_locks` cannot delete a foreign-owned key; sustain compare-and-set respects ownership

## Verification

- [x] `pytest test/unit/test_resource_lock.py` - 15/15 passed
- [x] Full `test/unit` sweep - no regressions (remaining failures are byte-identical on clean main: they need the Docker test environment)
- [x] Both Lua scripts also validated directly against a real Redis (owner delete -> 1, foreign delete -> 0 with key intact, owner heartbeat -> 1)
- [x] `pre-commit run` - black, isort, mypy, flake8 all pass